### PR TITLE
Fix artifact citations without linked papers

### DIFF
--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -5,6 +5,7 @@ import { dirname } from "node:path";
 import {
   type Artifact,
   artifactSchema,
+  artifactTypeSchema,
   type ChatMode,
   type ChatRun,
   chatRunSchema,
@@ -1353,7 +1354,7 @@ export class PaperPilotDb {
     if (input.projectId) params.projectId = input.projectId;
     if (input.artifactId) params.artifactId = input.artifactId;
     try {
-      return this.db
+      const rows = this.db
         .prepare(
           `SELECT
              document_chunks_fts.chunk_id as chunkId,
@@ -1378,14 +1379,15 @@ export class PaperPilotDb {
            ORDER BY score
            LIMIT @limit`
         )
-        .all(params) as unknown as ChunkSearchRow[];
+        .all(params) as Row[];
+      return rows.map((row) => this.chunkSearchFromRow(row));
     } catch {
       return [];
     }
   }
 
   listArtifactChunks(projectId: string, artifactId: string, limit = 2): ChunkSearchRow[] {
-    return this.db
+    const rows = this.db
       .prepare(
         `SELECT
            document_chunks.id as chunkId,
@@ -1409,7 +1411,8 @@ export class PaperPilotDb {
          ORDER BY document_chunks.ordinal ASC
          LIMIT ?`
       )
-      .all(projectId, artifactId, limit) as unknown as ChunkSearchRow[];
+      .all(projectId, artifactId, limit) as Row[];
+    return rows.map((row) => this.chunkSearchFromRow(row));
   }
 
   searchChunks(
@@ -1645,6 +1648,24 @@ export class PaperPilotDb {
     });
   }
 
+  private chunkSearchFromRow(row: Row): ChunkSearchRow {
+    return {
+      chunkId: String(row.chunkId),
+      projectId: String(row.projectId),
+      projectTitle: String(row.projectTitle),
+      artifactId: String(row.artifactId),
+      artifactTitle: String(row.artifactTitle),
+      artifactType: artifactTypeSchema.parse(row.artifactType),
+      artifactCreatedAt: String(row.artifactCreatedAt),
+      paperId: optionalString(row.paperId),
+      paperTitle: optionalString(row.paperTitle),
+      text: String(row.text),
+      metadataJson: String(row.metadataJson),
+      snippet: String(row.snippet),
+      score: Number(row.score)
+    };
+  }
+
   private paperFromRow(row: Row): Paper {
     return paperSchema.parse({
       id: row.id,
@@ -1730,6 +1751,10 @@ function parseJsonArray(value: unknown): string[] {
 function normalizeOptional(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? normalizeOptional(value) : undefined;
 }
 
 function buildFtsQuery(query: string): string {

--- a/tests/research-chat.test.ts
+++ b/tests/research-chat.test.ts
@@ -63,6 +63,64 @@ describe("ResearchChatService", () => {
     expect(db.searchChunks(projectId, "controlled improvement")).toHaveLength(0);
   });
 
+  it("completes grounded answers cited to artifacts without linked papers", async () => {
+    const project = db.createProject("Imported evidence project");
+    const conversation = db.ensureDefaultConversation(project.id);
+    const artifact = db.saveArtifact({
+      id: "artifact_without_paper",
+      projectId: project.id,
+      type: "markdown",
+      title: "Imported experiment notes",
+      path: join(dir, "experiment-notes.md"),
+      mime: "text/markdown",
+      hash: "artifact-hash",
+      source: "import",
+      metadata: {},
+      createdAt: new Date().toISOString()
+    });
+    db.addDocumentChunks({
+      projectId: project.id,
+      artifactId: artifact.id,
+      chunks: [{ text: "The imported experiment reports a reproducible measured improvement." }]
+    });
+    expect(db.listArtifactChunks(project.id, artifact.id)[0].paperId).toBeUndefined();
+    expect(
+      db.searchIndexedChunks({ projectId: project.id, query: "reproducible measured improvement" })[0].paperId
+    ).toBeUndefined();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            `${JSON.stringify({ message: { content: "The experiment reports a reproducible improvement. [[S1]]" } })}\n`,
+            { status: 200, headers: { "content-type": "application/x-ndjson" } }
+          )
+        )
+    );
+    const service = createService();
+    const events: ChatRunEvent[] = [];
+    const terminalPromise = terminalEvent(events);
+
+    const started = await service.start(
+      {
+        projectId: project.id,
+        conversationId: conversation.id,
+        content: "What reproducible improvement does the imported experiment report?",
+        mode: "grounded",
+        sourceRefs: []
+      },
+      (event) => events.push(event)
+    );
+    const terminal = await terminalPromise;
+
+    expect(terminal.type).toBe("complete");
+    expect(db.getChatRun(started.runId)?.status).toBe("completed");
+    expect(db.listCitations(started.runId)).toMatchObject([
+      { evidenceId: "S1", sourceType: "artifact", artifactId: artifact.id, paperId: undefined }
+    ]);
+  });
+
   it("repairs an invalid grounded citation once", async () => {
     const { projectId, conversationId } = seedProject();
     const fetchMock = vi


### PR DESCRIPTION
## Summary

- normalize nullable SQLite fields when materializing indexed artifact chunks instead of leaking `null` through optional TypeScript fields
- allow grounded answers to persist artifact-only citations when a document chunk has no linked paper
- add an end-to-end regression covering retrieval, citation persistence, and successful run completion for an imported unlinked document

## Root cause

SQLite returned `NULL` for `document_chunks.paper_id`, while the query result was cast to a type that promised `string | undefined`. The `null` reached `citationSchema` during run finalization and failed an otherwise citation-valid grounded answer.

## Testing

- `npm run verify` (98 passed, 2 opt-in live tests skipped)
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)