### PR TITLE
[codex] Add Windows release signing pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,53 +9,157 @@ on:
       tag:
         description: 'Tag to release (e.g. v0.2.0)'
         required: true
+        type: string
 
 permissions:
-  contents: write
+  contents: read
+
+env:
+  NODE_VERSION: '22.18.0'
+  RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            platform: mac
-            artifact_glob: 'release/*.dmg'
-          - os: windows-latest
-            platform: win
-            artifact_glob: 'release/*.exe'
-          - os: ubuntu-latest
-            platform: linux
-            artifact_glob: 'release/*.AppImage'
-
-    runs-on: ${{ matrix.os }}
-    name: Build (${{ matrix.platform }})
+  verify:
+    runs-on: windows-latest
+    name: Verify
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build & package
-        run: npm run package -- --${{ matrix.platform }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify
+        run: npm run verify
 
-      - name: Upload release artifacts
-        uses: softprops/action-gh-release@v2
+  build-windows-signed:
+    runs-on: windows-latest
+    name: Build signed Windows installer
+    needs: verify
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      AZURE_SIGNING_ENABLED: '1'
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SIGNING_ENDPOINT: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+      AZURE_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
+      AZURE_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_SIGNING_CERTIFICATE_PROFILE_NAME }}
+      AZURE_SIGNING_PUBLISHER_NAME: ${{ vars.AZURE_SIGNING_PUBLISHER_NAME }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          tag_name: ${{ github.ref_name || inputs.tag }}
-          draft: false
-          generate_release_notes: true
-          files: ${{ matrix.artifact_glob }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build signed Windows installer
+        run: npm run package -- --win --x64 --publish never
+
+      - name: Verify Authenticode signatures
+        shell: pwsh
+        run: |
+          $installerFiles = Get-ChildItem -Path release -File -Filter *.exe
+          $appFiles = Get-ChildItem -Path release\win-unpacked -File -Filter *.exe -Recurse
+          $targets = @($installerFiles) + @($appFiles)
+
+          if ($targets.Count -eq 0) {
+            throw "No executable files were produced for signature verification."
+          }
+
+          foreach ($target in $targets) {
+            $signature = Get-AuthenticodeSignature -FilePath $target.FullName
+            Write-Host "$($target.FullName): $($signature.Status)"
+
+            if ($signature.Status -ne "Valid") {
+              throw "Invalid Authenticode signature for $($target.FullName): $($signature.StatusMessage)"
+            }
+          }
+
+      - name: Generate checksums
+        shell: pwsh
+        run: |
+          $installerFiles = Get-ChildItem -Path release -File -Filter *.exe | Sort-Object Name
+
+          if ($installerFiles.Count -eq 0) {
+            throw "No installer executables were produced for checksum generation."
+          }
+
+          $checksums = foreach ($installer in $installerFiles) {
+            $hash = Get-FileHash -Path $installer.FullName -Algorithm SHA256
+            "$($hash.Hash.ToLowerInvariant())  $($installer.Name)"
+          }
+
+          $checksums | Set-Content -Path release\SHA256SUMS.txt -Encoding ascii
+
+      - name: Upload signed release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper-pilot-windows-signed
+          path: |
+            release/*.exe
+            release/SHA256SUMS.txt
+          if-no-files-found: error
+
+  publish-release:
+    runs-on: ubuntu-latest
+    name: Publish GitHub release
+    needs: build-windows-signed
+    permissions:
+      contents: write
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Download signed release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Publish release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -d '' files < <(find release-artifacts -type f \( -name '*.exe' -o -name 'SHA256SUMS.txt' \) -print0 | sort -z)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No release files were downloaded." >&2
+            exit 1
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+          else
+            gh release create "$RELEASE_TAG" "${files[@]}" --verify-tag --title "$RELEASE_TAG" --generate-notes
+          fi

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,92 @@
+# Release Signing
+
+Paper Pilot publishes a signed Windows NSIS installer from GitHub Actions. The release workflow uses GitHub OIDC with Azure Artifact Signing, so it does not need a stored Azure client secret.
+
+## Azure Signing Resources
+
+The release workflow expects these Azure resources:
+
+- Subscription: `8b52aba2-7348-4d4a-abfd-132b6365187c`
+- Tenant: `5556ae28-2fa4-474a-a064-7e0a65a5296e`
+- Resource group: `PaperPilot`
+- Artifact Signing account: `NeroCodeSign1`
+- Endpoint: `https://wus3.codesigning.azure.net/`
+- Certificate profile: `PaperPilotCert1`
+- Publisher name: `Zhuowen Cui`
+
+## One-Time Azure Setup
+
+Create or reuse an Entra app registration named `paper-pilot-github-release-signer`.
+
+```powershell
+$subscriptionId = "8b52aba2-7348-4d4a-abfd-132b6365187c"
+$tenantId = "5556ae28-2fa4-474a-a064-7e0a65a5296e"
+$resourceGroup = "PaperPilot"
+$signingAccount = "NeroCodeSign1"
+$appName = "paper-pilot-github-release-signer"
+
+az account set --subscription $subscriptionId
+
+$app = az ad app create --display-name $appName | ConvertFrom-Json
+$servicePrincipal = az ad sp create --id $app.appId | ConvertFrom-Json
+
+$federatedCredential = @{
+  name = "paper-pilot-release-environment"
+  issuer = "https://token.actions.githubusercontent.com"
+  subject = "repo:Xueyang-Song/paper-pilot:environment:release"
+  audiences = @("api://AzureADTokenExchange")
+} | ConvertTo-Json
+
+$federatedCredentialPath = New-TemporaryFile
+$federatedCredential | Set-Content -Path $federatedCredentialPath -Encoding ascii
+az ad app federated-credential create --id $app.appId --parameters "@$federatedCredentialPath"
+Remove-Item $federatedCredentialPath
+
+$scope = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup/providers/Microsoft.CodeSigning/codeSigningAccounts/$signingAccount"
+az role assignment create `
+  --assignee-object-id $servicePrincipal.id `
+  --assignee-principal-type ServicePrincipal `
+  --role "Artifact Signing Certificate Profile Signer" `
+  --scope $scope
+```
+
+If Azure displays the older role name, use `Trusted Signing Certificate Profile Signer`; it maps to the same signing permission.
+
+## GitHub Environment Setup
+
+Create a GitHub environment named `release`.
+
+- Do not require manual reviewers unless you want releases to pause before signing.
+- Restrict deployments to release tags matching `v*.*.*`.
+- When using `workflow_dispatch`, run the workflow from the tag ref in GitHub's "Use workflow from" selector.
+
+Store these as environment variables on the `release` environment:
+
+```text
+AZURE_TENANT_ID=5556ae28-2fa4-474a-a064-7e0a65a5296e
+AZURE_SUBSCRIPTION_ID=8b52aba2-7348-4d4a-abfd-132b6365187c
+AZURE_CLIENT_ID=<new Entra app client ID>
+AZURE_SIGNING_ENDPOINT=https://wus3.codesigning.azure.net/
+AZURE_SIGNING_ACCOUNT_NAME=NeroCodeSign1
+AZURE_SIGNING_CERTIFICATE_PROFILE_NAME=PaperPilotCert1
+AZURE_SIGNING_PUBLISHER_NAME=Zhuowen Cui
+```
+
+These values are referenced with GitHub Actions `vars`, not `secrets`. The workflow relies on the environment-bound OIDC trust and Azure role assignment for authorization.
+
+## Release Flow
+
+1. Update `package.json` to the version you want to publish.
+2. Create and push a release tag such as `v0.1.1`.
+3. GitHub Actions runs `npm run verify`, builds a Windows x64 NSIS installer, signs it with Azure Artifact Signing, verifies Authenticode signatures, and publishes the installer plus `SHA256SUMS.txt` to the GitHub Release.
+
+## Local Checks
+
+Run the unsigned local checks before tagging:
+
+```bash
+npm run verify
+npm run package -- --win --x64 --publish never
+```
+
+Do not set `AZURE_SIGNING_ENABLED=1` locally unless the Azure signing variables are present and you intend to produce a signed build.

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -1,0 +1,51 @@
+const signingEnabled = process.env.AZURE_SIGNING_ENABLED === "1";
+
+const requireEnv = (name) => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} must be set when AZURE_SIGNING_ENABLED=1`);
+  }
+
+  return value;
+};
+
+const config = {
+  appId: "science.paperpilot.app",
+  productName: "Paper Pilot",
+  npmRebuild: false,
+  directories: {
+    output: "release",
+  },
+  files: ["dist/**/*", "dist-electron/**/*", "package.json"],
+  asarUnpack: ["**/*.node"],
+  win: {
+    target: "nsis",
+  },
+  mac: {
+    target: "dmg",
+  },
+  linux: {
+    target: "AppImage",
+  },
+};
+
+if (signingEnabled) {
+  config.forceCodeSigning = true;
+  config.win = {
+    ...config.win,
+    azureSignOptions: {
+      publisherName: requireEnv("AZURE_SIGNING_PUBLISHER_NAME"),
+      endpoint: requireEnv("AZURE_SIGNING_ENDPOINT"),
+      certificateProfileName: requireEnv(
+        "AZURE_SIGNING_CERTIFICATE_PROFILE_NAME",
+      ),
+      codeSigningAccountName: requireEnv("AZURE_SIGNING_ACCOUNT_NAME"),
+      fileDigest: "SHA256",
+      timestampRfc3161: "http://timestamp.acs.microsoft.com",
+      timestampDigest: "SHA256",
+    },
+  };
+}
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -17,32 +17,7 @@
     "test:crawlers:api": "cross-env PAPER_PILOT_LIVE_CRAWLER_SMOKE=1 vitest run tests/crawler-smoke.test.ts --testTimeout=120000",
     "test:crawlers:browser": "cross-env PAPER_PILOT_BROWSER_SMOKE=1 vitest run tests/crawler-smoke.test.ts --testTimeout=240000",
     "start": "electron .",
-    "package": "npm run build && electron-builder"
-  },
-  "build": {
-    "appId": "science.paperpilot.app",
-    "productName": "Paper Pilot",
-    "npmRebuild": false,
-    "directories": {
-      "output": "release"
-    },
-    "files": [
-      "dist/**/*",
-      "dist-electron/**/*",
-      "package.json"
-    ],
-    "asarUnpack": [
-      "**/*.node"
-    ],
-    "win": {
-      "target": "nsis"
-    },
-    "mac": {
-      "target": "dmg"
-    },
-    "linux": {
-      "target": "AppImage"
-    }
+    "package": "npm run build && electron-builder --config electron-builder.config.cjs"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",


### PR DESCRIPTION
## Summary

- Replace the multi-platform release workflow with a Windows-only signed release pipeline.
- Add Azure Artifact Signing support through electron-builder using GitHub OIDC, with no stored Azure client secret.
- Add release setup documentation for the GitHub `release` environment and Azure signer app.

## Validation

- `npm ci`
- `npm run verify`
- `npm run package -- --win --x64 --publish never`
- Confirmed local unsigned package output is not Authenticode-signed when Azure signing is disabled.
- Confirmed `AZURE_SIGNING_ENABLED=1` loads `forceCodeSigning` and the configured Azure signing options.

## Notes

The GitHub `release` environment and Azure OIDC signer app have already been configured. No GitHub secrets are required; the workflow uses environment variables plus OIDC.
