### PR TITLE
[codex] Add GitHub release auto updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,18 +118,52 @@ jobs:
             }
           }
 
+      - name: Verify updater metadata
+        shell: pwsh
+        run: |
+          $installerFiles = @(Get-ChildItem -Path release -File -Filter *.exe | Sort-Object Name)
+
+          if ($installerFiles.Count -eq 0) {
+            throw "No installer executables were produced."
+          }
+
+          $latestYml = Get-Item -Path release\latest.yml -ErrorAction SilentlyContinue
+          if (-not $latestYml) {
+            throw "latest.yml was not produced. Check electron-builder publish configuration."
+          }
+
+          $latestContent = Get-Content -Path $latestYml.FullName -Raw
+          if ($latestContent -notmatch "sha512") {
+            throw "latest.yml does not contain SHA512 update metadata."
+          }
+
+          foreach ($installer in $installerFiles) {
+            $blockmapPath = "$($installer.FullName).blockmap"
+            if (-not (Test-Path -LiteralPath $blockmapPath)) {
+              throw "Missing updater blockmap for $($installer.Name)."
+            }
+
+            if ($latestContent -notmatch [regex]::Escape($installer.Name)) {
+              throw "latest.yml does not reference $($installer.Name)."
+            }
+          }
+
       - name: Generate checksums
         shell: pwsh
         run: |
-          $installerFiles = Get-ChildItem -Path release -File -Filter *.exe | Sort-Object Name
+          $releaseFiles = @(
+            Get-ChildItem -Path release -File -Filter *.exe
+            Get-ChildItem -Path release -File -Filter *.exe.blockmap
+            Get-Item -Path release\latest.yml
+          ) | Sort-Object Name
 
