### PR TITLE
Add automatic Ollama model discovery

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,6 +7,7 @@ import {
   artifactSchema,
   artifactUpdateSchema,
   appSettingsSchema,
+  aiModelListRequestSchema,
   aiProviderCheckRequestSchema,
   chatModeSchema,
   chatRunSchema,
@@ -351,6 +352,10 @@ export function registerIpc(services: IpcServices): void {
 
   ipcMain.handle("ai:checkProvider", (_event, input: unknown) =>
     services.ai.checkProvider(aiProviderCheckRequestSchema.parse(input))
+  );
+
+  ipcMain.handle("ai:listModels", (_event, input: unknown) =>
+    services.ai.listModels(aiModelListRequestSchema.parse(input))
   );
 
   ipcMain.handle("papers:score", (_event, input: unknown) => {

--- a/src/main/services/ai-service.ts
+++ b/src/main/services/ai-service.ts
@@ -1,5 +1,10 @@
+import { z } from "zod";
 import {
+  aiModelListSchema,
   aiProviderHealthSchema,
+  type AiModelInfo,
+  type AiModelList,
+  type AiModelListRequest,
   type AiProviderCheckRequest,
   type AiProviderHealth,
   type AppSettings,
@@ -10,6 +15,30 @@ import type { ArtifactService } from "./artifact-service.js";
 import type { CredentialService } from "./credential-service.js";
 import type { JobQueue } from "./job-queue.js";
 import type { SettingsService } from "./settings-service.js";
+
+const ollamaTagsResponseSchema = z.object({
+  models: z
+    .array(
+      z.object({
+        name: z.string().optional(),
+        model: z.string().optional(),
+        modified_at: z.string().optional(),
+        size: z.number().nonnegative().optional(),
+        details: z
+          .object({
+            family: z.string().optional(),
+            parameter_size: z.string().optional(),
+            quantization_level: z.string().optional()
+          })
+          .optional()
+      })
+    )
+    .default([])
+});
+
+const openAiModelsResponseSchema = z.object({
+  data: z.array(z.object({ id: z.string().trim().min(1) })).default([])
+});
 
 export class AiService {
   constructor(
@@ -157,6 +186,19 @@ export class AiService {
     return data.message?.content ?? "No response content returned by the local Ollama model.";
   }
 
+  async listModels(input: AiModelListRequest): Promise<AiModelList> {
+    const models =
+      input.provider === "ollama"
+        ? await this.listOllamaModels(input.baseUrl)
+        : await this.listOpenAiCompatibleModels(input.provider, input.baseUrl);
+    return aiModelListSchema.parse({
+      provider: input.provider,
+      baseUrl: input.baseUrl,
+      fetchedAt: new Date().toISOString(),
+      models
+    });
+  }
+
   async checkProvider(input: AiProviderCheckRequest = {}): Promise<AiProviderHealth> {
     const current = await this.settings.get();
     const ai = { ...current.ai, ...(input ?? {}) };
@@ -164,12 +206,8 @@ export class AiService {
     const hasApiKey = this.credentials.has("ai-gateway");
     try {
       if (ai.provider === "ollama") {
-        const response = await fetch(`${trimTrailingSlash(ai.baseUrl)}/api/tags`, {
-          signal: AbortSignal.timeout(2500)
-        });
-        if (!response.ok) throw new Error(`Ollama returned ${response.status}.`);
-        const data = (await response.json()) as { models?: Array<{ name?: string }> };
-        const models = (data.models ?? []).map((model) => model.name).filter((name): name is string => Boolean(name));
+        const modelList = await this.listModels({ provider: ai.provider, baseUrl: ai.baseUrl });
+        const models = modelList.models.map((model) => model.id);
         const status = models.length && models.includes(ai.model) ? "ok" : "warning";
         const detail = !models.length
           ? "Ollama is reachable, but no models are installed."
@@ -202,16 +240,8 @@ export class AiService {
         });
       }
 
-      const response = await fetch(openAiCompatibleUrl(ai.baseUrl, "models"), {
-        headers: hasApiKey ? { Authorization: `Bearer ${this.credentials.get("ai-gateway")}` } : {},
-        signal: AbortSignal.timeout(5000)
-      });
-      if (!response.ok) {
-        const detail = await response.text().catch(() => "");
-        throw new Error(`Model list failed ${response.status}: ${detail.slice(0, 300)}`);
-      }
-      const data = (await response.json()) as { data?: Array<{ id?: string }> };
-      const models = (data.data ?? []).map((model) => model.id).filter((name): name is string => Boolean(name));
+      const modelList = await this.listModels({ provider: ai.provider, baseUrl: ai.baseUrl });
+      const models = modelList.models.map((model) => model.id);
       return aiProviderHealthSchema.parse({
         provider: ai.provider,
         baseUrl: ai.baseUrl,
@@ -236,6 +266,62 @@ export class AiService {
       });
     }
   }
+
+  private async listOllamaModels(baseUrl: string): Promise<AiModelInfo[]> {
+    const response = await fetch(`${trimTrailingSlash(baseUrl)}/api/tags`, {
+      signal: AbortSignal.timeout(5000)
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(
+        `Ollama model discovery failed (${response.status})${detail ? `: ${detail.slice(0, 300)}` : "."}`
+      );
+    }
+    const parsed = ollamaTagsResponseSchema.parse(await response.json());
+    return uniqueModels(
+      parsed.models.flatMap((entry) => {
+        const id = entry.model?.trim() || entry.name?.trim();
+        if (!id) return [];
+        return [
+          {
+            id,
+            name: entry.name?.trim() || id,
+            modifiedAt: entry.modified_at,
+            sizeBytes: entry.size,
+            family: entry.details?.family,
+            parameterSize: entry.details?.parameter_size,
+            quantizationLevel: entry.details?.quantization_level
+          }
+        ];
+      })
+    );
+  }
+
+  private async listOpenAiCompatibleModels(
+    provider: Exclude<AppSettings["ai"]["provider"], "ollama">,
+    baseUrl: string
+  ): Promise<AiModelInfo[]> {
+    const apiKey = this.credentials.get("ai-gateway");
+    if (provider === "vercel" && !apiKey) throw new Error("AI Gateway API key is not configured.");
+    const response = await fetch(openAiCompatibleUrl(baseUrl, "models"), {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      signal: AbortSignal.timeout(5000)
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(`Model discovery failed (${response.status})${detail ? `: ${detail.slice(0, 300)}` : "."}`);
+    }
+    const parsed = openAiModelsResponseSchema.parse(await response.json());
+    return uniqueModels(parsed.data.map(({ id }) => ({ id, name: id })));
+  }
+}
+
+function uniqueModels(models: AiModelInfo[]): AiModelInfo[] {
+  const byId = new Map(models.map((model) => [model.id, model]));
+  return [...byId.values()].sort(
+    (left, right) =>
+      (right.modifiedAt ?? "").localeCompare(left.modifiedAt ?? "") || left.name.localeCompare(right.name)
+  );
 }
 
 function providerLabel(provider: AppSettings["ai"]["provider"]): string {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,8 @@
 import electron from "electron";
 import type {
   AppSettings,
+  AiModelList,
+  AiModelListRequest,
   AiProviderCheckRequest,
   AiProviderHealth,
   Artifact,
@@ -112,6 +114,7 @@ export interface PaperPilotApi {
     projectId: string;
     prompt: string;
   }): Promise<{ content: string; artifactId: string; jobId: string }>;
+  listAiModels(input: AiModelListRequest): Promise<AiModelList>;
   checkAiProvider(input?: AiProviderCheckRequest): Promise<AiProviderHealth>;
   scorePapers(input: { projectId: string }): Promise<{ scoredCount: number; papers: Paper[] }>;
   updatePaper(input: PaperUpdate): Promise<Paper>;
@@ -219,6 +222,7 @@ const api: PaperPilotApi = {
   testCredential: (input) => ipcRenderer.invoke("credentials:test", input),
   runCrawl: (input) => ipcRenderer.invoke("crawl:run", input),
   generateBrief: (input) => ipcRenderer.invoke("brief:generate", input),
+  listAiModels: (input) => ipcRenderer.invoke("ai:listModels", input),
   checkAiProvider: (input) => ipcRenderer.invoke("ai:checkProvider", input),
   scorePapers: (input) => ipcRenderer.invoke("papers:score", input),
   updatePaper: (input) => ipcRenderer.invoke("papers:update", input),

--- a/src/renderer/components/settings-panel.tsx
+++ b/src/renderer/components/settings-panel.tsx
@@ -78,6 +78,7 @@ export function SettingsPanel({
   const [provider, setProvider] = useState<AppSettings["ai"]["provider"]>("ollama");
   const [model, setModel] = useState(providerDefaults.ollama.model);
   const [baseUrl, setBaseUrl] = useState(providerDefaults.ollama.baseUrl);
+  const [modelDiscoveryUrl, setModelDiscoveryUrl] = useState(providerDefaults.ollama.baseUrl);
 
   useEffect(() => {
     if (settingsQuery.data) {
@@ -92,6 +93,33 @@ export function SettingsPanel({
       queryClient.setQueryData<UpdateStatus>(["updates"], status);
     });
   }, [queryClient]);
+
+  useEffect(() => {
+    if (!open || provider !== "ollama") return;
+    const timer = window.setTimeout(() => setModelDiscoveryUrl(baseUrl.trim()), 400);
+    return () => window.clearTimeout(timer);
+  }, [baseUrl, open, provider]);
+
+  const ollamaDiscoveryUrl = provider === "ollama" && isHttpUrl(modelDiscoveryUrl) ? modelDiscoveryUrl : "";
+  const ollamaModelsQuery = useQuery({
+    queryKey: ["ai-models", "ollama", ollamaDiscoveryUrl],
+    queryFn: () => window.paperPilot.listAiModels({ provider: "ollama", baseUrl: ollamaDiscoveryUrl }),
+    enabled: open && Boolean(ollamaDiscoveryUrl),
+    retry: false,
+    staleTime: 10_000,
+    refetchOnWindowFocus: false
+  });
+
+  useEffect(() => {
+    if (
+      provider !== "ollama" ||
+      ollamaModelsQuery.data?.baseUrl !== baseUrl.trim() ||
+      !ollamaModelsQuery.data.models.length
+    )
+      return;
+    const installed = ollamaModelsQuery.data.models;
+    if (!installed.some((candidate) => candidate.id === model)) setModel(installed[0].id);
+  }, [baseUrl, model, ollamaModelsQuery.data, provider]);
 
   const saveCredential = useMutation({
     mutationFn: () => window.paperPilot.saveCredential({ sourceId: selectedSource, label: "default", secret }),
@@ -179,6 +207,13 @@ export function SettingsPanel({
     candidateHealth?.provider === provider && candidateHealth.baseUrl === baseUrl && candidateHealth.model === model
       ? candidateHealth
       : undefined;
+  const ollamaDiscoveryIsCurrent = ollamaModelsQuery.data?.baseUrl === baseUrl.trim();
+  const ollamaDiscoveryRequestIsCurrent = modelDiscoveryUrl === baseUrl.trim();
+  const installedOllamaModels = ollamaDiscoveryIsCurrent ? (ollamaModelsQuery.data?.models ?? []) : [];
+  const selectedOllamaModel = installedOllamaModels.find((candidate) => candidate.id === model);
+  const canSaveAiSettings = provider !== "ollama" || Boolean(selectedOllamaModel);
+  const ollamaModelsLoading =
+    provider === "ollama" && isHttpUrl(baseUrl) && (!ollamaDiscoveryIsCurrent || ollamaModelsQuery.isPending);
   const disabledSourceIds = new Set(settingsQuery.data?.sources.disabledSourceIds ?? []);
   const updateStatus = updateQuery.data;
   const updateBusy =
@@ -360,24 +395,100 @@ export function SettingsPanel({
               </Select>
               <FieldLabel>Base URL</FieldLabel>
               <Input value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} />
-              <FieldLabel>Model</FieldLabel>
-              <Input value={model} onChange={(event) => setModel(event.target.value)} />
-              {displayedHealth?.models.length ? (
-                <Select value={model} onValueChange={setModel}>
-                  <SelectTrigger className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {displayedHealth.models.map((modelName) => (
-                      <SelectItem key={modelName} value={modelName}>
-                        {modelName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : null}
+              <FieldLabel>{provider === "ollama" ? "Installed model" : "Model"}</FieldLabel>
+              {provider === "ollama" ? (
+                <>
+                  <div className="flex gap-2">
+                    <Select
+                      value={selectedOllamaModel?.id ?? ""}
+                      onValueChange={setModel}
+                      disabled={ollamaModelsLoading || installedOllamaModels.length === 0}
+                    >
+                      <SelectTrigger className="min-w-0 flex-1" aria-label="Installed Ollama model">
+                        <SelectValue
+                          placeholder={ollamaModelsLoading ? "Loading installed models..." : "Select a model"}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {installedOllamaModels.map((candidate) => (
+                          <SelectItem key={candidate.id} value={candidate.id}>
+                            {candidate.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="outline"
+                      aria-label="Refresh installed Ollama models"
+                      title="Refresh installed Ollama models"
+                      onClick={() => void ollamaModelsQuery.refetch()}
+                      disabled={!ollamaDiscoveryUrl || !ollamaDiscoveryRequestIsCurrent || ollamaModelsQuery.isFetching}
+                    >
+                      <RefreshCw size={14} className={cn(ollamaModelsQuery.isFetching && "animate-spin")} />
+                    </Button>
+                  </div>
+                  {!isHttpUrl(baseUrl) ? (
+                    <p className="text-xs text-destructive">Enter a valid Ollama base URL to discover models.</p>
+                  ) : null}
+                  {ollamaDiscoveryRequestIsCurrent && ollamaModelsQuery.isError ? (
+                    <Alert variant="destructive">
+                      <AlertTitle>Could not load Ollama models</AlertTitle>
+                      <AlertDescription>
+                        {errorMessage(ollamaModelsQuery.error)} Make sure Ollama is running and the base URL is correct.
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
+                  {ollamaDiscoveryIsCurrent && ollamaModelsQuery.isSuccess && installedOllamaModels.length === 0 ? (
+                    <Alert className="border-chart-4/45 bg-chart-4/10">
+                      <AlertTitle>No installed models found</AlertTitle>
+                      <AlertDescription>
+                        Install a model with Ollama, then refresh this list. Paper Pilot cannot run a model that is not
+                        installed.
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
+                  {selectedOllamaModel ? (
+                    <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                      <span>Exact model: {selectedOllamaModel.id}</span>
+                      {selectedOllamaModel.parameterSize ? (
+                        <Badge variant="secondary">{selectedOllamaModel.parameterSize}</Badge>
+                      ) : null}
+                      {selectedOllamaModel.quantizationLevel ? (
+                        <Badge variant="outline">{selectedOllamaModel.quantizationLevel}</Badge>
+                      ) : null}
+                      {selectedOllamaModel.sizeBytes !== undefined ? (
+                        <Badge variant="outline">{formatBytes(selectedOllamaModel.sizeBytes)}</Badge>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <Input value={model} onChange={(event) => setModel(event.target.value)} />
+                  {displayedHealth?.models.length ? (
+                    <Select value={model} onValueChange={setModel}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {displayedHealth.models.map((modelName) => (
+                          <SelectItem key={modelName} value={modelName}>
+                            {modelName}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : null}
+                </>
+              )}
               <div className="grid grid-cols-2 gap-2">
-                <Button type="button" onClick={() => saveSettings.mutate()} disabled={saveSettings.isPending}>
+                <Button
+                  type="button"
+                  onClick={() => saveSettings.mutate()}
+                  disabled={saveSettings.isPending || !canSaveAiSettings}
+                >
                   {saveSettings.isPending ? <Loader2 size={14} className="animate-spin" /> : null}
                   Save AI settings
                 </Button>
@@ -385,7 +496,7 @@ export function SettingsPanel({
                   type="button"
                   variant="outline"
                   onClick={() => checkProvider.mutate()}
-                  disabled={checkProvider.isPending}
+                  disabled={checkProvider.isPending || !canSaveAiSettings}
                 >
                   {checkProvider.isPending ? (
                     <Loader2 size={14} className="animate-spin" />
@@ -601,6 +712,19 @@ export function SettingsPanel({
 
 function FieldLabel({ children }: { children: string }): JSX.Element {
   return <label className="block text-xs font-medium text-muted-foreground">{children}</label>;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function updateStatusText(status: UpdateStatus | undefined): string {

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -383,6 +383,31 @@ export type AppSettings = z.infer<typeof appSettingsSchema>;
 export const aiProviderSchema = appSettingsSchema.shape.ai.shape.provider;
 export type AiProvider = z.infer<typeof aiProviderSchema>;
 
+export const aiModelInfoSchema = z.object({
+  id: z.string().trim().min(1),
+  name: z.string().trim().min(1),
+  modifiedAt: z.string().optional(),
+  sizeBytes: z.number().nonnegative().optional(),
+  family: z.string().optional(),
+  parameterSize: z.string().optional(),
+  quantizationLevel: z.string().optional()
+});
+export type AiModelInfo = z.infer<typeof aiModelInfoSchema>;
+
+export const aiModelListRequestSchema = z.object({
+  provider: aiProviderSchema,
+  baseUrl: z.string().url()
+});
+export type AiModelListRequest = z.infer<typeof aiModelListRequestSchema>;
+
+export const aiModelListSchema = z.object({
+  provider: aiProviderSchema,
+  baseUrl: z.string().url(),
+  fetchedAt: z.string(),
+  models: z.array(aiModelInfoSchema)
+});
+export type AiModelList = z.infer<typeof aiModelListSchema>;
+
 export const aiProviderCheckRequestSchema = z
   .object({
     provider: aiProviderSchema.optional(),

--- a/tests/ai-service.test.ts
+++ b/tests/ai-service.test.ts
@@ -173,6 +173,75 @@ describe("AiService", () => {
     expect(health.detail).toContain("no models");
   });
 
+  it("discovers exact installed Ollama model identifiers and metadata", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("http://ollama.test/api/tags");
+      return new Response(
+        JSON.stringify({
+          models: [
+            {
+              name: "qwen3.8:latest",
+              model: "qwen3.8:latest",
+              modified_at: "2026-08-19T23:46:32.000Z",
+              size: 17_741_872_154,
+              details: {
+                family: "qwen3",
+                parameter_size: "27.3B",
+                quantization_level: "Q4_K_M"
+              }
+            },
+            {
+              name: "gemma3:4b",
+              model: "gemma3:4b",
+              modified_at: "2026-08-18T00:00:00.000Z"
+            }
+          ]
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await serviceWithSettings({
+      ai: {
+        provider: "ollama",
+        baseUrl: "http://ollama.test",
+        model: "qwen3.8:latest",
+        hasApiKey: false,
+        reasoningEnabled: true
+      },
+      python: { runtimeMode: "managed", markitdownEnabled: true }
+    }).listModels({ provider: "ollama", baseUrl: "http://ollama.test" });
+
+    expect(result.models.map((model) => model.id)).toEqual(["qwen3.8:latest", "gemma3:4b"]);
+    expect(result.models[0]).toMatchObject({
+      name: "qwen3.8:latest",
+      parameterSize: "27.3B",
+      quantizationLevel: "Q4_K_M",
+      sizeBytes: 17_741_872_154
+    });
+  });
+
+  it("surfaces Ollama model-discovery response details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("runner process exited", { status: 500 }))
+    );
+
+    await expect(
+      serviceWithSettings({
+        ai: {
+          provider: "ollama",
+          baseUrl: "http://ollama.test",
+          model: "qwen3.8:latest",
+          hasApiKey: false,
+          reasoningEnabled: true
+        },
+        python: { runtimeMode: "managed", markitdownEnabled: true }
+      }).listModels({ provider: "ollama", baseUrl: "http://ollama.test" })
+    ).rejects.toThrow("Ollama model discovery failed (500): runner process exited");
+  });
+
   it("checks gateway health with a non-generating model-list request", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toBe("https://gateway.test/v1/models");

--- a/tests/settings-panel.test.tsx
+++ b/tests/settings-panel.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PaperPilotApi } from "../src/preload/index";
+import { SettingsPanel } from "../src/renderer/components/settings-panel";
+import type { AppSettings } from "../src/shared/schemas";
+
+const settings: AppSettings = {
+  ui: { theme: "system" },
+  ai: {
+    provider: "ollama",
+    baseUrl: "http://127.0.0.1:11434",
+    model: "missing-model",
+    hasApiKey: false,
+    reasoningEnabled: true
+  },
+  python: { runtimeMode: "managed", markitdownEnabled: true },
+  sources: { disabledSourceIds: [] }
+};
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AI provider settings", () => {
+  it("loads installed Ollama models and saves the exact discovered identifier", async () => {
+    const api = createApiMock();
+    Object.defineProperty(window, "paperPilot", { configurable: true, value: api });
+
+    renderSettings();
+
+    await waitFor(() =>
+      expect(api.listAiModels).toHaveBeenCalledWith({
+        provider: "ollama",
+        baseUrl: "http://127.0.0.1:11434"
+      })
+    );
+    expect(await screen.findByText("Exact model: qwen3.8:latest")).toBeTruthy();
+    expect(screen.queryByDisplayValue("missing-model")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save AI settings" }));
+
+    await waitFor(() =>
+      expect(api.updateSettings).toHaveBeenCalledWith({
+        ai: expect.objectContaining({
+          provider: "ollama",
+          baseUrl: "http://127.0.0.1:11434",
+          model: "qwen3.8:latest"
+        })
+      })
+    );
+  });
+
+  it("shows a useful discovery error when Ollama cannot be reached", async () => {
+    const api = createApiMock();
+    vi.mocked(api.listAiModels).mockRejectedValueOnce(new Error("connect ECONNREFUSED 127.0.0.1:11434"));
+    Object.defineProperty(window, "paperPilot", { configurable: true, value: api });
+
+    renderSettings();
+
+    expect(await screen.findByText("Could not load Ollama models")).toBeTruthy();
+    expect(screen.getByText(/connect ECONNREFUSED/)).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Save AI settings" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+function renderSettings(): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsPanel
+        open
+        sources={[]}
+        themePreference="system"
+        isThemeSaving={false}
+        onThemeChange={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </QueryClientProvider>
+  );
+}
+
+function createApiMock(): PaperPilotApi {
+  return {
+    getSettings: vi.fn().mockResolvedValue(settings),
+    listCredentialFlags: vi.fn().mockResolvedValue([]),
+    getUpdateStatus: vi.fn().mockResolvedValue({
+      state: "idle",
+      currentVersion: "0.0.0-development",
+      retryCount: 0
+    }),
+    onUpdateStatusChanged: vi.fn().mockReturnValue(() => undefined),
+    listAiModels: vi.fn().mockResolvedValue({
+      provider: "ollama",
+      baseUrl: settings.ai.baseUrl,
+      fetchedAt: "2026-08-20T00:00:00.000Z",
+      models: [
+        {
+          id: "qwen3.8:latest",
+          name: "qwen3.8:latest",
+          sizeBytes: 17_741_872_154,
+          parameterSize: "27.3B",
+          quantizationLevel: "Q4_K_M"
+        }
+      ]
+    }),
+    updateSettings: vi.fn().mockResolvedValue(settings),
+    checkAiProvider: vi.fn()
+  } as unknown as PaperPilotApi;
+}


### PR DESCRIPTION
## Summary

- discover installed Ollama models through the official `/api/tags` endpoint and preserve exact model identifiers plus useful metadata
- replace free-form Ollama model entry with an automatically loaded, refreshable picker and clear loading, empty, and error states
- validate the new model-list contract across IPC/preload boundaries and reuse discovery for provider health checks
- add service and renderer coverage for exact model selection and discovery failures

## Testing

- `npm run verify` (97 passed, 2 opt-in live tests skipped)
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)