### PR TITLE
Document pre-1.0 minor releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
   gate:
     name: Gate
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     needs: [quality, windows, codeql, dependency-review, release-policy]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ Every squash merge creates a signed Windows GitHub Release. Choose at most one v
 - `release:minor`: minor release, such as `v1.2.3` to `v1.3.0`.
 - `release:major`: major release, such as `v1.2.3` to `v2.0.0`.
 
+For a pre-1.0 example, applying `release:minor` after `v0.2.5` produces `v0.3.0`; it does not increment the patch component.
+
 Git tags are the version source of truth. The release workflow injects the calculated version into the signed package, while the checked-in manifest stays at `0.0.0-development`.
 
 If publishing fails after merge, rerun the failed workflow. For recovery, manually dispatch the Release workflow with the merge commit SHA; it will reuse the existing version and repair incomplete assets.


### PR DESCRIPTION
## Summary

- document how minor labels behave for pre-1.0 versions
- exercise the release:minor path from v0.2.5 to v0.3.0

## Validation

- npm run format:check