-          if ($installerFiles.Count -eq 0) {
-            throw "No installer executables were produced for checksum generation."
+          if ($releaseFiles.Count -eq 0) {
+            throw "No release files were produced for checksum generation."
           }
 
-          $checksums = foreach ($installer in $installerFiles) {
-            $hash = Get-FileHash -Path $installer.FullName -Algorithm SHA256
-            "$($hash.Hash.ToLowerInvariant())  $($installer.Name)"
+          $checksums = foreach ($file in $releaseFiles) {
+            $hash = Get-FileHash -Path $file.FullName -Algorithm SHA256
+            "$($hash.Hash.ToLowerInvariant())  $($file.Name)"
           }
 
           $checksums | Set-Content -Path release\SHA256SUMS.txt -Encoding ascii
@@ -140,6 +174,8 @@ jobs:
           name: paper-pilot-windows-signed
           path: |
             release/*.exe
+            release/*.exe.blockmap
+            release/latest.yml
             release/SHA256SUMS.txt
           if-no-files-found: error
 
@@ -165,7 +201,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          mapfile -d '' files < <(find release-artifacts -type f \( -name '*.exe' -o -name 'SHA256SUMS.txt' \) -print0 | sort -z)
+          mapfile -d '' files < <(find release-artifacts -type f \( -name '*.exe' -o -name '*.exe.blockmap' -o -name 'latest.yml' -o -name 'SHA256SUMS.txt' \) -print0 | sort -z)
 
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No release files were downloaded." >&2

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -92,7 +92,7 @@ The non-sensitive values are referenced with GitHub Actions `vars`. `AZURE_CLIEN
 
 1. Update `package.json` to the version you want to publish.
 2. Create and push a release tag such as `v0.1.1`.
-3. GitHub Actions runs `npm run verify`, builds a Windows x64 NSIS installer, signs it with Azure Artifact Signing, verifies Authenticode signatures, and publishes the installer plus `SHA256SUMS.txt` to the GitHub Release.
+3. GitHub Actions runs `npm run verify`, builds a Windows x64 NSIS installer, signs it with Azure Artifact Signing, verifies Authenticode signatures, verifies updater metadata, and publishes the installer, blockmap, `latest.yml`, and `SHA256SUMS.txt` to the GitHub Release.
 
 ## Local Checks
 
@@ -102,5 +102,7 @@ Run the unsigned local checks before tagging:
 npm run verify
 npm run package -- --win --x64 --publish never
 ```
+
+The unsigned local package should produce `release/latest.yml`, an installer `.exe`, an installer `.exe.blockmap`, and `release/win-unpacked/resources/app-update.yml`. GitHub Releases need those metadata files for installed apps to discover and download updates.
 
 Do not set `AZURE_SIGNING_ENABLED=1` locally unless the Azure signing variables are present and you intend to produce a signed build.

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -17,8 +17,18 @@ const config = {
   directories: {
     output: "release",
   },
+  artifactName: "Paper-Pilot-Setup-${version}.${ext}",
   files: ["dist/**/*", "dist-electron/**/*", "package.json"],
   asarUnpack: ["**/*.node"],
+  publish: [
+    {
+      provider: "github",
+      owner: "Xueyang-Song",
+      repo: "paper-pilot",
+      channel: "latest",
+      releaseType: "release",
+    },
+  ],
   win: {
     target: "nsis",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.90.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "electron-updater": "^6.8.9",
         "fast-xml-parser": "^5.3.2",
         "framer-motion": "^12.23.24",
         "jotai": "^2.15.1",
@@ -6491,6 +6492,47 @@
       "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -7331,7 +7373,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -8523,7 +8564,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -8798,6 +8838,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -11750,7 +11803,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -12597,6 +12649,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^5.90.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-updater": "^6.8.9",
     "fast-xml-parser": "^5.3.2",
     "framer-motion": "^12.23.24",
     "jotai": "^2.15.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import { PaperScoringService } from "./services/paper-scoring-service.js";
 import { PythonService } from "./services/python-service.js";
 import { SearchService } from "./services/search-service.js";
 import { SettingsService } from "./services/settings-service.js";
+import { createUpdateService } from "./services/update-service.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -110,9 +111,15 @@ app.whenReady().then(() => {
   const ai = new AiService(db, settings, credentials, artifacts, jobs);
   const localAgent = new LocalAgentService(db, registry, crawl, ai, jobs, { settings });
   const agent = new AgentService(db, crawl, ai, artifacts, jobs, localAgent);
+  const updates = createUpdateService({
+    currentVersion: app.getVersion(),
+    isPackaged: app.isPackaged,
+    platform: process.platform
+  });
 
-  registerIpc({ db, registry, agent, crawl, ai, artifacts, credentials, settings, python, jobs, scoring, search, dataRoot });
+  registerIpc({ db, registry, agent, crawl, ai, artifacts, credentials, settings, python, jobs, scoring, search, updates, dataRoot });
   mainWindow = createWindow();
+  updates.start();
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) mainWindow = createWindow();

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -32,6 +32,7 @@ import type { PaperScoringService } from "./services/paper-scoring-service.js";
 import type { PythonService } from "./services/python-service.js";
 import type { SearchService } from "./services/search-service.js";
 import type { SettingsService } from "./services/settings-service.js";
+import type { UpdateService } from "./services/update-service.js";
 
 const { BrowserWindow, dialog, ipcMain, shell } = electron;
 const MAX_TEXT_VIEW_BYTES = 2 * 1024 * 1024;
@@ -49,6 +50,7 @@ export interface IpcServices {
   jobs: JobQueue;
   scoring: PaperScoringService;
   search: SearchService;
+  updates: UpdateService;
   dataRoot: string;
 }
 
@@ -203,6 +205,14 @@ export function registerIpc(services: IpcServices): void {
     if (error) throw new Error(error);
     return { ok: true };
   });
+
+  ipcMain.handle("updates:getStatus", () => services.updates.getStatus());
+
+  ipcMain.handle("updates:check", () => services.updates.checkForUpdates(true));
+
+  ipcMain.handle("updates:download", () => services.updates.downloadUpdate(true));
+
+  ipcMain.handle("updates:installNow", () => services.updates.installUpdateNow());
 
   ipcMain.handle("credentials:save", (_event, input: unknown) => {
     services.credentials.upsert(credentialUpsertSchema.parse(input));
@@ -442,6 +452,12 @@ export function registerIpc(services: IpcServices): void {
   services.jobs.onChanged((job) => {
     for (const window of BrowserWindow.getAllWindows()) {
       window.webContents.send("jobs:changed", job);
+    }
+  });
+
+  services.updates.on("changed", (status) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send("updates:changed", status);
     }
   });
 }

--- a/src/main/services/update-service.ts
+++ b/src/main/services/update-service.ts
@@ -1,0 +1,310 @@
+import { EventEmitter } from "node:events";
+import { autoUpdater } from "electron-updater";
+import type { UpdateStatus } from "../../shared/schemas.js";
+
+export const UPDATE_STARTUP_CHECK_DELAY_MS = 10_000;
+export const UPDATE_PERIODIC_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+export const UPDATE_RETRY_DELAYS_MS = [30_000, 2 * 60_000, 10 * 60_000] as const;
+
+type Timer = ReturnType<typeof setTimeout>;
+
+interface VersionInfo {
+  version?: string;
+}
+
+interface ProgressInfo {
+  percent?: number;
+  transferred?: number;
+  total?: number;
+  bytesPerSecond?: number;
+}
+
+export interface UpdateClient {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  allowPrerelease: boolean;
+  allowDowngrade: boolean;
+  checkForUpdates(): Promise<unknown>;
+  downloadUpdate(): Promise<string[]>;
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
+  on(event: "checking-for-update", listener: () => void): this;
+  on(event: "update-not-available", listener: (info: VersionInfo) => void): this;
+  on(event: "update-available", listener: (info: VersionInfo) => void): this;
+  on(event: "download-progress", listener: (info: ProgressInfo) => void): this;
+  on(event: "update-downloaded", listener: (info: VersionInfo) => void): this;
+  on(event: "error", listener: (error: Error, message?: string) => void): this;
+}
+
+export interface UpdateServiceOptions {
+  updater: UpdateClient;
+  currentVersion: string;
+  isPackaged: boolean;
+  platform: NodeJS.Platform | string;
+  startupCheckDelayMs?: number;
+  periodicCheckIntervalMs?: number;
+  retryDelaysMs?: readonly number[];
+  now?: () => Date;
+}
+
+export class UpdateService extends EventEmitter {
+  private readonly enabled: boolean;
+  private readonly startupCheckDelayMs: number;
+  private readonly periodicCheckIntervalMs: number;
+  private readonly retryDelaysMs: readonly number[];
+  private readonly now: () => Date;
+  private status: UpdateStatus;
+  private started = false;
+  private isChecking = false;
+  private isDownloading = false;
+  private operationFailureHandled = false;
+  private startupTimer: Timer | undefined;
+  private periodicTimer: Timer | undefined;
+  private retryTimer: Timer | undefined;
+
+  constructor(private readonly options: UpdateServiceOptions) {
+    super();
+    this.enabled = options.isPackaged && options.platform === "win32";
+    this.startupCheckDelayMs = options.startupCheckDelayMs ?? UPDATE_STARTUP_CHECK_DELAY_MS;
+    this.periodicCheckIntervalMs = options.periodicCheckIntervalMs ?? UPDATE_PERIODIC_CHECK_INTERVAL_MS;
+    this.retryDelaysMs = options.retryDelaysMs ?? UPDATE_RETRY_DELAYS_MS;
+    this.now = options.now ?? (() => new Date());
+    this.status = {
+      state: this.enabled ? "idle" : "disabled",
+      currentVersion: options.currentVersion,
+      retryCount: 0
+    };
+
+    if (this.enabled) {
+      this.configureUpdater();
+      this.wireUpdaterEvents();
+    }
+  }
+
+  start(): void {
+    if (!this.enabled || this.started) return;
+    this.started = true;
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = undefined;
+      void this.checkForUpdates();
+    }, this.startupCheckDelayMs);
+    this.periodicTimer = setInterval(() => {
+      void this.checkForUpdates();
+    }, this.periodicCheckIntervalMs);
+  }
+
+  stop(): void {
+    this.clearStartupTimer();
+    this.clearPeriodicTimer();
+    this.clearRetryTimer();
+    this.started = false;
+  }
+
+  getStatus(): UpdateStatus {
+    return { ...this.status };
+  }
+
+  async checkForUpdates(manual = false): Promise<UpdateStatus> {
+    if (!this.enabled || this.status.state === "downloaded") return this.getStatus();
+    if (manual) this.resetRetryCycle();
+    if (this.isChecking || this.isDownloading) return this.getStatus();
+
+    this.operationFailureHandled = false;
+    this.isChecking = true;
+    this.setStatus({
+      state: "checking",
+      downloadPercent: undefined,
+      transferredBytes: undefined,
+      totalBytes: undefined,
+      bytesPerSecond: undefined,
+      nextRetryAt: undefined,
+      error: undefined
+    });
+
+    try {
+      await this.options.updater.checkForUpdates();
+    } catch (error) {
+      this.handleFailure(error);
+    } finally {
+      this.isChecking = false;
+    }
+
+    return this.getStatus();
+  }
+
+  async downloadUpdate(manual = false): Promise<UpdateStatus> {
+    if (!this.enabled || this.status.state === "downloaded") return this.getStatus();
+    if (manual) this.resetRetryCycle();
+    if (this.isChecking || this.isDownloading) return this.getStatus();
+
+    this.operationFailureHandled = false;
+    this.isDownloading = true;
+    this.setStatus({
+      state: "downloading",
+      downloadPercent: this.status.downloadPercent ?? 0,
+      nextRetryAt: undefined,
+      error: undefined
+    });
+
+    try {
+      await this.options.updater.downloadUpdate();
+    } catch (error) {
+      this.handleFailure(error);
+    } finally {
+      this.isDownloading = false;
+    }
+
+    return this.getStatus();
+  }
+
+  installUpdateNow(): UpdateStatus {
+    if (this.enabled && this.status.state === "downloaded") {
+      this.options.updater.quitAndInstall(true, true);
+    }
+    return this.getStatus();
+  }
+
+  private configureUpdater(): void {
+    const updater = this.options.updater;
+    updater.autoDownload = false;
+    updater.autoInstallOnAppQuit = true;
+    updater.allowPrerelease = false;
+    updater.allowDowngrade = false;
+  }
+
+  private wireUpdaterEvents(): void {
+    this.options.updater.on("checking-for-update", () => {
+      this.setStatus({ state: "checking", error: undefined, nextRetryAt: undefined });
+    });
+
+    this.options.updater.on("update-not-available", () => {
+      this.clearRetryTimer();
+      this.setStatus({
+        state: "not-available",
+        lastCheckedAt: this.isoNow(),
+        retryCount: 0,
+        nextRetryAt: undefined,
+        error: undefined
+      });
+    });
+
+    this.options.updater.on("update-available", (info) => {
+      this.setStatus({
+        state: "available",
+        availableVersion: info.version,
+        lastCheckedAt: this.isoNow(),
+        retryCount: 0,
+        nextRetryAt: undefined,
+        error: undefined
+      });
+      setTimeout(() => {
+        void this.downloadUpdate();
+      }, 0);
+    });
+
+    this.options.updater.on("download-progress", (info) => {
+      this.setStatus({
+        state: "downloading",
+        downloadPercent: clampPercent(info.percent),
+        transferredBytes: info.transferred,
+        totalBytes: info.total,
+        bytesPerSecond: info.bytesPerSecond,
+        error: undefined
+      });
+    });
+
+    this.options.updater.on("update-downloaded", (info) => {
+      this.clearRetryTimer();
+      this.setStatus({
+        state: "downloaded",
+        availableVersion: info.version ?? this.status.availableVersion,
+        downloadPercent: 100,
+        retryCount: 0,
+        nextRetryAt: undefined,
+        error: undefined
+      });
+    });
+
+    this.options.updater.on("error", (error, message) => {
+      this.handleFailure(message ? new Error(message, { cause: error }) : error);
+    });
+  }
+
+  private handleFailure(error: unknown): void {
+    if (this.operationFailureHandled) return;
+    this.operationFailureHandled = true;
+
+    const scheduledRetries = this.status.retryCount;
+    if (scheduledRetries >= this.retryDelaysMs.length) {
+      this.setStatus({
+        state: "failed",
+        retryCount: scheduledRetries,
+        nextRetryAt: undefined,
+        error: errorMessage(error)
+      });
+      return;
+    }
+
+    const retryCount = scheduledRetries + 1;
+    const delayMs = this.retryDelaysMs[scheduledRetries] ?? this.retryDelaysMs.at(-1) ?? 0;
+    const nextRetryAt = new Date(this.now().getTime() + delayMs).toISOString();
+
+    this.clearRetryTimer();
+    this.setStatus({
+      state: "failed",
+      retryCount,
+      nextRetryAt,
+      error: errorMessage(error)
+    });
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = undefined;
+      void this.checkForUpdates();
+    }, delayMs);
+  }
+
+  private resetRetryCycle(): void {
+    this.clearRetryTimer();
+    this.setStatus({
+      retryCount: 0,
+      nextRetryAt: undefined,
+      error: undefined
+    });
+  }
+
+  private setStatus(patch: Partial<UpdateStatus>): void {
+    this.status = { ...this.status, ...patch };
+    this.emit("changed", this.getStatus());
+  }
+
+  private clearStartupTimer(): void {
+    if (this.startupTimer) clearTimeout(this.startupTimer);
+    this.startupTimer = undefined;
+  }
+
+  private clearPeriodicTimer(): void {
+    if (this.periodicTimer) clearInterval(this.periodicTimer);
+    this.periodicTimer = undefined;
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    this.retryTimer = undefined;
+  }
+
+  private isoNow(): string {
+    return this.now().toISOString();
+  }
+}
+
+export function createUpdateService(options: Omit<UpdateServiceOptions, "updater">): UpdateService {
+  return new UpdateService({ ...options, updater: autoUpdater });
+}
+
+function clampPercent(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  return Math.min(100, Math.max(0, value));
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,7 +19,8 @@ import type {
   ReindexResponse,
   SearchRequest,
   SearchResponse,
-  SourceDefinition
+  SourceDefinition,
+  UpdateStatus
 } from "../shared/schemas.js";
 
 const { contextBridge, ipcRenderer } = electron;
@@ -73,6 +74,11 @@ export interface PaperPilotApi {
   getSettings(): Promise<AppSettings>;
   updateSettings(input: Partial<AppSettings>): Promise<AppSettings>;
   openDataFolder(): Promise<{ ok: boolean }>;
+  getUpdateStatus(): Promise<UpdateStatus>;
+  checkForUpdates(): Promise<UpdateStatus>;
+  downloadUpdate(): Promise<UpdateStatus>;
+  installUpdateNow(): Promise<UpdateStatus>;
+  onUpdateStatusChanged(listener: (status: UpdateStatus) => void): () => void;
   saveCredential(input: CredentialUpsert): Promise<Array<{ sourceId: string; label: string; updatedAt: string }>>;
   listCredentialFlags(): Promise<Array<{ sourceId: string; label: string; updatedAt: string }>>;
   removeCredential(input: { sourceId: string; label?: string }): Promise<Array<{ sourceId: string; label: string; updatedAt: string }>>;
@@ -142,6 +148,15 @@ const api: PaperPilotApi = {
   getSettings: () => ipcRenderer.invoke("settings:get"),
   updateSettings: (input) => ipcRenderer.invoke("settings:update", input),
   openDataFolder: () => ipcRenderer.invoke("app:openDataFolder"),
+  getUpdateStatus: () => ipcRenderer.invoke("updates:getStatus"),
+  checkForUpdates: () => ipcRenderer.invoke("updates:check"),
+  downloadUpdate: () => ipcRenderer.invoke("updates:download"),
+  installUpdateNow: () => ipcRenderer.invoke("updates:installNow"),
+  onUpdateStatusChanged: (listener) => {
+    const handler = (_event: Electron.IpcRendererEvent, status: UpdateStatus) => listener(status);
+    ipcRenderer.on("updates:changed", handler);
+    return () => ipcRenderer.off("updates:changed", handler);
+  },
   saveCredential: (input) => ipcRenderer.invoke("credentials:save", input),
   listCredentialFlags: () => ipcRenderer.invoke("credentials:listFlags"),
   removeCredential: (input) => ipcRenderer.invoke("credentials:remove", input),

--- a/src/renderer/components/settings-panel.tsx
+++ b/src/renderer/components/settings-panel.tsx
@@ -1,14 +1,31 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Brain, CheckCircle2, Database, KeyRound, Loader2, Monitor, Moon, RefreshCw, Search, ShieldCheck, Sun, Trash2 } from "lucide-react";
+import {
+  Brain,
+  CheckCircle2,
+  Database,
+  Download,
+  KeyRound,
+  Loader2,
+  Monitor,
+  Moon,
+  PackageCheck,
+  Power,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  Sun,
+  Trash2
+} from "lucide-react";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
-import type { AiProviderHealth, AppSettings, Project, SourceDefinition, SourceId } from "../../shared/schemas";
+import type { AiProviderHealth, AppSettings, Project, SourceDefinition, SourceId, UpdateStatus } from "../../shared/schemas";
 import { PanelSection, PolicyToggle } from "./ui";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
@@ -45,6 +62,7 @@ export function SettingsPanel({
   const queryClient = useQueryClient();
   const settingsQuery = useQuery({ queryKey: ["settings"], queryFn: () => window.paperPilot.getSettings() });
   const flagsQuery = useQuery({ queryKey: ["credentialFlags"], queryFn: () => window.paperPilot.listCredentialFlags() });
+  const updateQuery = useQuery({ queryKey: ["updates"], queryFn: () => window.paperPilot.getUpdateStatus() });
   const [selectedSource, setSelectedSource] = useState<SourceId | "ai-gateway">("ai-gateway");
   const [secret, setSecret] = useState("");
   const [provider, setProvider] = useState<AppSettings["ai"]["provider"]>("ollama");
@@ -58,6 +76,12 @@ export function SettingsPanel({
       setBaseUrl(settingsQuery.data.ai.baseUrl);
     }
   }, [settingsQuery.data]);
+
+  useEffect(() => {
+    return window.paperPilot.onUpdateStatusChanged((status) => {
+      queryClient.setQueryData<UpdateStatus>(["updates"], status);
+    });
+  }, [queryClient]);
 
   const saveCredential = useMutation({
     mutationFn: () => window.paperPilot.saveCredential({ sourceId: selectedSource, label: "default", secret }),
@@ -124,12 +148,34 @@ export function SettingsPanel({
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["settings"] })
   });
 
+  const checkForUpdates = useMutation({
+    mutationFn: () => window.paperPilot.checkForUpdates(),
+    onSuccess: (status) => queryClient.setQueryData(["updates"], status)
+  });
+
+  const downloadUpdate = useMutation({
+    mutationFn: () => window.paperPilot.downloadUpdate(),
+    onSuccess: (status) => queryClient.setQueryData(["updates"], status)
+  });
+
+  const installUpdateNow = useMutation({
+    mutationFn: () => window.paperPilot.installUpdateNow(),
+    onSuccess: (status) => queryClient.setQueryData(["updates"], status)
+  });
+
   const flags = flagsQuery.data ?? [];
   const credentialed = useMemo(() => new Set(flags.map((flag) => flag.sourceId)), [flags]);
   const candidateHealth = checkProvider.data ?? aiHealth;
   const displayedHealth =
     candidateHealth?.provider === provider && candidateHealth.baseUrl === baseUrl && candidateHealth.model === model ? candidateHealth : undefined;
   const disabledSourceIds = new Set(settingsQuery.data?.sources.disabledSourceIds ?? []);
+  const updateStatus = updateQuery.data;
+  const updateBusy =
+    updateStatus?.state === "checking" ||
+    updateStatus?.state === "downloading" ||
+    checkForUpdates.isPending ||
+    downloadUpdate.isPending ||
+    installUpdateNow.isPending;
 
   function changeProvider(nextProvider: AppSettings["ai"]["provider"]): void {
     setProvider(nextProvider);
@@ -172,6 +218,81 @@ export function SettingsPanel({
                   );
                 })}
               </ToggleGroup>
+            </PanelSection>
+
+            <PanelSection icon={<PackageCheck size={17} />} title="Software Update">
+              <div className="rounded-lg border border-border bg-card p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium">{updateStatusText(updateStatus)}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      Current version {updateStatus?.currentVersion ?? "unknown"}
+                      {updateStatus?.lastCheckedAt ? ` / Last checked ${formatDate(updateStatus.lastCheckedAt)}` : ""}
+                    </div>
+                  </div>
+                  {updateStatus?.state ? (
+                    <Badge variant={updateStatus.state === "failed" ? "destructive" : "outline"} className="shrink-0 capitalize">
+                      {updateStatus.state.replace("-", " ")}
+                    </Badge>
+                  ) : null}
+                </div>
+                {updateStatus?.state === "downloading" ? (
+                  <div className="mt-3">
+                    <Progress value={updateStatus.downloadPercent ?? 0} />
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      {formatPercent(updateStatus.downloadPercent)} downloaded
+                      {updateStatus.totalBytes ? ` / ${formatBytes(updateStatus.transferredBytes ?? 0)} of ${formatBytes(updateStatus.totalBytes)}` : ""}
+                    </div>
+                  </div>
+                ) : null}
+                {updateStatus?.state === "failed" && updateStatus.error ? (
+                  <Alert variant="destructive" className="mt-3">
+                    <AlertTitle>Update failed</AlertTitle>
+                    <AlertDescription>
+                      {updateStatus.error}
+                      {updateStatus.nextRetryAt ? ` Next retry ${formatDate(updateStatus.nextRetryAt)}.` : ""}
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+                {updateStatus?.state === "downloaded" ? (
+                  <Alert className="mt-3 border-primary/40 bg-accent/45">
+                    <AlertDescription>
+                      Version {updateStatus.availableVersion ?? "update"} is ready and will install the next time Paper Pilot restarts.
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  {updateStatus?.state === "failed" ? (
+                    <Button type="button" variant="outline" onClick={() => checkForUpdates.mutate()} disabled={updateBusy}>
+                      {checkForUpdates.isPending ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+                      Retry
+                    </Button>
+                  ) : updateStatus && ["idle", "not-available"].includes(updateStatus.state) ? (
+                    <Button type="button" variant="outline" onClick={() => checkForUpdates.mutate()} disabled={updateBusy}>
+                      {checkForUpdates.isPending ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+                      Check
+                    </Button>
+                  ) : null}
+                  {updateStatus?.state === "available" ? (
+                    <Button type="button" onClick={() => downloadUpdate.mutate()} disabled={updateBusy}>
+                      {downloadUpdate.isPending ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+                      Download
+                    </Button>
+                  ) : null}
+                  {updateStatus?.state === "downloaded" ? (
+                    <Button type="button" onClick={() => installUpdateNow.mutate()} disabled={installUpdateNow.isPending} className="col-span-2">
+                      {installUpdateNow.isPending ? <Loader2 size={14} className="animate-spin" /> : <Power size={14} />}
+                      Restart and install
+                    </Button>
+                  ) : null}
+                  {updateStatus?.state === "checking" || updateStatus?.state === "downloading" ? (
+                    <Button type="button" variant="outline" disabled className="col-span-2">
+                      <Loader2 size={14} className="animate-spin" />
+                      {updateStatus.state === "checking" ? "Checking" : "Downloading"}
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
             </PanelSection>
 
             <PanelSection icon={<Brain size={17} />} title="AI Provider">
@@ -388,4 +509,43 @@ export function SettingsPanel({
 
 function FieldLabel({ children }: { children: string }): JSX.Element {
   return <label className="block text-xs font-medium text-muted-foreground">{children}</label>;
+}
+
+function updateStatusText(status: UpdateStatus | undefined): string {
+  if (!status) return "Checking update status...";
+  if (status.state === "disabled") return "Updates are available in installed Windows releases.";
+  if (status.state === "idle") return "Ready to check for updates.";
+  if (status.state === "checking") return "Checking for updates...";
+  if (status.state === "available") return `Version ${status.availableVersion ?? "update"} is available.`;
+  if (status.state === "downloading") return `Downloading version ${status.availableVersion ?? "update"}...`;
+  if (status.state === "downloaded") return `Version ${status.availableVersion ?? "update"} is ready.`;
+  if (status.state === "not-available") return "Paper Pilot is up to date.";
+  return "Update failed.";
+}
+
+function formatPercent(value: number | undefined): string {
+  return `${Math.round(value ?? 0)}%`;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`;
+  const units = ["KB", "MB", "GB"];
+  let unitIndex = -1;
+  let size = value;
+  do {
+    size /= 1024;
+    unitIndex += 1;
+  } while (size >= 1024 && unitIndex < units.length - 1);
+  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  });
 }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -254,6 +254,33 @@ export const jobSchema = z.object({
 });
 export type Job = z.infer<typeof jobSchema>;
 
+export const updateStateSchema = z.enum([
+  "disabled",
+  "idle",
+  "checking",
+  "available",
+  "downloading",
+  "downloaded",
+  "not-available",
+  "failed"
+]);
+export type UpdateState = z.infer<typeof updateStateSchema>;
+
+export const updateStatusSchema = z.object({
+  state: updateStateSchema,
+  currentVersion: z.string(),
+  availableVersion: z.string().optional(),
+  downloadPercent: z.number().min(0).max(100).optional(),
+  transferredBytes: z.number().nonnegative().optional(),
+  totalBytes: z.number().nonnegative().optional(),
+  bytesPerSecond: z.number().nonnegative().optional(),
+  lastCheckedAt: z.string().optional(),
+  retryCount: z.number().int().nonnegative().default(0),
+  nextRetryAt: z.string().optional(),
+  error: z.string().optional()
+});
+export type UpdateStatus = z.infer<typeof updateStatusSchema>;
+
 export const appSettingsSchema = z.object({
   ui: z
     .object({

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appSettingsSchema, crawlConfigSchema, paperDedupeKey } from "../src/shared/schemas";
+import { appSettingsSchema, crawlConfigSchema, paperDedupeKey, updateStatusSchema } from "../src/shared/schemas";
 
 describe("shared schemas", () => {
   it("applies crawl defaults", () => {
@@ -21,5 +21,21 @@ describe("shared schemas", () => {
     });
     expect(settings.ui.theme).toBe("system");
     expect(settings.sources.disabledSourceIds).toEqual([]);
+  });
+
+  it("validates updater status payloads", () => {
+    const status = updateStatusSchema.parse({
+      state: "downloading",
+      currentVersion: "0.2.3",
+      availableVersion: "0.2.4",
+      downloadPercent: 45,
+      transferredBytes: 45,
+      totalBytes: 100,
+      bytesPerSecond: 10,
+      lastCheckedAt: "2026-06-08T12:00:00.000Z"
+    });
+
+    expect(status.retryCount).toBe(0);
+    expect(status.state).toBe("downloading");
   });
 });

--- a/tests/update-service.test.ts
+++ b/tests/update-service.test.ts
@@ -1,0 +1,198 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateService, type UpdateClient } from "../src/main/services/update-service";
+
+class FakeUpdater extends EventEmitter implements UpdateClient {
+  autoDownload = true;
+  autoInstallOnAppQuit = false;
+  allowPrerelease = true;
+  allowDowngrade = true;
+  checkForUpdates = vi.fn<() => Promise<unknown>>(async () => null);
+  downloadUpdate = vi.fn<() => Promise<string[]>>(async () => []);
+  quitAndInstall = vi.fn<(isSilent?: boolean, isForceRunAfter?: boolean) => void>();
+
+  override on(event: string | symbol, listener: (...args: unknown[]) => void): this {
+    return super.on(event, listener);
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-08T12:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("UpdateService", () => {
+  it("configures updater for stable Windows app updates", () => {
+    const { updater } = createService();
+
+    expect(updater.autoDownload).toBe(false);
+    expect(updater.autoInstallOnAppQuit).toBe(true);
+    expect(updater.allowPrerelease).toBe(false);
+    expect(updater.allowDowngrade).toBe(false);
+  });
+
+  it("checks on startup and downloads an available update", async () => {
+    const { service, updater } = createService();
+    updater.checkForUpdates.mockImplementation(async () => {
+      updater.emit("update-available", { version: "0.2.4" });
+      return null;
+    });
+    updater.downloadUpdate.mockImplementation(async () => {
+      updater.emit("download-progress", {
+        percent: 42.4,
+        transferred: 42,
+        total: 100,
+        bytesPerSecond: 10
+      });
+      updater.emit("update-downloaded", { version: "0.2.4" });
+      return ["installer.exe"];
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(service.getStatus()).toMatchObject({
+      state: "downloaded",
+      currentVersion: "0.2.3",
+      availableVersion: "0.2.4",
+      downloadPercent: 100,
+      retryCount: 0
+    });
+  });
+
+  it("installs a downloaded update on demand", async () => {
+    const { service, updater } = createService();
+    updater.checkForUpdates.mockImplementation(async () => {
+      updater.emit("update-available", { version: "0.2.4" });
+      return null;
+    });
+    updater.downloadUpdate.mockImplementation(async () => {
+      updater.emit("update-downloaded", { version: "0.2.4" });
+      return ["installer.exe"];
+    });
+
+    await service.checkForUpdates(true);
+    await vi.runOnlyPendingTimersAsync();
+    service.installUpdateNow();
+
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true);
+  });
+
+  it("backs off failed checks and stops after automatic retries are exhausted", async () => {
+    const { service, updater } = createService();
+    updater.checkForUpdates.mockRejectedValue(new Error("offline"));
+
+    await service.checkForUpdates(true);
+
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(service.getStatus()).toMatchObject({
+      state: "failed",
+      retryCount: 1,
+      error: "offline",
+      nextRetryAt: "2026-06-08T12:00:00.100Z"
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
+    expect(service.getStatus().retryCount).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(3);
+    expect(service.getStatus().retryCount).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(4);
+    expect(service.getStatus()).toMatchObject({
+      state: "failed",
+      retryCount: 3,
+      nextRetryAt: undefined,
+      error: "offline"
+    });
+  });
+
+  it("resets the retry cycle for a manual retry", async () => {
+    const { service, updater } = createService();
+    updater.checkForUpdates.mockRejectedValueOnce(new Error("offline"));
+
+    await service.checkForUpdates(true);
+    expect(service.getStatus().retryCount).toBe(1);
+
+    updater.checkForUpdates.mockReset();
+    updater.checkForUpdates.mockImplementation(async () => {
+      updater.emit("update-not-available", { version: "0.2.3" });
+      return null;
+    });
+
+    await service.checkForUpdates(true);
+
+    expect(service.getStatus()).toMatchObject({
+      state: "not-available",
+      retryCount: 0,
+      nextRetryAt: undefined,
+      error: undefined
+    });
+  });
+
+  it("ignores concurrent manual checks", async () => {
+    const { service, updater } = createService();
+    let resolveCheck: (value: unknown) => void = () => undefined;
+    updater.checkForUpdates.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCheck = resolve;
+        })
+    );
+
+    const first = service.checkForUpdates(true);
+    const second = service.checkForUpdates(true);
+    updater.emit("update-not-available", { version: "0.2.3" });
+    resolveCheck(null);
+
+    await Promise.all([first, second]);
+
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays disabled outside packaged Windows builds", async () => {
+    const updater = new FakeUpdater();
+    const service = new UpdateService({
+      updater,
+      currentVersion: "0.2.3",
+      isPackaged: false,
+      platform: "win32",
+      startupCheckDelayMs: 1,
+      periodicCheckIntervalMs: 10,
+      retryDelaysMs: [100, 200, 300]
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await service.checkForUpdates(true);
+    await service.downloadUpdate(true);
+
+    expect(service.getStatus()).toMatchObject({ state: "disabled", currentVersion: "0.2.3" });
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+    expect(updater.downloadUpdate).not.toHaveBeenCalled();
+  });
+});
+
+function createService() {
+  const updater = new FakeUpdater();
+  const service = new UpdateService({
+    updater,
+    currentVersion: "0.2.3",
+    isPackaged: true,
+    platform: "win32",
+    startupCheckDelayMs: 1_000,
+    periodicCheckIntervalMs: 10_000,
+    retryDelaysMs: [100, 200, 300]
+  });
+  return { service, updater };
+}


### PR DESCRIPTION
## Summary

- Adds Windows-only Electron auto updates through GitHub Releases using `electron-updater`.
- Checks on startup and every 6 hours, downloads stable public releases in the background, and installs on next quit or via Settings.
- Adds typed update IPC/preload APIs and a Software Update section in Settings.
- Updates release packaging so GitHub Releases include `latest.yml`, installer blockmaps, and checksums required for updater clients.

## Why

The signed Windows releases were publishable, but installed apps had no updater runtime or update metadata. This gives users automatic update discovery/downloads after they manually install the first updater-enabled release.

## Validation

- `npm run typecheck`
- `npm test` — 13 passed, 1 skipped; 61 passed, 2 skipped
- `npm run build`
- `npm run verify`
- `npm run package -- --win --x64 --publish never`
- Local CI-style updater metadata validation confirmed `latest.yml`, matching installer, matching `.exe.blockmap`, and packaged `resources/app-update.yml` exist.
