### PR TITLE
feat: add auditable evidence review workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ Simultaneously queries **8+ academic databases**:
 
 </td>
 </tr>
+<tr>
+<td colspan="2">
+
+### 🔬 Auditable Evidence Review
+
+- Versioned protocols with separate title/abstract and full-text screening
+- Previewed RIS, BibTeX, and mapped CSV imports with conservative deduplication
+- Typed, evidence-linked extraction matrix and append-only decision history
+- Provider-neutral, on-demand AI suggestions that require human confirmation
+- Deterministic review-flow summary and traceable export package
+
+See the [evidence review guide](docs/evidence-review.md).
+
+</td>
+</tr>
 </table>
 
 ---
@@ -186,6 +201,7 @@ This is an **early v1** — buildable, test-covered, but still hardening for pro
 | SQLite + FTS5 + vector search                     | ✅ Stable       |
 | AI agent (Ollama / OpenAI-compatible)             | ✅ Stable       |
 | Evidence-grounded multi-chat research workspace   | ✅ Stable       |
+| Auditable evidence review workspace               | ✅ Stable       |
 | Google Scholar crawler                            | ⚠️ Experimental |
 | macOS / Linux packaging                           | ⚠️ Untested     |
 | Cloud sync / collaboration                        | ❌ Not planned  |

--- a/docs/evidence-review.md
+++ b/docs/evidence-review.md
@@ -1,0 +1,63 @@
+# Auditable evidence reviews
+
+Paper Pilot can turn the papers in one project into a structured, local-first evidence review. Review mode is intentionally separate from reading status, favorites, notes, scores, and research chat. AI output is advisory: it never becomes a screening decision or confirmed extraction value without an explicit reviewer action.
+
+## Workflow
+
+1. Open a project, switch from **Chat** to **Review**, and activate review mode.
+2. Define the research question, objectives, and ordered title/abstract and full-text criteria. The Blank, General empirical study, and PICO templates are starting points only.
+3. Add candidates through an existing project corpus, a crawl, or a RIS, BibTeX, or CSV import. Import preview reports invalid records and conservative identity matches before it changes the project.
+4. Screen titles and abstracts with Include, Exclude, or Uncertain. Only included papers move to full-text screening.
+5. Fetch open-access text or attach a PDF. Every full-text exclusion requires a protocol criterion or custom reason. Only included full texts move to extraction.
+6. Define up to 30 typed extraction fields, enter values, and link evidence where applicable.
+7. Inspect the deterministic Review flow summary and export the auditable package.
+
+Protocol revisions preserve prior human decisions and audit history. They mark earlier AI suggestions stale; use **Mark for re-review** when a decision should be reconsidered against the new protocol.
+
+## Import and identity rules
+
+Reference imports are limited to 50 MiB and 50,000 records. A title is required. CSV imports expose editable column mapping; RIS and BibTeX are mapped automatically.
+
+Paper identity is deliberately conservative, in this order:
+
+1. normalized DOI;
+2. an authoritative source identifier;
+3. exact normalized title, year, and first-author fingerprint.
+
+A title match by itself is never auto-merged. Ambiguous records must be kept separate, merged into a selected paper, or skipped. Every source occurrence remains in discovery provenance even when it resolves to an existing paper.
+
+## AI assistance and privacy
+
+Review assistance uses the provider and model selected in Settings and processes at most 25 papers sequentially. Hosted-provider warnings follow the project policy. The service has no chat, crawler, brief, script, or destructive tools.
+
+- Abstract screening sends only that paper's metadata, abstract, active protocol, and stage criteria.
+- Full-text screening and extraction send only trusted indexed chunks linked to that paper.
+- Extraction fields are sent in groups of at most six.
+- Application-owned evidence IDs are checked for ownership and value type.
+- Malformed output receives one repair attempt. A second failure is stored as failed with no suggestion.
+- Cancellation uses an abort signal. Completed papers remain available; Retry processes only failed or cancelled items.
+
+Events and audit records contain provider/model identifiers, progress, validated suggestions, errors, and timestamps. They exclude API keys, raw provider payloads, and hidden reasoning.
+
+AI-derived extraction values require linked evidence before confirmation. Manual values can be confirmed without evidence and remain labeled **Manual—no linked evidence**.
+
+## Review package
+
+Export writes a directory with:
+
+- `evidence-matrix.csv`
+- `evidence-locators.csv`
+- `screening-decisions.csv`
+- `included-references.ris`
+- `included-references.bib`
+- `methods-and-status.md`
+- `review-flow.svg`
+- `review-audit.json`
+
+The flow table and diagram are deterministic summaries of stored discovery provenance and current human decisions. They are labeled **Review flow** and do not claim PRISMA 2020 compliance. The package contains no AI-authored conclusions and is not automatically indexed as chat grounding material.
+
+## Compatibility and recovery
+
+Database schema version 3 is applied through ordered, transactional migrations. Existing projects are activated into a **Pre-existing project papers** batch without changing or losing paper data; the UI discloses that historical duplicate counts are unavailable.
+
+Project export format version 3 carries review state and audit history. Versions 1 and 2 remain importable and become projects without an active review. Deleting linked papers or artifacts preserves review snapshots, excerpts, locators, decisions, and audit history even when navigation to the original identifier is no longer possible.

--- a/docs/qa-checklist.md
+++ b/docs/qa-checklist.md
@@ -62,3 +62,24 @@ Use this checklist for fundamentals/stabilization passes before adding another m
 - [ ] Launch the packaged app from `release/win-unpacked`.
 - [ ] Confirm the app opens without renderer/preload bridge errors.
 - [ ] Confirm project list and settings load in the packaged app.
+
+## Phase 3 Evidence Review Acceptance
+
+- [ ] Upgrade a version-2 database and confirm projects, papers, artifacts, conversations, and messages are unchanged.
+- [ ] Activate review mode on an existing project and confirm every paper appears in the pre-existing pending queue with the historical-count warning.
+- [ ] Preview overlapping RIS and CSV files; resolve ambiguous records; confirm identified, invalid, duplicate, merged, and new counts match provenance.
+- [ ] Confirm a same-title-only match is never merged automatically.
+- [ ] Make title/abstract decisions with the keyboard and confirm only inclusions reach full-text screening.
+- [ ] Confirm a full-text exclusion cannot be saved without a criterion or custom reason and does not change reading status.
+- [ ] Attach or fetch a PDF and confirm trusted chunks are linked to the correct paper.
+- [ ] Run a 25-paper Ollama review batch; stop it; confirm completed items remain and Retry processes only cancelled/failed items.
+- [ ] Repeat with a hosted provider after the paid-model warning and confirm no credentials or raw payloads appear in events/audit data.
+- [ ] Return malformed AI JSON twice and confirm one repair attempt followed by a failed item with no saved suggestion.
+- [ ] Confirm a paper without indexed full text receives no purported full-text or extraction answer.
+- [ ] Revise the protocol and confirm decisions remain, AI suggestions become stale, and selected decisions can be marked for re-review.
+- [ ] Confirm AI-derived extraction values cannot be confirmed without valid same-paper evidence; manual values show the no-evidence label.
+- [ ] Delete a cited paper/artifact and confirm evidence snapshots, locators, decisions, and audit events remain readable.
+- [ ] Duplicate and export/import a reviewed project; compare protocol versions, provenance, decisions, extraction state, evidence, runs, and audit history.
+- [ ] Export the review package and trace every flow count and matrix row to stored provenance and human decisions.
+- [ ] Confirm the SVG is labeled “Review flow” and does not claim PRISMA compliance.
+- [ ] Run `npm run verify` on Ubuntu and `npm run verify:platform` on Windows.

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -13,20 +13,57 @@ import {
   citationSchema,
   type Conversation,
   conversationSchema,
+  type DiscoveryBatch,
+  discoveryBatchSchema,
+  type ExtractionField,
+  extractionFieldSchema,
+  type ExtractionValue,
+  extractionValueSchema,
+  isBlankExtractionValue,
   type Job,
   jobSchema,
+  MAX_EXTRACTION_FIELDS,
+  MAX_REVIEW_BATCH_PAPERS,
   type Message,
   messageSchema,
   type Paper,
-  paperDedupeKey,
   type PaperScore,
   paperSchema,
   paperScoreSchema,
   type Project,
   type ProjectPolicy,
-  projectSchema
+  projectSchema,
+  type ReviewAuditEvent,
+  reviewAuditEventSchema,
+  type ReviewCriterion,
+  reviewCriterionSchema,
+  type ReviewEvidence,
+  reviewEvidenceSchema,
+  type ReviewFlowSummary,
+  reviewFlowSummarySchema,
+  type ReviewPaperPage,
+  type ReviewPaperQuery,
+  reviewPaperQuerySchema,
+  reviewPaperSummarySchema,
+  type ReviewProtocol,
+  reviewProtocolSchema,
+  type ReviewProtocolRevision,
+  reviewProtocolRevisionSchema,
+  type ReviewRun,
+  reviewRunSchema,
+  type ReviewRunItem,
+  reviewRunItemSchema,
+  type ScreeningDecision,
+  screeningDecisionSchema
 } from "../shared/schemas.js";
 import { id, nowIso } from "./utils.js";
+import {
+  bibliographicFingerprint,
+  doiIdentityKey,
+  normalizeBibliographicTitle,
+  sourceIdentifierIdentityKey,
+  type PaperIdentityInput
+} from "./services/paper-identity.js";
 
 type Row = Record<string, unknown>;
 
@@ -60,6 +97,78 @@ export interface PaperSearchRow {
   updatedAt: string;
 }
 
+export interface ReviewCandidateOrigin {
+  id: string;
+  reviewId: string;
+  batchId: string;
+  paperId?: string;
+  matchedPaperId?: string;
+  sourceRecordId?: string;
+  resolution: "created" | "duplicate" | "merged" | "kept-separate" | "skipped" | "invalid" | "filtered";
+  paperSnapshot: Record<string, unknown>;
+  recordSnapshot: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface ReviewCandidateOriginInput {
+  id?: string;
+  reviewId: string;
+  batchId: string;
+  paperId?: string;
+  matchedPaperId?: string;
+  sourceRecordId?: string;
+  resolution: ReviewCandidateOrigin["resolution"];
+  paperSnapshot?: Record<string, unknown>;
+  recordSnapshot?: unknown;
+  createdAt?: string;
+}
+
+export interface ReviewRereviewFlag {
+  id: string;
+  reviewId: string;
+  paperId: string;
+  stage: "title-abstract" | "full-text";
+  protocolRevisionId: string;
+  paperSnapshot: Record<string, unknown>;
+  invalidatesDownstream?: boolean;
+  createdAt: string;
+  resolvedAt?: string;
+}
+
+export type PortableDiscoveryBatch = DiscoveryBatch & { config: Record<string, unknown> };
+export type PortableScreeningDecision = ScreeningDecision & { paperSnapshot: Record<string, unknown> };
+export type PortableExtractionValue = ExtractionValue & { paperSnapshot: Record<string, unknown> };
+export type PortableReviewEvidence = ReviewEvidence & { paperSnapshot?: Record<string, unknown> };
+export type PortableReviewRunItem = Omit<ReviewRunItem, "evidence"> & {
+  evidenceIds: string[];
+  paperSnapshot: Record<string, unknown>;
+  stale: boolean;
+};
+
+export type ExtractionFieldHistoryEntry = ExtractionField & { recordedAt: string };
+export type ExtractionValueHistoryEntry = ExtractionValue & {
+  changeRevision: number;
+  paperSnapshot: Record<string, unknown>;
+  recordedAt: string;
+};
+
+export interface ReviewPortabilityState {
+  review: ReviewProtocol;
+  revisions: ReviewProtocolRevision[];
+  discoveryBatches: PortableDiscoveryBatch[];
+  candidateOrigins: ReviewCandidateOrigin[];
+  rereviewFlags: ReviewRereviewFlag[];
+  screeningDecisions: PortableScreeningDecision[];
+  extractionFields: ExtractionField[];
+  extractionFieldHistory?: ExtractionFieldHistoryEntry[];
+  extractionValues: PortableExtractionValue[];
+  extractionValueHistory?: ExtractionValueHistoryEntry[];
+  evidence: PortableReviewEvidence[];
+  runs: ReviewRun[];
+  runItems: PortableReviewRunItem[];
+  auditEvents: ReviewAuditEvent[];
+}
+
 const defaultPolicy: ProjectPolicy = {
   autonomy: "project",
   autoApproveSources: false,
@@ -72,6 +181,7 @@ const defaultPolicy: ProjectPolicy = {
 export class PaperPilotDb {
   private db: DatabaseSync;
   private vecAvailable = false;
+  private transactionDepth = 0;
 
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
@@ -91,16 +201,63 @@ export class PaperPilotDb {
     this.db.close();
   }
 
+  transaction<T>(operation: () => T): T {
+    if (this.transactionDepth > 0) {
+      this.transactionDepth += 1;
+      try {
+        return operation();
+      } finally {
+        this.transactionDepth -= 1;
+      }
+    }
+    this.db.exec("BEGIN IMMEDIATE");
+    this.transactionDepth = 1;
+    try {
+      const result = operation();
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    } finally {
+      this.transactionDepth = 0;
+    }
+  }
+
   migrate(): void {
     const currentVersion = Number(
       (this.db.prepare("PRAGMA user_version").get() as { user_version?: number }).user_version ?? 0
     );
-    if (currentVersion > 2) {
+    if (currentVersion > 3) {
       throw new Error(`Database schema version ${currentVersion} is newer than this Paper Pilot build supports.`);
     }
+    const migrations: Array<{ version: number; run: () => void }> = [
+      { version: 2, run: () => this.migrateToVersion2() },
+      { version: 3, run: () => this.migrateToVersion3() }
+    ];
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      this.db.exec(`
+      for (const migration of migrations) {
+        if (currentVersion < migration.version) migration.run();
+      }
+      this.ensureVersion3IntegritySchema();
+      if (this.vecAvailable) {
+        this.db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS chunk_embeddings_vec USING vec0(
+          embedding float[384],
+          +chunk_id text
+        );
+        `);
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  private migrateToVersion2(): void {
+    this.db.exec(`
       CREATE TABLE IF NOT EXISTS projects (
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
@@ -313,21 +470,21 @@ export class PaperPilotDb {
         created_at TEXT NOT NULL
       );
     `);
-      this.ensureColumn("projects", "description", "TEXT");
-      this.ensureColumn("projects", "archived_at", "TEXT");
-      this.ensureColumn("projects", "pinned_at", "TEXT");
-      this.ensureColumn("papers", "score", "REAL");
-      this.ensureColumn("papers", "score_json", "TEXT");
-      this.ensureColumn("papers", "favorite", "INTEGER NOT NULL DEFAULT 0");
-      this.ensureColumn("papers", "user_status", "TEXT NOT NULL DEFAULT 'unread'");
-      this.ensureColumn("papers", "tags_json", "TEXT NOT NULL DEFAULT '[]'");
-      this.ensureColumn("papers", "notes", "TEXT");
-      this.ensureColumn("messages", "conversation_id", "TEXT");
-      this.ensureColumn("messages", "run_id", "TEXT");
-      this.ensureColumn("messages", "status", "TEXT NOT NULL DEFAULT 'completed'");
-      this.ensureColumn("tool_runs", "run_id", "TEXT");
-      this.backfillConversations();
-      this.db.exec(`
+    this.ensureColumn("projects", "description", "TEXT");
+    this.ensureColumn("projects", "archived_at", "TEXT");
+    this.ensureColumn("projects", "pinned_at", "TEXT");
+    this.ensureColumn("papers", "score", "REAL");
+    this.ensureColumn("papers", "score_json", "TEXT");
+    this.ensureColumn("papers", "favorite", "INTEGER NOT NULL DEFAULT 0");
+    this.ensureColumn("papers", "user_status", "TEXT NOT NULL DEFAULT 'unread'");
+    this.ensureColumn("papers", "tags_json", "TEXT NOT NULL DEFAULT '[]'");
+    this.ensureColumn("papers", "notes", "TEXT");
+    this.ensureColumn("messages", "conversation_id", "TEXT");
+    this.ensureColumn("messages", "run_id", "TEXT");
+    this.ensureColumn("messages", "status", "TEXT NOT NULL DEFAULT 'completed'");
+    this.ensureColumn("tool_runs", "run_id", "TEXT");
+    this.backfillConversations();
+    this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_conversations_project_updated
         ON conversations(project_id, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_messages_conversation_created
@@ -338,19 +495,416 @@ export class PaperPilotDb {
         ON chat_citations(run_id, evidence_id);
       PRAGMA user_version = 2;
     `);
-      if (this.vecAvailable) {
-        this.db.exec(`
-        CREATE VIRTUAL TABLE IF NOT EXISTS chunk_embeddings_vec USING vec0(
-          embedding float[384],
-          +chunk_id text
-        );
-        `);
+  }
+
+  private migrateToVersion3(): void {
+    this.db.exec(`
+      CREATE TABLE reviews (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL UNIQUE REFERENCES projects(id) ON DELETE CASCADE,
+        template TEXT NOT NULL CHECK (template IN ('blank', 'general-empirical', 'pico')),
+        current_protocol_revision_id TEXT,
+        historical_counts_available INTEGER NOT NULL DEFAULT 1,
+        activated_at TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE review_protocol_revisions (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        revision INTEGER NOT NULL CHECK (revision > 0),
+        research_question TEXT NOT NULL,
+        objectives_json TEXT NOT NULL,
+        note TEXT,
+        created_at TEXT NOT NULL,
+        UNIQUE(review_id, revision)
+      );
+
+      CREATE TABLE review_criteria (
+        row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        id TEXT NOT NULL,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        protocol_revision_id TEXT NOT NULL REFERENCES review_protocol_revisions(id) ON DELETE CASCADE,
+        stage TEXT NOT NULL CHECK (stage IN ('title-abstract', 'full-text')),
+        kind TEXT NOT NULL CHECK (kind IN ('inclusion', 'exclusion')),
+        label TEXT NOT NULL,
+        description TEXT,
+        ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+        created_at TEXT NOT NULL,
+        UNIQUE(protocol_revision_id, id)
+      );
+
+      CREATE TABLE discovery_batches (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        kind TEXT NOT NULL CHECK (kind IN ('pre-existing', 'reference-import', 'crawl')),
+        label TEXT NOT NULL,
+        source TEXT,
+        file_name TEXT,
+        import_format TEXT CHECK (import_format IN ('ris', 'bibtex', 'csv')),
+        status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+        historical_counts_available INTEGER NOT NULL DEFAULT 1,
+        identified_count INTEGER NOT NULL DEFAULT 0 CHECK (identified_count >= 0),
+        filtered_count INTEGER NOT NULL DEFAULT 0 CHECK (filtered_count >= 0),
+        invalid_count INTEGER NOT NULL DEFAULT 0 CHECK (invalid_count >= 0),
+        duplicate_count INTEGER NOT NULL DEFAULT 0 CHECK (duplicate_count >= 0),
+        merged_count INTEGER NOT NULL DEFAULT 0 CHECK (merged_count >= 0),
+        new_records_count INTEGER NOT NULL DEFAULT 0 CHECK (new_records_count >= 0),
+        config_json TEXT NOT NULL DEFAULT '{}',
+        error TEXT,
+        created_at TEXT NOT NULL,
+        completed_at TEXT
+      );
+
+      CREATE TABLE review_candidate_origins (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        batch_id TEXT NOT NULL REFERENCES discovery_batches(id) ON DELETE CASCADE,
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        matched_paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        source_record_id TEXT,
+        resolution TEXT NOT NULL CHECK (
+          resolution IN ('created', 'duplicate', 'merged', 'kept-separate', 'skipped', 'invalid', 'filtered')
+        ),
+        paper_snapshot_json TEXT NOT NULL,
+        record_snapshot_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE review_screening_decisions (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        paper_snapshot_json TEXT NOT NULL,
+        stage TEXT NOT NULL CHECK (stage IN ('title-abstract', 'full-text')),
+        decision TEXT NOT NULL CHECK (decision IN ('include', 'exclude', 'uncertain')),
+        protocol_revision_id TEXT NOT NULL REFERENCES review_protocol_revisions(id) ON DELETE CASCADE,
+        reason_criterion_id TEXT,
+        custom_reason TEXT,
+        run_item_id TEXT REFERENCES review_run_items(id) ON DELETE SET NULL,
+        decided_by TEXT NOT NULL DEFAULT 'human' CHECK (decided_by IN ('human', 'system')),
+        supersedes_decision_id TEXT REFERENCES review_screening_decisions(id) ON DELETE SET NULL,
+        created_at TEXT NOT NULL,
+        CHECK (
+          stage != 'full-text' OR decision != 'exclude' OR reason_criterion_id IS NOT NULL OR length(trim(coalesce(custom_reason, ''))) > 0
+        )
+      );
+
+      CREATE TABLE review_rereview_flags (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        paper_snapshot_json TEXT NOT NULL,
+        stage TEXT NOT NULL CHECK (stage IN ('title-abstract', 'full-text')),
+        protocol_revision_id TEXT NOT NULL REFERENCES review_protocol_revisions(id) ON DELETE CASCADE,
+        invalidates_downstream INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        resolved_at TEXT
+      );
+
+      CREATE TABLE extraction_fields (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        description TEXT,
+        field_type TEXT NOT NULL CHECK (
+          field_type IN ('short-text', 'long-text', 'number', 'boolean', 'single-select', 'multi-select')
+        ),
+        options_json TEXT NOT NULL DEFAULT '[]',
+        ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+        revision INTEGER NOT NULL DEFAULT 1 CHECK (revision > 0),
+        active INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE review_runs (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        protocol_revision_id TEXT NOT NULL REFERENCES review_protocol_revisions(id) ON DELETE CASCADE,
+        provider TEXT NOT NULL CHECK (provider IN ('ollama', 'vercel', 'openai-compatible')),
+        model TEXT NOT NULL,
+        stage TEXT NOT NULL CHECK (stage IN ('title-abstract', 'full-text', 'extraction')),
+        status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'partial', 'cancelled', 'failed')),
+        selected_paper_ids_json TEXT NOT NULL,
+        extraction_field_ids_json TEXT NOT NULL DEFAULT '[]',
+        total_items INTEGER NOT NULL DEFAULT 0 CHECK (total_items >= 0),
+        completed_items INTEGER NOT NULL DEFAULT 0 CHECK (completed_items >= 0),
+        failed_items INTEGER NOT NULL DEFAULT 0 CHECK (failed_items >= 0),
+        cancelled_items INTEGER NOT NULL DEFAULT 0 CHECK (cancelled_items >= 0),
+        error TEXT,
+        started_at TEXT,
+        completed_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE review_run_items (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL REFERENCES review_runs(id) ON DELETE CASCADE,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        paper_snapshot_json TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled')),
+        recommendation_json TEXT,
+        attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+        stale INTEGER NOT NULL DEFAULT 0,
+        error TEXT,
+        started_at TEXT,
+        completed_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(run_id, paper_id)
+      );
+
+      CREATE TABLE extraction_values (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        field_id TEXT NOT NULL REFERENCES extraction_fields(id) ON DELETE CASCADE,
+        field_revision INTEGER NOT NULL CHECK (field_revision > 0),
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        paper_snapshot_json TEXT NOT NULL,
+        run_item_id TEXT REFERENCES review_run_items(id) ON DELETE SET NULL,
+        value_json TEXT,
+        status TEXT NOT NULL CHECK (status IN ('suggested', 'confirmed', 'rejected', 'not-found', 'needs-review')),
+        provenance TEXT NOT NULL CHECK (provenance IN ('manual', 'ai')),
+        confirmed_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(review_id, field_id, paper_id)
+      );
+
+      CREATE TABLE review_evidence (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        extraction_value_id TEXT REFERENCES extraction_values(id) ON DELETE CASCADE,
+        run_id TEXT REFERENCES review_runs(id) ON DELETE SET NULL,
+        run_item_id TEXT REFERENCES review_run_items(id) ON DELETE SET NULL,
+        evidence_id TEXT NOT NULL,
+        source_type TEXT NOT NULL CHECK (source_type IN ('paper-metadata', 'paper-abstract', 'artifact-chunk')),
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        paper_snapshot_json TEXT NOT NULL DEFAULT '{}',
+        artifact_id TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
+        chunk_id TEXT,
+        title TEXT NOT NULL,
+        excerpt TEXT NOT NULL,
+        page INTEGER,
+        locator TEXT,
+        doi TEXT,
+        url TEXT,
+        retrieval_score REAL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE review_extraction_value_evidence (
+        value_id TEXT NOT NULL REFERENCES extraction_values(id) ON DELETE CASCADE,
+        evidence_id TEXT NOT NULL REFERENCES review_evidence(id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY(value_id, evidence_id)
+      );
+
+      CREATE TABLE review_audit_events (
+        id TEXT PRIMARY KEY,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        actor TEXT NOT NULL CHECK (actor IN ('user', 'ai', 'system')),
+        action TEXT NOT NULL,
+        entity_type TEXT NOT NULL,
+        entity_id TEXT,
+        payload_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX idx_review_protocol_revisions_review
+        ON review_protocol_revisions(review_id, revision DESC);
+      CREATE INDEX idx_review_criteria_revision
+        ON review_criteria(protocol_revision_id, stage, kind, ordinal);
+      CREATE INDEX idx_discovery_batches_review
+        ON discovery_batches(review_id, created_at DESC);
+      CREATE INDEX idx_review_candidate_origins_batch
+        ON review_candidate_origins(batch_id, created_at ASC);
+      CREATE INDEX idx_review_candidate_origins_paper
+        ON review_candidate_origins(review_id, paper_id);
+      CREATE INDEX idx_review_screening_current
+        ON review_screening_decisions(review_id, paper_id, stage, created_at DESC);
+      CREATE INDEX idx_review_rereview_open
+        ON review_rereview_flags(review_id, paper_id, stage, resolved_at);
+      CREATE INDEX idx_extraction_fields_review
+        ON extraction_fields(review_id, active, ordinal);
+      CREATE UNIQUE INDEX idx_review_one_active_run
+        ON review_runs(project_id) WHERE status IN ('queued', 'running');
+      CREATE INDEX idx_review_runs_review
+        ON review_runs(review_id, created_at DESC);
+      CREATE INDEX idx_review_run_items_run
+        ON review_run_items(run_id, status);
+      CREATE INDEX idx_extraction_values_review
+        ON extraction_values(review_id, paper_id, field_id);
+      CREATE INDEX idx_review_evidence_value
+        ON review_evidence(extraction_value_id, evidence_id);
+      CREATE INDEX idx_review_audit_events_review
+        ON review_audit_events(review_id, created_at ASC);
+
+      PRAGMA user_version = 3;
+    `);
+    this.backfillPaperIdentityKeys();
+  }
+
+  private ensureVersion3IntegritySchema(): void {
+    this.ensureColumn(
+      "review_screening_decisions",
+      "run_item_id",
+      "TEXT REFERENCES review_run_items(id) ON DELETE SET NULL"
+    );
+    this.ensureColumn("review_evidence", "paper_snapshot_json", "TEXT NOT NULL DEFAULT '{}'");
+    this.ensureColumn("review_rereview_flags", "invalidates_downstream", "INTEGER NOT NULL DEFAULT 0");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS review_extraction_value_evidence (
+        value_id TEXT NOT NULL REFERENCES extraction_values(id) ON DELETE CASCADE,
+        evidence_id TEXT NOT NULL REFERENCES review_evidence(id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY(value_id, evidence_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS extraction_field_revisions (
+        field_id TEXT NOT NULL REFERENCES extraction_fields(id) ON DELETE CASCADE,
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        revision INTEGER NOT NULL CHECK (revision > 0),
+        name TEXT NOT NULL,
+        description TEXT,
+        field_type TEXT NOT NULL CHECK (
+          field_type IN ('short-text', 'long-text', 'number', 'boolean', 'single-select', 'multi-select')
+        ),
+        options_json TEXT NOT NULL DEFAULT '[]',
+        ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+        active INTEGER NOT NULL DEFAULT 1,
+        recorded_at TEXT NOT NULL,
+        PRIMARY KEY(field_id, revision)
+      );
+
+      CREATE TABLE IF NOT EXISTS extraction_value_revisions (
+        value_id TEXT NOT NULL REFERENCES extraction_values(id) ON DELETE CASCADE,
+        change_revision INTEGER NOT NULL CHECK (change_revision > 0),
+        review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+        field_id TEXT NOT NULL REFERENCES extraction_fields(id) ON DELETE CASCADE,
+        field_revision INTEGER NOT NULL CHECK (field_revision > 0),
+        paper_id TEXT REFERENCES papers(id) ON DELETE SET NULL,
+        paper_snapshot_json TEXT NOT NULL,
+        run_item_id TEXT REFERENCES review_run_items(id) ON DELETE SET NULL,
+        value_json TEXT,
+        status TEXT NOT NULL CHECK (status IN ('suggested', 'confirmed', 'rejected', 'not-found', 'needs-review')),
+        provenance TEXT NOT NULL CHECK (provenance IN ('manual', 'ai')),
+        evidence_ids_json TEXT NOT NULL DEFAULT '[]',
+        confirmed_at TEXT,
+        recorded_at TEXT NOT NULL,
+        PRIMARY KEY(value_id, change_revision)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_extraction_field_revisions_review
+        ON extraction_field_revisions(review_id, field_id, revision);
+      CREATE INDEX IF NOT EXISTS idx_extraction_value_revisions_review
+        ON extraction_value_revisions(review_id, value_id, change_revision);
+      CREATE INDEX IF NOT EXISTS idx_review_extraction_value_evidence_evidence
+        ON review_extraction_value_evidence(evidence_id, value_id);
+
+      INSERT OR IGNORE INTO review_extraction_value_evidence (value_id, evidence_id, created_at)
+      SELECT extraction_value_id, id, created_at FROM review_evidence
+      WHERE extraction_value_id IS NOT NULL;
+
+      UPDATE review_evidence SET extraction_value_id = NULL WHERE extraction_value_id IS NOT NULL;
+
+      UPDATE review_evidence
+      SET paper_snapshot_json = COALESCE(
+        (SELECT paper_snapshot_json FROM review_run_items WHERE id = review_evidence.run_item_id),
+        (SELECT paper_snapshot_json FROM extraction_values WHERE id = review_evidence.extraction_value_id),
+        (SELECT json_object('id', id, 'title', title) FROM papers WHERE id = review_evidence.paper_id),
+        '{}'
+      )
+      WHERE paper_snapshot_json = '{}';
+
+      INSERT OR IGNORE INTO extraction_field_revisions (
+        field_id, review_id, revision, name, description, field_type, options_json,
+        ordinal, active, recorded_at
+      )
+      SELECT id, review_id, revision, name, description, field_type, options_json,
+             ordinal, active, updated_at
+      FROM extraction_fields;
+
+      INSERT OR IGNORE INTO extraction_value_revisions (
+        value_id, change_revision, review_id, field_id, field_revision, paper_id,
+        paper_snapshot_json, run_item_id, value_json, status, provenance,
+        evidence_ids_json, confirmed_at, recorded_at
+      )
+      SELECT value.id, 1, value.review_id, value.field_id, value.field_revision, value.paper_id,
+             value.paper_snapshot_json, value.run_item_id, value.value_json, value.status, value.provenance,
+             COALESCE((
+               SELECT json_group_array(link.evidence_id)
+               FROM review_extraction_value_evidence link
+               WHERE link.value_id = value.id
+             ), '[]'),
+             value.confirmed_at, value.updated_at
+      FROM extraction_values value;
+    `);
+  }
+
+  private backfillPaperIdentityKeys(): void {
+    const rows = this.db
+      .prepare(
+        `SELECT id, project_id, dedupe_key, title, authors_json, year, doi, source, source_paper_id, raw_json
+         FROM papers ORDER BY project_id, created_at, id`
+      )
+      .all() as Row[];
+    const seen = new Set<string>();
+    const reserved = new Set(rows.map((row) => `${String(row.project_id)}:${String((row as Row).dedupe_key ?? "")}`));
+    const plans: Array<{ id: string; projectId: string; dedupeKey: string; normalizedTitle: string }> = [];
+    for (const row of rows) {
+      const paper = {
+        id: String(row.id),
+        title: String(row.title),
+        authors: parseJson<string[]>(row.authors_json, []),
+        year: row.year == null ? undefined : Number(row.year),
+        doi: optionalString(row.doi),
+        source: optionalString(row.source),
+        sourcePaperId: optionalString(row.source_paper_id),
+        raw: parseJson<Record<string, unknown>>(row.raw_json, {})
+      };
+      let dedupeKey = paperIdentityDedupeKey(paper);
+      const projectId = String(row.project_id);
+      let scopedKey = `${projectId}:${dedupeKey}`;
+      if (seen.has(scopedKey)) {
+        dedupeKey = `record:${paper.id}`;
+        scopedKey = `${projectId}:${dedupeKey}`;
+        let suffix = 1;
+        while (seen.has(scopedKey)) {
+          dedupeKey = `record:${paper.id}:${suffix}`;
+          scopedKey = `${projectId}:${dedupeKey}`;
+          suffix += 1;
+        }
       }
-      this.db.exec("COMMIT");
-    } catch (error) {
-      this.db.exec("ROLLBACK");
-      throw error;
+      seen.add(scopedKey);
+      plans.push({
+        id: paper.id,
+        projectId,
+        dedupeKey,
+        normalizedTitle: normalizeBibliographicTitle(paper.title)
+      });
     }
+    const stage = this.db.prepare("UPDATE papers SET dedupe_key = ? WHERE id = ?");
+    for (const plan of plans) {
+      let temporaryKey = `migration-v3:${plan.id}`;
+      let scopedTemporaryKey = `${plan.projectId}:${temporaryKey}`;
+      let suffix = 1;
+      while (reserved.has(scopedTemporaryKey) || seen.has(scopedTemporaryKey)) {
+        temporaryKey = `migration-v3:${plan.id}:${suffix}`;
+        scopedTemporaryKey = `${plan.projectId}:${temporaryKey}`;
+        suffix += 1;
+      }
+      reserved.add(scopedTemporaryKey);
+      stage.run(temporaryKey, plan.id);
+    }
+    const finalize = this.db.prepare("UPDATE papers SET dedupe_key = ?, normalized_title = ? WHERE id = ?");
+    for (const plan of plans) finalize.run(plan.dedupeKey, plan.normalizedTitle, plan.id);
   }
 
   private backfillConversations(): void {
@@ -522,6 +1076,2307 @@ export class PaperPilotDb {
       )
       .run(projectId, policyJson, updatedAt);
     return policy;
+  }
+
+  getReview(projectId: string): ReviewProtocol | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT r.*, pr.revision AS current_revision_number
+         FROM reviews r
+         JOIN review_protocol_revisions pr ON pr.id = r.current_protocol_revision_id
+         WHERE r.project_id = ?`
+      )
+      .get(projectId) as Row | undefined;
+    return row ? this.reviewFromRow(row) : undefined;
+  }
+
+  getReviewById(reviewId: string): ReviewProtocol | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT r.*, pr.revision AS current_revision_number
+         FROM reviews r
+         JOIN review_protocol_revisions pr ON pr.id = r.current_protocol_revision_id
+         WHERE r.id = ?`
+      )
+      .get(reviewId) as Row | undefined;
+    return row ? this.reviewFromRow(row) : undefined;
+  }
+
+  createReview(input: {
+    projectId: string;
+    template?: "blank" | "general-empirical" | "pico";
+    researchQuestion?: string;
+    objectives?: string[];
+    criteria?: Array<{
+      id?: string;
+      stage: "title-abstract" | "full-text";
+      type: "inclusion" | "exclusion";
+      label: string;
+      description?: string;
+      order?: number;
+    }>;
+  }): ReviewProtocol {
+    const existing = this.getReview(input.projectId);
+    if (existing) return existing;
+    const project = this.getProject(input.projectId);
+    if (!project) throw new Error(`Project not found: ${input.projectId}`);
+    const createdAt = nowIso();
+    const reviewId = id("review");
+    const revisionId = id("protocol");
+    const papers = this.listPapers(input.projectId);
+    const historicalCountsAvailable = papers.length === 0;
+    this.withTransaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO reviews (
+             id, project_id, template, current_protocol_revision_id,
+             historical_counts_available, activated_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          reviewId,
+          input.projectId,
+          input.template ?? "blank",
+          revisionId,
+          historicalCountsAvailable ? 1 : 0,
+          createdAt,
+          createdAt,
+          createdAt
+        );
+      this.db
+        .prepare(
+          `INSERT INTO review_protocol_revisions (
+             id, review_id, revision, research_question, objectives_json, created_at
+           ) VALUES (?, ?, 1, ?, ?, ?)`
+        )
+        .run(
+          revisionId,
+          reviewId,
+          input.researchQuestion?.trim() ?? "",
+          JSON.stringify(input.objectives ?? []),
+          createdAt
+        );
+      this.insertReviewCriteria(reviewId, revisionId, input.criteria ?? [], createdAt);
+      const batchId = id("batch");
+      this.db
+        .prepare(
+          `INSERT INTO discovery_batches (
+             id, review_id, kind, label, status, historical_counts_available,
+             identified_count, new_records_count, created_at, completed_at
+           ) VALUES (?, ?, 'pre-existing', 'Pre-existing project papers', 'completed', ?, ?, ?, ?, ?)`
+        )
+        .run(batchId, reviewId, historicalCountsAvailable ? 1 : 0, papers.length, papers.length, createdAt, createdAt);
+      const insertOrigin = this.db.prepare(
+        `INSERT INTO review_candidate_origins (
+           id, review_id, batch_id, paper_id, resolution, paper_snapshot_json, record_snapshot_json, created_at
+         ) VALUES (?, ?, ?, ?, 'created', ?, '{}', ?)`
+      );
+      for (const paper of papers) {
+        insertOrigin.run(id("origin"), reviewId, batchId, paper.id, JSON.stringify(paper), createdAt);
+      }
+      this.insertReviewAuditEvent({
+        reviewId,
+        projectId: input.projectId,
+        actor: "system",
+        action: "review-activated",
+        entityType: "review",
+        entityId: reviewId,
+        payload: { preExistingPaperCount: papers.length, historicalCountsAvailable },
+        createdAt
+      });
+    });
+    return this.getReview(input.projectId)!;
+  }
+
+  getReviewProtocolRevision(reviewId: string, revisionId?: string): ReviewProtocolRevision | undefined {
+    const review = this.getReviewById(reviewId);
+    if (!review) return undefined;
+    const row = this.db
+      .prepare(
+        `SELECT * FROM review_protocol_revisions
+         WHERE review_id = ? AND id = ?`
+      )
+      .get(reviewId, revisionId ?? review.currentRevisionId) as Row | undefined;
+    return row ? this.reviewProtocolRevisionFromRow(row) : undefined;
+  }
+
+  listReviewProtocolRevisions(reviewId: string): ReviewProtocolRevision[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM review_protocol_revisions WHERE review_id = ? ORDER BY revision DESC")
+        .all(reviewId) as Row[]
+    ).map((row) => this.reviewProtocolRevisionFromRow(row));
+  }
+
+  listReviewCriteria(reviewId: string, revisionId?: string): ReviewCriterion[] {
+    const selectedRevision = revisionId ?? this.getReviewById(reviewId)?.currentRevisionId;
+    if (!selectedRevision) return [];
+    return (
+      this.db
+        .prepare(
+          `SELECT * FROM review_criteria
+         WHERE review_id = ? AND protocol_revision_id = ?
+         ORDER BY stage, kind, ordinal, id`
+        )
+        .all(reviewId, selectedRevision) as Row[]
+    ).map((row) => this.reviewCriterionFromRow(row));
+  }
+
+  reviseReviewProtocol(input: {
+    reviewId: string;
+    researchQuestion: string;
+    objectives?: string[];
+    criteria?: Array<{
+      id?: string;
+      stage: "title-abstract" | "full-text";
+      type: "inclusion" | "exclusion";
+      label: string;
+      description?: string;
+      order?: number;
+    }>;
+    changeNote?: string;
+  }): ReviewProtocolRevision {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const createdAt = nowIso();
+    const revisionId = id("protocol");
+    const revision = review.currentRevisionNumber + 1;
+    this.withTransaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO review_protocol_revisions (
+             id, review_id, revision, research_question, objectives_json, note, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          revisionId,
+          input.reviewId,
+          revision,
+          input.researchQuestion.trim(),
+          JSON.stringify(input.objectives ?? []),
+          normalizeOptional(input.changeNote) ?? null,
+          createdAt
+        );
+      this.insertReviewCriteria(input.reviewId, revisionId, input.criteria ?? [], createdAt);
+      this.db
+        .prepare("UPDATE reviews SET current_protocol_revision_id = ?, updated_at = ? WHERE id = ?")
+        .run(revisionId, createdAt, input.reviewId);
+      this.db
+        .prepare(
+          `UPDATE review_run_items
+           SET stale = 1, updated_at = ?
+           WHERE review_id = ? AND stale = 0
+             AND EXISTS (
+               SELECT 1 FROM review_runs run
+               WHERE run.id = review_run_items.run_id AND run.protocol_revision_id != ?
+             )`
+        )
+        .run(createdAt, input.reviewId, revisionId);
+      this.markExtractionValuesNeedsReview(
+        `review_id = ? AND run_item_id IN (
+           SELECT item.id FROM review_run_items item
+           JOIN review_runs run ON run.id = item.run_id
+           WHERE item.review_id = ? AND run.protocol_revision_id != ?
+         )`,
+        [input.reviewId, input.reviewId, revisionId],
+        createdAt
+      );
+      this.insertReviewAuditEvent({
+        reviewId: input.reviewId,
+        projectId: review.projectId,
+        actor: "user",
+        action: "protocol-revised",
+        entityType: "protocol-revision",
+        entityId: revisionId,
+        payload: { fromVersion: review.currentRevisionNumber, toVersion: revision },
+        createdAt
+      });
+    });
+    return this.getReviewProtocolRevision(input.reviewId, revisionId)!;
+  }
+
+  listDiscoveryBatches(reviewId: string): DiscoveryBatch[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM discovery_batches WHERE review_id = ? ORDER BY created_at DESC, id DESC")
+        .all(reviewId) as Row[]
+    ).map((row) => this.discoveryBatchFromRow(row));
+  }
+
+  saveDiscoveryBatch(input: {
+    id?: string;
+    reviewId: string;
+    kind: "pre-existing" | "reference-import" | "crawl";
+    label: string;
+    sourceId?: string;
+    fileName?: string;
+    importFormat?: "ris" | "bibtex" | "csv";
+    status?: "pending" | "running" | "completed" | "failed" | "cancelled";
+    counts?: Partial<{
+      identified: number;
+      filtered: number;
+      invalid: number;
+      duplicates: number;
+      merged: number;
+      newRecords: number;
+    }>;
+    historicalCountsAvailable?: boolean;
+    config?: Record<string, unknown>;
+    error?: string;
+    createdAt?: string;
+    completedAt?: string;
+  }): DiscoveryBatch {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const existing = input.id
+      ? (this.db.prepare("SELECT * FROM discovery_batches WHERE id = ?").get(input.id) as Row | undefined)
+      : undefined;
+    if (existing && String(existing.review_id) !== input.reviewId) {
+      throw new Error(`Discovery batch belongs to another review: ${input.id}`);
+    }
+    const batchId = input.id ?? id("batch");
+    const counts = input.counts ?? {};
+    const createdAt = input.createdAt ?? (existing ? String(existing.created_at) : nowIso());
+    this.db
+      .prepare(
+        `INSERT INTO discovery_batches (
+           id, review_id, kind, label, source, file_name, import_format, status,
+           historical_counts_available, identified_count, filtered_count, invalid_count,
+           duplicate_count, merged_count, new_records_count, config_json, error, created_at, completed_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           label = excluded.label,
+           status = excluded.status,
+           identified_count = excluded.identified_count,
+           filtered_count = excluded.filtered_count,
+           invalid_count = excluded.invalid_count,
+           duplicate_count = excluded.duplicate_count,
+           merged_count = excluded.merged_count,
+           new_records_count = excluded.new_records_count,
+           config_json = excluded.config_json,
+           error = excluded.error,
+           completed_at = excluded.completed_at`
+      )
+      .run(
+        batchId,
+        input.reviewId,
+        input.kind,
+        input.label.trim(),
+        input.sourceId ?? null,
+        input.fileName ?? null,
+        input.importFormat ?? null,
+        input.status ?? "pending",
+        input.historicalCountsAvailable === false ? 0 : 1,
+        counts.identified ?? 0,
+        counts.filtered ?? 0,
+        counts.invalid ?? 0,
+        counts.duplicates ?? 0,
+        counts.merged ?? 0,
+        counts.newRecords ?? 0,
+        JSON.stringify(input.config ?? {}),
+        input.error ?? null,
+        createdAt,
+        input.completedAt ?? null
+      );
+    return this.listDiscoveryBatches(input.reviewId).find((batch) => batch.id === batchId)!;
+  }
+
+  recordReviewCandidateOrigin(input: ReviewCandidateOriginInput): ReviewCandidateOrigin {
+    return this.recordReviewCandidateOriginsBulk([input])[0]!;
+  }
+
+  recordReviewCandidateOriginsBulk(inputs: ReviewCandidateOriginInput[]): ReviewCandidateOrigin[] {
+    if (!inputs.length) return [];
+    return this.withTransaction(() => {
+      const reviews = new Map<string, ReviewProtocol>();
+      const batches = new Set<string>();
+      const suppliedIds = new Set<string>();
+      const findOrigin = this.db.prepare("SELECT id FROM review_candidate_origins WHERE id = ?");
+      const findBatch = this.db.prepare("SELECT id FROM discovery_batches WHERE id = ? AND review_id = ?");
+      const insert = this.db.prepare(
+        `INSERT INTO review_candidate_origins (
+           id, review_id, batch_id, paper_id, matched_paper_id, source_record_id,
+           resolution, paper_snapshot_json, record_snapshot_json, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      const inserted: ReviewCandidateOrigin[] = [];
+      for (const input of inputs) {
+        let review = reviews.get(input.reviewId);
+        if (!review) {
+          review = this.getReviewById(input.reviewId);
+          if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+          reviews.set(input.reviewId, review);
+        }
+        const batchKey = `${input.reviewId}:${input.batchId}`;
+        if (!batches.has(batchKey)) {
+          if (!findBatch.get(input.batchId, input.reviewId)) {
+            throw new Error(`Discovery batch not found in review: ${input.batchId}`);
+          }
+          batches.add(batchKey);
+        }
+        if (input.id) {
+          if (suppliedIds.has(input.id) || findOrigin.get(input.id)) {
+            throw new Error(`Review candidate origin already exists: ${input.id}`);
+          }
+          suppliedIds.add(input.id);
+        }
+        const paper = input.paperId ? this.getPaper(review.projectId, input.paperId) : undefined;
+        if (input.paperId && !paper) throw new Error(`Paper not found in review project: ${input.paperId}`);
+        if (input.matchedPaperId && !this.getPaper(review.projectId, input.matchedPaperId)) {
+          throw new Error(`Matched paper not found in review project: ${input.matchedPaperId}`);
+        }
+        const createdAt = input.createdAt ?? nowIso();
+        const originId = input.id ?? id("origin");
+        const paperSnapshot = input.paperSnapshot ?? paper ?? {};
+        const recordSnapshot = parseJsonRecordValue(input.recordSnapshot);
+        insert.run(
+          originId,
+          input.reviewId,
+          input.batchId,
+          input.paperId ?? null,
+          input.matchedPaperId ?? null,
+          input.sourceRecordId ?? null,
+          input.resolution,
+          JSON.stringify(paperSnapshot),
+          JSON.stringify(recordSnapshot),
+          createdAt
+        );
+        inserted.push({
+          id: originId,
+          reviewId: input.reviewId,
+          batchId: input.batchId,
+          paperId: input.paperId ?? optionalString(paperSnapshot.id),
+          matchedPaperId: input.matchedPaperId,
+          sourceRecordId: input.sourceRecordId,
+          resolution: input.resolution,
+          paperSnapshot,
+          recordSnapshot,
+          createdAt
+        });
+      }
+      return inserted;
+    });
+  }
+
+  listReviewCandidateOrigins(reviewId: string, batchId?: string): ReviewCandidateOrigin[] {
+    const rows = batchId
+      ? this.db
+          .prepare(
+            "SELECT * FROM review_candidate_origins WHERE review_id = ? AND batch_id = ? ORDER BY created_at, id"
+          )
+          .all(reviewId, batchId)
+      : this.db
+          .prepare("SELECT * FROM review_candidate_origins WHERE review_id = ? ORDER BY created_at, id")
+          .all(reviewId);
+    return (rows as Row[]).map((row) => this.reviewCandidateOriginFromRow(row));
+  }
+
+  setScreeningDecision(input: {
+    reviewId: string;
+    paperId: string;
+    stage: "title-abstract" | "full-text";
+    decision: "include" | "exclude" | "uncertain";
+    protocolRevisionId?: string;
+    reasonCriterionId?: string;
+    customReason?: string;
+    runItemId?: string;
+  }): ScreeningDecision {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const paper = this.getPaper(review.projectId, input.paperId);
+    if (!paper) throw new Error(`Paper not found in review project: ${input.paperId}`);
+    if (input.stage === "full-text") {
+      const abstractDecision = this.getCurrentScreeningDecision(input.reviewId, input.paperId, "title-abstract");
+      if (abstractDecision?.decision !== "include") {
+        throw new Error("A paper must be included during title/abstract screening before full-text screening.");
+      }
+      if (input.decision === "exclude" && !input.reasonCriterionId && !normalizeOptional(input.customReason)) {
+        throw new Error("Full-text exclusions require a criterion or custom reason.");
+      }
+    }
+    const protocolRevisionId = input.protocolRevisionId ?? review.currentRevisionId;
+    if (!this.getReviewProtocolRevision(input.reviewId, protocolRevisionId)) {
+      throw new Error(`Protocol revision not found in review: ${protocolRevisionId}`);
+    }
+    if (input.reasonCriterionId) {
+      const criterion = this.db
+        .prepare(
+          `SELECT * FROM review_criteria
+           WHERE id = ? AND review_id = ? AND protocol_revision_id = ? AND stage = ?`
+        )
+        .get(input.reasonCriterionId, input.reviewId, protocolRevisionId, input.stage) as Row | undefined;
+      if (!criterion) throw new Error("The selected exclusion criterion does not belong to this protocol stage.");
+      if (String(criterion.kind) !== "exclusion")
+        throw new Error("A screening exclusion reason must use an exclusion criterion.");
+    }
+    if (input.runItemId) {
+      const runItem = this.db
+        .prepare(
+          `SELECT item.review_id, item.paper_id, item.paper_snapshot_json, run.stage
+           FROM review_run_items item
+           JOIN review_runs run ON run.id = item.run_id
+           WHERE item.id = ?`
+        )
+        .get(input.runItemId) as Row | undefined;
+      if (
+        !runItem ||
+        String(runItem.review_id) !== input.reviewId ||
+        this.reviewPaperIdentity(runItem.paper_id, runItem.paper_snapshot_json) !== input.paperId ||
+        String(runItem.stage) !== input.stage
+      ) {
+        throw new Error("The linked review run item must belong to the same review, paper, and screening stage.");
+      }
+    }
+    const previous = this.getCurrentScreeningDecision(input.reviewId, input.paperId, input.stage);
+    const decisionId = id("decision");
+    const createdAt = nowIso();
+    this.withTransaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO review_screening_decisions (
+             id, review_id, paper_id, paper_snapshot_json, stage, decision,
+             protocol_revision_id, reason_criterion_id, custom_reason, run_item_id,
+             supersedes_decision_id, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          decisionId,
+          input.reviewId,
+          input.paperId,
+          JSON.stringify(paper),
+          input.stage,
+          input.decision,
+          protocolRevisionId,
+          input.reasonCriterionId ?? null,
+          normalizeOptional(input.customReason) ?? null,
+          input.runItemId ?? null,
+          previous?.id ?? null,
+          createdAt
+        );
+      this.db
+        .prepare(
+          `UPDATE review_rereview_flags SET resolved_at = ?
+           WHERE review_id = ? AND paper_id = ? AND stage = ? AND resolved_at IS NULL`
+        )
+        .run(createdAt, input.reviewId, input.paperId, input.stage);
+      if (input.stage === "title-abstract" && input.decision !== "include") {
+        this.invalidateDownstreamReviewState(input.reviewId, input.paperId, paper, createdAt);
+      }
+      this.insertReviewAuditEvent({
+        reviewId: input.reviewId,
+        projectId: review.projectId,
+        actor: "user",
+        action: "decision-recorded",
+        entityType: "screening-decision",
+        entityId: decisionId,
+        payload: {
+          paperId: input.paperId,
+          stage: input.stage,
+          decision: input.decision,
+          previousDecisionId: previous?.id
+        },
+        createdAt
+      });
+    });
+    return this.getScreeningDecision(decisionId)!;
+  }
+
+  getScreeningDecision(decisionId: string): ScreeningDecision | undefined {
+    const row = this.db.prepare("SELECT * FROM review_screening_decisions WHERE id = ?").get(decisionId) as
+      Row | undefined;
+    return row ? this.screeningDecisionFromRow(row) : undefined;
+  }
+
+  getCurrentScreeningDecision(
+    reviewId: string,
+    paperId: string,
+    stage: "title-abstract" | "full-text"
+  ): ScreeningDecision | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM review_screening_decisions
+         WHERE review_id = ?
+           AND COALESCE(paper_id, json_extract(paper_snapshot_json, '$.id')) = ?
+           AND stage = ?
+         ORDER BY created_at DESC, rowid DESC LIMIT 1`
+      )
+      .get(reviewId, paperId, stage) as Row | undefined;
+    return row ? this.screeningDecisionFromRow(row) : undefined;
+  }
+
+  listScreeningDecisionHistory(
+    reviewId: string,
+    paperId?: string,
+    stage?: "title-abstract" | "full-text"
+  ): ScreeningDecision[] {
+    const conditions = ["review_id = ?"];
+    const parameters: Array<string> = [reviewId];
+    if (paperId) {
+      conditions.push("COALESCE(paper_id, json_extract(paper_snapshot_json, '$.id')) = ?");
+      parameters.push(paperId);
+    }
+    if (stage) {
+      conditions.push("stage = ?");
+      parameters.push(stage);
+    }
+    return (
+      this.db
+        .prepare(
+          `SELECT * FROM review_screening_decisions
+         WHERE ${conditions.join(" AND ")} ORDER BY created_at ASC, rowid ASC`
+        )
+        .all(...parameters) as Row[]
+    ).map((row) => this.screeningDecisionFromRow(row));
+  }
+
+  markScreeningForRereview(input: {
+    reviewId: string;
+    paperIds: string[];
+    stage: "title-abstract" | "full-text";
+  }): number {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const createdAt = nowIso();
+    let created = 0;
+    this.withTransaction(() => {
+      const open = this.db.prepare(
+        `SELECT id FROM review_rereview_flags
+         WHERE review_id = ? AND paper_id = ? AND stage = ? AND resolved_at IS NULL`
+      );
+      const insert = this.db.prepare(
+        `INSERT INTO review_rereview_flags (
+           id, review_id, paper_id, paper_snapshot_json, stage, protocol_revision_id, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const paperId of [...new Set(input.paperIds)]) {
+        const paper = this.getPaper(review.projectId, paperId);
+        if (!paper) throw new Error(`Paper not found in review project: ${paperId}`);
+        if (open.get(input.reviewId, paperId, input.stage)) continue;
+        insert.run(
+          id("rereview"),
+          input.reviewId,
+          paperId,
+          JSON.stringify(paper),
+          input.stage,
+          review.currentRevisionId,
+          createdAt
+        );
+        created += 1;
+      }
+      this.insertReviewAuditEvent({
+        reviewId: input.reviewId,
+        projectId: review.projectId,
+        actor: "user",
+        action: "decision-marked-for-review",
+        entityType: "screening-stage",
+        entityId: input.stage,
+        payload: { paperIds: input.paperIds, created },
+        createdAt
+      });
+    });
+    return created;
+  }
+
+  listReviewRereviewFlags(reviewId: string): ReviewRereviewFlag[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM review_rereview_flags WHERE review_id = ? ORDER BY created_at, rowid")
+        .all(reviewId) as Row[]
+    ).map((row) => {
+      const paperSnapshot = parseJson<Record<string, unknown>>(row.paper_snapshot_json, {});
+      return {
+        id: String(row.id),
+        reviewId: String(row.review_id),
+        paperId: optionalString(row.paper_id) ?? optionalString(paperSnapshot.id) ?? "",
+        stage: row.stage as ReviewRereviewFlag["stage"],
+        protocolRevisionId: String(row.protocol_revision_id),
+        paperSnapshot,
+        invalidatesDownstream: Boolean(row.invalidates_downstream),
+        createdAt: String(row.created_at),
+        resolvedAt: optionalString(row.resolved_at)
+      };
+    });
+  }
+
+  exportReviewPortabilityState(reviewId: string): ReviewPortabilityState {
+    const review = this.getReviewById(reviewId);
+    if (!review) throw new Error(`Review not found: ${reviewId}`);
+    const runs = this.listReviewRuns(reviewId).filter((run) => run.status !== "queued" && run.status !== "running");
+    const runItems = runs.flatMap((run) =>
+      this.listReviewRunItems(run.id).map(({ evidence, ...item }) => ({
+        ...item,
+        evidenceIds: evidence.map((entry) => entry.id),
+        paperSnapshot: parseJson<Record<string, unknown>>(
+          (this.db.prepare("SELECT paper_snapshot_json FROM review_run_items WHERE id = ?").get(item.id) as Row)
+            .paper_snapshot_json,
+          {}
+        ),
+        stale: Boolean((this.db.prepare("SELECT stale FROM review_run_items WHERE id = ?").get(item.id) as Row).stale)
+      }))
+    );
+    const discoveryBatches = this.listDiscoveryBatches(reviewId).map((batch) => ({
+      ...batch,
+      config: parseJson<Record<string, unknown>>(
+        (this.db.prepare("SELECT config_json FROM discovery_batches WHERE id = ?").get(batch.id) as Row).config_json,
+        {}
+      )
+    }));
+    const screeningDecisions = this.listScreeningDecisionHistory(reviewId).map((decision) => ({
+      ...decision,
+      paperSnapshot: parseJson<Record<string, unknown>>(
+        (
+          this.db
+            .prepare("SELECT paper_snapshot_json FROM review_screening_decisions WHERE id = ?")
+            .get(decision.id) as Row
+        ).paper_snapshot_json,
+        {}
+      )
+    }));
+    const extractionValues = this.listExtractionValues(reviewId).map((value) => ({
+      ...value,
+      paperSnapshot: parseJson<Record<string, unknown>>(
+        (this.db.prepare("SELECT paper_snapshot_json FROM extraction_values WHERE id = ?").get(value.id) as Row)
+          .paper_snapshot_json,
+        {}
+      )
+    }));
+    const evidence = this.listReviewEvidence(reviewId).map((entry) => ({
+      ...entry,
+      paperSnapshot: parseJson<Record<string, unknown>>(
+        (this.db.prepare("SELECT paper_snapshot_json FROM review_evidence WHERE id = ?").get(entry.id) as Row)
+          .paper_snapshot_json,
+        {}
+      )
+    }));
+    const extractionFields = this.listExtractionFields(reviewId, true);
+    return {
+      review,
+      revisions: this.listReviewProtocolRevisions(reviewId),
+      discoveryBatches,
+      candidateOrigins: this.listReviewCandidateOrigins(reviewId),
+      rereviewFlags: this.listReviewRereviewFlags(reviewId),
+      screeningDecisions,
+      extractionFields,
+      extractionFieldHistory: extractionFields.flatMap((field) => this.listExtractionFieldHistory(field.id)),
+      extractionValues,
+      extractionValueHistory: extractionValues.flatMap((value) => this.listExtractionValueHistory(value.id)),
+      evidence,
+      runs,
+      runItems,
+      auditEvents: this.listReviewAuditEvents(reviewId)
+    };
+  }
+
+  importReviewPortabilityState(projectId: string, state: ReviewPortabilityState): ReviewProtocol {
+    if (!this.getProject(projectId)) throw new Error(`Project not found: ${projectId}`);
+    if (this.getReview(projectId)) throw new Error(`Project already has a review: ${projectId}`);
+    const review = reviewProtocolSchema.parse(state.review);
+    if (review.projectId !== projectId)
+      throw new Error("Portable review state was not remapped to the target project.");
+    const revisions = state.revisions.map((revision) => reviewProtocolRevisionSchema.parse(revision));
+    const revisionIds = new Set(revisions.map((revision) => revision.id));
+    if (!revisionIds.has(review.currentRevisionId)) {
+      throw new Error("Portable review state does not include its current protocol revision.");
+    }
+    if (revisions.some((revision) => revision.reviewId !== review.id)) {
+      throw new Error("Portable protocol revisions must belong to the imported review.");
+    }
+    const batches = state.discoveryBatches.map((batch) => ({
+      ...discoveryBatchSchema.parse(batch),
+      config: parseJsonRecordValue(batch.config)
+    }));
+    const batchIds = new Set(batches.map((batch) => batch.id));
+    if (batches.some((batch) => batch.reviewId !== review.id)) {
+      throw new Error("Portable discovery batches must belong to the imported review.");
+    }
+    const decisions = state.screeningDecisions.map((decision) => ({
+      ...screeningDecisionSchema.parse(decision),
+      paperSnapshot: parseJsonRecordValue(decision.paperSnapshot)
+    }));
+    const fields = state.extractionFields.map((field) => extractionFieldSchema.parse(field));
+    const fieldIds = new Set(fields.map((field) => field.id));
+    const fieldHistory = (state.extractionFieldHistory ?? []).map((entry) => ({
+      ...extractionFieldSchema.parse(entry),
+      recordedAt: entry.recordedAt
+    }));
+    const values = state.extractionValues.map((value) => ({
+      ...extractionValueSchema.parse(value),
+      paperSnapshot: parseJsonRecordValue(value.paperSnapshot)
+    }));
+    const valueIds = new Set(values.map((value) => value.id));
+    const valueHistory = (state.extractionValueHistory ?? []).map((entry) => ({
+      ...extractionValueSchema.parse(entry),
+      changeRevision: entry.changeRevision,
+      paperSnapshot: parseJsonRecordValue(entry.paperSnapshot),
+      recordedAt: entry.recordedAt
+    }));
+    const evidenceSnapshots = new Map(
+      state.evidence.map((entry) => [entry.id, parseJsonRecordValue(entry.paperSnapshot)])
+    );
+    const evidence = state.evidence.map((entry) => reviewEvidenceSchema.parse(entry));
+    const evidenceById = new Map(evidence.map((entry) => [entry.id, entry]));
+    const runs = state.runs.map((run) => reviewRunSchema.parse(run));
+    const runIds = new Set(runs.map((run) => run.id));
+    if (runs.some((run) => run.reviewId !== review.id || run.status === "queued" || run.status === "running")) {
+      throw new Error("Portable review state may contain only terminal runs from the imported review.");
+    }
+    const runItems = state.runItems.map((item) => {
+      const nestedEvidence = item.evidenceIds.map((evidenceId) => {
+        const entry = evidenceById.get(evidenceId);
+        if (!entry) throw new Error(`Portable run item references missing evidence: ${evidenceId}`);
+        return entry;
+      });
+      return {
+        parsed: reviewRunItemSchema.parse({ ...item, evidence: nestedEvidence }),
+        evidenceIds: [...item.evidenceIds],
+        paperSnapshot: parseJsonRecordValue(item.paperSnapshot),
+        stale: item.stale
+      };
+    });
+    const runItemIds = new Set(runItems.map(({ parsed }) => parsed.id));
+    for (const decision of decisions) {
+      if (!decision.runItemId) continue;
+      const linked = runItems.find(({ parsed }) => parsed.id === decision.runItemId)?.parsed;
+      const linkedRun = linked ? runs.find((run) => run.id === linked.runId) : undefined;
+      if (
+        !linked ||
+        !linkedRun ||
+        linked.paperId !== decision.paperId ||
+        linkedRun.stage !== decision.stage ||
+        linkedRun.reviewId !== decision.reviewId
+      ) {
+        throw new Error(`Portable screening decision has an invalid run item: ${decision.id}`);
+      }
+    }
+    if (fieldHistory.some((entry) => entry.reviewId !== review.id || !fieldIds.has(entry.id))) {
+      throw new Error("Portable extraction field history is outside the imported review.");
+    }
+    if (valueHistory.some((entry) => entry.reviewId !== review.id || !valueIds.has(entry.id))) {
+      throw new Error("Portable extraction value history is outside the imported review.");
+    }
+    const portableFieldHistory = fieldHistory.length
+      ? fieldHistory
+      : fields.map((field) => ({ ...field, recordedAt: field.updatedAt }));
+    const portableValueHistory = valueHistory.length
+      ? valueHistory
+      : values.map((value) => ({
+          ...value,
+          changeRevision: 1,
+          paperSnapshot: value.paperSnapshot,
+          recordedAt: value.updatedAt
+        }));
+    const auditEvents = state.auditEvents.map((event) => reviewAuditEventSchema.parse(event));
+    const paperIds = new Set(this.listPapers(projectId).map((paper) => paper.id));
+    const artifactIds = new Set(this.listArtifacts(projectId).map((artifact) => artifact.id));
+    const chunks = this.db
+      .prepare("SELECT id, artifact_id FROM document_chunks WHERE project_id = ?")
+      .all(projectId) as Row[];
+    const chunkArtifactIds = new Map(chunks.map((row) => [String(row.id), String(row.artifact_id)]));
+    const evidenceValueIds = new Map<string, string[]>();
+    for (const value of values) {
+      for (const evidenceId of value.evidenceIds) {
+        if (!evidenceById.has(evidenceId)) {
+          throw new Error(`Portable extraction value references missing evidence: ${evidenceId}`);
+        }
+        const linkedValues = evidenceValueIds.get(evidenceId) ?? [];
+        if (!linkedValues.includes(value.id)) linkedValues.push(value.id);
+        evidenceValueIds.set(evidenceId, linkedValues);
+      }
+    }
+    const evidenceRunItemIds = new Map<string, string>();
+    for (const item of runItems) {
+      for (const evidenceId of item.evidenceIds) {
+        const existingItem = evidenceRunItemIds.get(evidenceId);
+        if (existingItem && existingItem !== item.parsed.id) {
+          throw new Error(`Portable evidence is associated with multiple run items: ${evidenceId}`);
+        }
+        evidenceRunItemIds.set(evidenceId, item.parsed.id);
+      }
+    }
+    for (const entry of evidence) {
+      const evidencePaperId = entry.paperId ?? optionalString(evidenceSnapshots.get(entry.id)?.id);
+      const linkedValues = (evidenceValueIds.get(entry.id) ?? []).map((valueId) =>
+        values.find((value) => value.id === valueId)
+      );
+      const runItemId = evidenceRunItemIds.get(entry.id) ?? entry.runItemId;
+      const linkedItem = runItemId ? runItems.find(({ parsed }) => parsed.id === runItemId)?.parsed : undefined;
+      if (linkedValues.some((value) => !value || !evidencePaperId || value.paperId !== evidencePaperId)) {
+        throw new Error(`Portable extraction evidence belongs to another paper: ${entry.id}`);
+      }
+      if (linkedItem && (!evidencePaperId || linkedItem.paperId !== evidencePaperId)) {
+        throw new Error(`Portable run evidence belongs to another paper: ${entry.id}`);
+      }
+      if (entry.sourceType === "artifact-chunk") {
+        if (!evidencePaperId) {
+          throw new Error(`Portable artifact evidence lacks a retained paper identity: ${entry.id}`);
+        }
+        if (entry.artifactId) {
+          if (
+            !entry.chunkId ||
+            !this.isTrustedReviewArtifactChunk(review.projectId, entry.artifactId, entry.chunkId, evidencePaperId)
+          ) {
+            throw new Error(`Portable artifact evidence does not reference a trusted paper chunk: ${entry.id}`);
+          }
+        } else if (
+          entry.chunkId &&
+          this.db.prepare("SELECT 1 FROM document_chunks WHERE project_id = ? AND id = ?").get(projectId, entry.chunkId)
+        ) {
+          throw new Error(`Portable artifact evidence omits the owner of a live chunk: ${entry.id}`);
+        }
+      }
+    }
+    this.withTransaction(() => {
+      this.db.exec("PRAGMA defer_foreign_keys = ON");
+      this.db
+        .prepare(
+          `INSERT INTO reviews (
+             id, project_id, template, current_protocol_revision_id, historical_counts_available,
+             activated_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          review.id,
+          projectId,
+          review.template,
+          review.currentRevisionId,
+          review.historicalCountsAvailable ? 1 : 0,
+          review.activatedAt,
+          review.createdAt,
+          review.updatedAt
+        );
+      const insertRevision = this.db.prepare(
+        `INSERT INTO review_protocol_revisions (
+           id, review_id, revision, research_question, objectives_json, note, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+      );
+      const insertCriterion = this.db.prepare(
+        `INSERT INTO review_criteria (
+           id, review_id, protocol_revision_id, stage, kind, label, description, ordinal, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const revision of revisions) {
+        insertRevision.run(
+          revision.id,
+          review.id,
+          revision.version,
+          revision.researchQuestion,
+          JSON.stringify(revision.objectives),
+          revision.changeNote ?? null,
+          revision.createdAt
+        );
+        for (const criterion of revision.criteria) {
+          insertCriterion.run(
+            criterion.id,
+            review.id,
+            revision.id,
+            criterion.stage,
+            criterion.type,
+            criterion.label,
+            criterion.description ?? null,
+            criterion.order,
+            revision.createdAt
+          );
+        }
+      }
+      const insertBatch = this.db.prepare(
+        `INSERT INTO discovery_batches (
+           id, review_id, kind, label, source, file_name, import_format, status,
+           historical_counts_available, identified_count, filtered_count, invalid_count,
+           duplicate_count, merged_count, new_records_count, config_json, error, created_at, completed_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const batch of batches) {
+        insertBatch.run(
+          batch.id,
+          review.id,
+          batch.kind,
+          batch.label,
+          batch.sourceId ?? null,
+          batch.fileName ?? null,
+          batch.importFormat ?? null,
+          batch.status,
+          batch.historicalCountsAvailable ? 1 : 0,
+          batch.counts.identified,
+          batch.counts.filtered,
+          batch.counts.invalid,
+          batch.counts.duplicates,
+          batch.counts.merged,
+          batch.counts.newRecords,
+          JSON.stringify(batch.config),
+          batch.error ?? null,
+          batch.createdAt,
+          batch.completedAt ?? null
+        );
+      }
+      const insertOrigin = this.db.prepare(
+        `INSERT INTO review_candidate_origins (
+           id, review_id, batch_id, paper_id, matched_paper_id, source_record_id,
+           resolution, paper_snapshot_json, record_snapshot_json, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const origin of state.candidateOrigins) {
+        if (origin.reviewId !== review.id || !batchIds.has(origin.batchId)) {
+          throw new Error(`Portable candidate origin is outside the imported review: ${origin.id}`);
+        }
+        insertOrigin.run(
+          origin.id,
+          review.id,
+          origin.batchId,
+          origin.paperId && paperIds.has(origin.paperId) ? origin.paperId : null,
+          origin.matchedPaperId && paperIds.has(origin.matchedPaperId) ? origin.matchedPaperId : null,
+          origin.sourceRecordId ?? null,
+          origin.resolution,
+          JSON.stringify(origin.paperSnapshot),
+          JSON.stringify(origin.recordSnapshot),
+          origin.createdAt
+        );
+      }
+      const insertDecision = this.db.prepare(
+        `INSERT INTO review_screening_decisions (
+           id, review_id, paper_id, paper_snapshot_json, stage, decision, protocol_revision_id,
+           reason_criterion_id, custom_reason, run_item_id, supersedes_decision_id, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const decision of decisions) {
+        if (decision.reviewId !== review.id || !revisionIds.has(decision.protocolRevisionId)) {
+          throw new Error(`Portable screening decision is outside the imported review: ${decision.id}`);
+        }
+        insertDecision.run(
+          decision.id,
+          review.id,
+          paperIds.has(decision.paperId) ? decision.paperId : null,
+          JSON.stringify(decision.paperSnapshot),
+          decision.stage,
+          decision.decision,
+          decision.protocolRevisionId,
+          decision.reasonCriterionId ?? null,
+          decision.customReason ?? null,
+          decision.runItemId ?? null,
+          decision.previousDecisionId ?? null,
+          decision.createdAt
+        );
+      }
+      const insertFlag = this.db.prepare(
+        `INSERT INTO review_rereview_flags (
+           id, review_id, paper_id, paper_snapshot_json, stage, protocol_revision_id,
+           invalidates_downstream, created_at, resolved_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const flag of state.rereviewFlags) {
+        if (flag.reviewId !== review.id || !revisionIds.has(flag.protocolRevisionId)) {
+          throw new Error(`Portable re-review flag is outside the imported review: ${flag.id}`);
+        }
+        insertFlag.run(
+          flag.id,
+          review.id,
+          paperIds.has(flag.paperId) ? flag.paperId : null,
+          JSON.stringify(flag.paperSnapshot),
+          flag.stage,
+          flag.protocolRevisionId,
+          flag.invalidatesDownstream ? 1 : 0,
+          flag.createdAt,
+          flag.resolvedAt ?? null
+        );
+      }
+      const insertField = this.db.prepare(
+        `INSERT INTO extraction_fields (
+           id, review_id, name, description, field_type, options_json, ordinal,
+           revision, active, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const field of fields) {
+        if (field.reviewId !== review.id) throw new Error(`Portable extraction field has wrong review: ${field.id}`);
+        insertField.run(
+          field.id,
+          review.id,
+          field.name,
+          field.description ?? null,
+          field.type,
+          JSON.stringify(field.options),
+          field.order,
+          field.revision,
+          field.active ? 1 : 0,
+          field.createdAt,
+          field.updatedAt
+        );
+      }
+      const insertRun = this.db.prepare(
+        `INSERT INTO review_runs (
+           id, review_id, project_id, protocol_revision_id, provider, model, stage, status,
+           selected_paper_ids_json, extraction_field_ids_json, total_items, completed_items, failed_items, cancelled_items,
+           error, started_at, completed_at, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const run of runs) {
+        if (!revisionIds.has(run.protocolRevisionId)) throw new Error(`Portable run has missing protocol: ${run.id}`);
+        if (run.fieldIds.some((fieldId) => !fieldIds.has(fieldId))) {
+          throw new Error(`Portable run has an extraction field outside the review: ${run.id}`);
+        }
+        insertRun.run(
+          run.id,
+          review.id,
+          projectId,
+          run.protocolRevisionId,
+          run.provider,
+          run.model,
+          run.stage,
+          run.status,
+          JSON.stringify(run.paperIds),
+          JSON.stringify(run.fieldIds),
+          run.paperIds.length,
+          run.completedCount,
+          run.failedCount,
+          run.cancelledCount,
+          run.error ?? null,
+          run.startedAt ?? null,
+          run.completedAt ?? null,
+          run.createdAt,
+          run.updatedAt
+        );
+      }
+      const insertRunItem = this.db.prepare(
+        `INSERT INTO review_run_items (
+           id, run_id, review_id, paper_id, paper_snapshot_json, status, recommendation_json,
+           attempts, stale, error, started_at, completed_at, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const { parsed: item, paperSnapshot, stale } of runItems) {
+        if (!runIds.has(item.runId)) throw new Error(`Portable run item has missing run: ${item.id}`);
+        const itemRun = runs.find((run) => run.id === item.runId)!;
+        insertRunItem.run(
+          item.id,
+          item.runId,
+          review.id,
+          paperIds.has(item.paperId) ? item.paperId : null,
+          JSON.stringify(paperSnapshot),
+          item.status,
+          JSON.stringify({
+            suggestedDecision: item.suggestedDecision,
+            suggestedReasonCriterionId: item.suggestedReasonCriterionId,
+            suggestedCustomReason: item.suggestedCustomReason,
+            rationale: item.rationale,
+            criterionAssessments: item.criterionAssessments,
+            extractionSuggestions: item.extractionSuggestions
+          }),
+          item.attemptCount,
+          stale || itemRun.protocolRevisionId !== review.currentRevisionId ? 1 : 0,
+          item.error ?? null,
+          item.startedAt ?? null,
+          item.completedAt ?? null,
+          item.createdAt,
+          item.updatedAt
+        );
+      }
+      const insertValue = this.db.prepare(
+        `INSERT INTO extraction_values (
+           id, review_id, field_id, field_revision, paper_id, paper_snapshot_json,
+           run_item_id, value_json, status, provenance, confirmed_at, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const value of values) {
+        if (value.reviewId !== review.id || !fieldIds.has(value.fieldId)) {
+          throw new Error(`Portable extraction value is outside the imported review: ${value.id}`);
+        }
+        insertValue.run(
+          value.id,
+          review.id,
+          value.fieldId,
+          value.fieldRevision,
+          paperIds.has(value.paperId) ? value.paperId : null,
+          JSON.stringify(value.paperSnapshot),
+          value.runItemId && runItemIds.has(value.runItemId) ? value.runItemId : null,
+          JSON.stringify(value.value),
+          value.status,
+          value.origin,
+          value.confirmedAt ?? null,
+          value.createdAt,
+          value.updatedAt
+        );
+      }
+      const insertEvidence = this.db.prepare(
+        `INSERT INTO review_evidence (
+           id, review_id, extraction_value_id, run_id, run_item_id, evidence_id, source_type,
+           paper_id, paper_snapshot_json, artifact_id, chunk_id, title, excerpt, page, locator, doi, url,
+           retrieval_score, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const entry of evidence) {
+        if (entry.reviewId !== review.id) throw new Error(`Portable evidence has wrong review: ${entry.id}`);
+        const runItemId = evidenceRunItemIds.get(entry.id) ?? entry.runItemId;
+        const runItem = runItemId ? runItems.find((candidate) => candidate.parsed.id === runItemId)?.parsed : undefined;
+        const runId = entry.runId && runIds.has(entry.runId) ? entry.runId : runItem?.runId;
+        const artifactId = entry.artifactId && artifactIds.has(entry.artifactId) ? entry.artifactId : undefined;
+        const chunkId =
+          entry.chunkId && artifactId && chunkArtifactIds.get(entry.chunkId) === artifactId ? entry.chunkId : undefined;
+        insertEvidence.run(
+          entry.id,
+          review.id,
+          null,
+          runId ?? null,
+          runItemId && runItemIds.has(runItemId) ? runItemId : null,
+          entry.evidenceId,
+          entry.sourceType,
+          entry.paperId && paperIds.has(entry.paperId) ? entry.paperId : null,
+          JSON.stringify(evidenceSnapshots.get(entry.id) ?? (entry.paperId ? { id: entry.paperId } : {})),
+          artifactId ?? null,
+          chunkId ?? null,
+          entry.title,
+          entry.excerpt,
+          entry.page ?? null,
+          entry.locator ?? null,
+          entry.doi ?? null,
+          entry.url ?? null,
+          entry.retrievalScore ?? null,
+          entry.createdAt
+        );
+      }
+      const insertValueEvidence = this.db.prepare(
+        `INSERT INTO review_extraction_value_evidence (value_id, evidence_id, created_at)
+         VALUES (?, ?, ?)`
+      );
+      for (const [evidenceId, linkedValueIds] of evidenceValueIds) {
+        for (const valueId of linkedValueIds) insertValueEvidence.run(valueId, evidenceId, review.updatedAt);
+      }
+      const insertFieldHistory = this.db.prepare(
+        `INSERT INTO extraction_field_revisions (
+           field_id, review_id, revision, name, description, field_type, options_json,
+           ordinal, active, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const entry of portableFieldHistory) {
+        insertFieldHistory.run(
+          entry.id,
+          review.id,
+          entry.revision,
+          entry.name,
+          entry.description ?? null,
+          entry.type,
+          JSON.stringify(entry.options),
+          entry.order,
+          entry.active ? 1 : 0,
+          entry.recordedAt
+        );
+      }
+      const insertValueHistory = this.db.prepare(
+        `INSERT INTO extraction_value_revisions (
+           value_id, change_revision, review_id, field_id, field_revision, paper_id,
+           paper_snapshot_json, run_item_id, value_json, status, provenance,
+           evidence_ids_json, confirmed_at, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const entry of portableValueHistory) {
+        insertValueHistory.run(
+          entry.id,
+          entry.changeRevision,
+          review.id,
+          entry.fieldId,
+          entry.fieldRevision,
+          paperIds.has(entry.paperId) ? entry.paperId : null,
+          JSON.stringify(entry.paperSnapshot),
+          entry.runItemId && runItemIds.has(entry.runItemId) ? entry.runItemId : null,
+          JSON.stringify(entry.value),
+          entry.status,
+          entry.origin,
+          JSON.stringify(entry.evidenceIds),
+          entry.confirmedAt ?? null,
+          entry.recordedAt
+        );
+      }
+      const insertAudit = this.db.prepare(
+        `INSERT INTO review_audit_events (
+           id, review_id, project_id, actor, action, entity_type, entity_id, payload_json, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const event of auditEvents) {
+        if (event.reviewId !== review.id) throw new Error(`Portable audit event has wrong review: ${event.id}`);
+        insertAudit.run(
+          event.id,
+          review.id,
+          projectId,
+          event.actor,
+          event.kind,
+          event.entityType ?? null,
+          event.entityId ?? null,
+          JSON.stringify(event.payload),
+          event.createdAt
+        );
+      }
+    });
+    return this.getReview(projectId)!;
+  }
+
+  listReviewPapers(input: ReviewPaperQuery): ReviewPaperPage {
+    const query = reviewPaperQuerySchema.parse(input);
+    const review = this.getReviewById(query.reviewId);
+    if (!review) throw new Error(`Review not found: ${query.reviewId}`);
+    const papers = this.listPapers(review.projectId);
+    const decisions = this.currentScreeningDecisionRows(query.reviewId);
+    const currentDecisions = new Map<string, ScreeningDecision>();
+    for (const decision of decisions) currentDecisions.set(`${decision.paperId}:${decision.stage}`, decision);
+    const batchIds = new Map(
+      (
+        this.db
+          .prepare(
+            `SELECT paper_id, json_group_array(DISTINCT batch_id) AS batch_ids
+             FROM review_candidate_origins
+             WHERE review_id = ? AND paper_id IS NOT NULL
+             GROUP BY paper_id`
+          )
+          .all(query.reviewId) as Row[]
+      ).map((row) => [String(row.paper_id), parseJson<string[]>(row.batch_ids, [])])
+    );
+    const fullTextIds = new Set(
+      (
+        this.db
+          .prepare(
+            `SELECT DISTINCT chunk.paper_id
+             FROM document_chunks chunk
+             JOIN artifacts artifact ON artifact.id = chunk.artifact_id AND artifact.project_id = chunk.project_id
+             WHERE chunk.project_id = ?
+               AND chunk.paper_id IS NOT NULL
+               AND length(trim(chunk.text)) > 0
+               AND artifact.type IN ('paper-pdf', 'markdown', 'table')
+               AND COALESCE(artifact.source, '') != 'research-chat'
+               AND json_extract(artifact.metadata_json, '$.paperId') = chunk.paper_id`
+          )
+          .all(review.projectId) as Row[]
+      ).map((row) => String(row.paper_id))
+    );
+    const openRereviewRows = this.db
+      .prepare(
+        `SELECT paper_id, paper_snapshot_json, stage, invalidates_downstream FROM review_rereview_flags
+         WHERE review_id = ? AND resolved_at IS NULL`
+      )
+      .all(query.reviewId) as Row[];
+    const openRereview = new Set(
+      openRereviewRows.map(
+        (row) => `${this.reviewPaperIdentity(row.paper_id, row.paper_snapshot_json)}:${String(row.stage)}`
+      )
+    );
+    const downstreamInvalidated = new Set(
+      openRereviewRows
+        .filter((row) => Boolean(row.invalidates_downstream))
+        .map((row) => `${this.reviewPaperIdentity(row.paper_id, row.paper_snapshot_json)}:${String(row.stage)}`)
+    );
+    const activeFieldCount = Number(
+      (
+        this.db
+          .prepare("SELECT COUNT(*) AS count FROM extraction_fields WHERE review_id = ? AND active = 1")
+          .get(query.reviewId) as Row
+      ).count ?? 0
+    );
+    const extractionRows = this.db
+      .prepare(
+        `SELECT paper_id,
+                SUM(CASE WHEN status = 'confirmed' THEN 1 ELSE 0 END) AS confirmed,
+                SUM(CASE WHEN status IN ('suggested', 'rejected', 'needs-review') THEN 1 ELSE 0 END) AS needs_review
+         FROM extraction_values WHERE review_id = ? AND paper_id IS NOT NULL GROUP BY paper_id`
+      )
+      .all(query.reviewId) as Row[];
+    const extractionProgress = new Map(
+      extractionRows.map((row) => [
+        String(row.paper_id),
+        { total: activeFieldCount, confirmed: Number(row.confirmed ?? 0), needsReview: Number(row.needs_review ?? 0) }
+      ])
+    );
+    const latestSuggestionStale = new Map<string, boolean>();
+    const suggestionRows = this.db
+      .prepare(
+        `SELECT item.paper_id, item.paper_snapshot_json, item.recommendation_json, item.stale
+         FROM review_run_items item
+         JOIN review_runs run ON run.id = item.run_id
+         WHERE item.review_id = ? AND run.stage = ? AND item.status = 'completed'
+         ORDER BY run.updated_at ASC, run.rowid ASC, item.rowid ASC`
+      )
+      .all(query.reviewId, query.stage) as Row[];
+    for (const row of suggestionRows) {
+      const recommendation = parseJson<Record<string, unknown>>(row.recommendation_json, {});
+      const isActionable =
+        query.stage === "extraction"
+          ? Array.isArray(recommendation.extractionSuggestions) && recommendation.extractionSuggestions.length > 0
+          : typeof recommendation.suggestedDecision === "string";
+      if (!isActionable) continue;
+      const paperId = this.reviewPaperIdentity(row.paper_id, row.paper_snapshot_json);
+      if (paperId) latestSuggestionStale.set(paperId, Boolean(row.stale));
+    }
+    const createdRows = this.db
+      .prepare("SELECT id, created_at FROM papers WHERE project_id = ?")
+      .all(review.projectId) as Row[];
+    const createdAtByPaper = new Map(createdRows.map((row) => [String(row.id), String(row.created_at)]));
+    const summaries = papers
+      .map((paper) => {
+        const titleAbstractDecision = currentDecisions.get(`${paper.id}:title-abstract`);
+        const fullTextDecision = currentDecisions.get(`${paper.id}:full-text`);
+        return {
+          reviewId: query.reviewId,
+          paperId: paper.id,
+          title: paper.title,
+          authors: paper.authors,
+          abstract: paper.abstract,
+          year: paper.year,
+          venue: paper.venue,
+          doi: paper.doi,
+          source: paper.source,
+          discoveryBatchIds: batchIds.get(paper.id) ?? [],
+          hasFullText: fullTextIds.has(paper.id),
+          titleAbstractDecision,
+          fullTextDecision,
+          extractionProgress: extractionProgress.get(paper.id) ?? {
+            total: activeFieldCount,
+            confirmed: 0,
+            needsReview: 0
+          },
+          needsReReview: openRereview.has(`${paper.id}:title-abstract`) || openRereview.has(`${paper.id}:full-text`),
+          aiSuggestionStale: latestSuggestionStale.get(paper.id) ?? false,
+          createdAt: createdAtByPaper.get(paper.id) ?? ""
+        };
+      })
+      .filter((paper) => {
+        if (query.stage === "full-text" && paper.titleAbstractDecision?.decision !== "include") return false;
+        if (
+          query.stage === "extraction" &&
+          (paper.titleAbstractDecision?.decision !== "include" ||
+            paper.fullTextDecision?.decision !== "include" ||
+            downstreamInvalidated.has(`${paper.paperId}:full-text`))
+        )
+          return false;
+        if (query.search) {
+          const haystack =
+            `${paper.title}\n${paper.abstract ?? ""}\n${paper.authors.join(" ")}\n${paper.doi ?? ""}`.toLowerCase();
+          if (!haystack.includes(query.search.toLowerCase())) return false;
+        }
+        if (query.sources.length && !query.sources.includes(paper.source)) return false;
+        if (query.yearFrom !== undefined && (paper.year === undefined || paper.year < query.yearFrom)) return false;
+        if (query.yearTo !== undefined && (paper.year === undefined || paper.year > query.yearTo)) return false;
+        if (query.fullText === "available" && !paper.hasFullText) return false;
+        if (query.fullText === "missing" && paper.hasFullText) return false;
+        if (query.needsReReview !== undefined && paper.needsReReview !== query.needsReReview) return false;
+        return true;
+      });
+    const decisionForStage = (paper: (typeof summaries)[number]) =>
+      query.stage === "title-abstract" ? paper.titleAbstractDecision?.decision : paper.fullTextDecision?.decision;
+    const counts = { pending: 0, include: 0, exclude: 0, uncertain: 0 };
+    for (const paper of summaries) counts[decisionForStage(paper) ?? "pending"] += 1;
+    const filtered = query.decisions.length
+      ? summaries.filter((paper) => query.decisions.includes(decisionForStage(paper) ?? "pending"))
+      : summaries;
+    filtered.sort((left, right) => {
+      let comparison: number;
+      if (query.sort === "title") comparison = left.title.localeCompare(right.title);
+      else if (query.sort === "year") comparison = (left.year ?? 0) - (right.year ?? 0);
+      else comparison = left.createdAt.localeCompare(right.createdAt);
+      if (comparison === 0) comparison = left.paperId.localeCompare(right.paperId);
+      return query.direction === "asc" ? comparison : -comparison;
+    });
+    const start = (query.page - 1) * query.pageSize;
+    return {
+      items: filtered.slice(start, start + query.pageSize).map((paper) => reviewPaperSummarySchema.parse(paper)),
+      page: query.page,
+      pageSize: query.pageSize,
+      total: filtered.length,
+      totalPages: filtered.length ? Math.ceil(filtered.length / query.pageSize) : 0,
+      counts
+    };
+  }
+
+  listExtractionFields(reviewId: string, includeInactive = false): ExtractionField[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM extraction_fields WHERE review_id = ? ${includeInactive ? "" : "AND active = 1"}
+         ORDER BY ordinal, id`
+      )
+      .all(reviewId) as Row[];
+    return rows.map((row) => this.extractionFieldFromRow(row));
+  }
+
+  listExtractionFieldHistory(fieldId: string): ExtractionFieldHistoryEntry[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM extraction_field_revisions WHERE field_id = ? ORDER BY revision")
+        .all(fieldId) as Row[]
+    ).map((row) => ({
+      ...this.extractionFieldFromRevisionRow(row),
+      recordedAt: String(row.recorded_at)
+    }));
+  }
+
+  saveExtractionField(input: {
+    id?: string;
+    reviewId: string;
+    name: string;
+    description?: string;
+    type: ExtractionField["type"];
+    options?: string[];
+    order?: number;
+    active?: boolean;
+  }): ExtractionField {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const existing = input.id
+      ? (this.db.prepare("SELECT * FROM extraction_fields WHERE id = ?").get(input.id) as Row | undefined)
+      : undefined;
+    if (existing && String(existing.review_id) !== input.reviewId) {
+      throw new Error(`Extraction field belongs to another review: ${input.id}`);
+    }
+    const willActivate = (input.active ?? (existing ? Boolean(existing.active) : true)) && !existing?.active;
+    if (willActivate) {
+      const activeCount = this.listExtractionFields(input.reviewId).length;
+      if (activeCount >= MAX_EXTRACTION_FIELDS) {
+        throw new Error(`Reviews support at most ${MAX_EXTRACTION_FIELDS} active extraction fields.`);
+      }
+    }
+    const fieldId = input.id ?? id("field");
+    const createdAt = existing ? String(existing.created_at) : nowIso();
+    const updatedAt = nowIso();
+    const options = input.options ?? [];
+    const field = extractionFieldSchema.parse({
+      id: fieldId,
+      reviewId: input.reviewId,
+      name: input.name,
+      description: input.description,
+      type: input.type,
+      options,
+      order:
+        input.order ?? (existing ? Number(existing.ordinal) : this.listExtractionFields(input.reviewId, true).length),
+      revision: existing ? Number(existing.revision) : 1,
+      active: input.active ?? (existing ? Boolean(existing.active) : true),
+      createdAt,
+      updatedAt
+    });
+    const semanticChange =
+      !!existing &&
+      (String(existing.name) !== field.name ||
+        normalizeOptional(existing.description == null ? undefined : String(existing.description)) !==
+          field.description ||
+        String(existing.field_type) !== field.type ||
+        JSON.stringify(parseJson<string[]>(existing.options_json, [])) !== JSON.stringify(field.options));
+    if (semanticChange) field.revision = Number(existing!.revision) + 1;
+    this.withTransaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO extraction_fields (
+             id, review_id, name, description, field_type, options_json, ordinal,
+             revision, active, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             name = excluded.name,
+             description = excluded.description,
+             field_type = excluded.field_type,
+             options_json = excluded.options_json,
+             ordinal = excluded.ordinal,
+             revision = excluded.revision,
+             active = excluded.active,
+             updated_at = excluded.updated_at`
+        )
+        .run(
+          field.id,
+          field.reviewId,
+          field.name,
+          field.description ?? null,
+          field.type,
+          JSON.stringify(field.options),
+          field.order,
+          field.revision,
+          field.active ? 1 : 0,
+          field.createdAt,
+          field.updatedAt
+        );
+      if (semanticChange) {
+        this.markExtractionValuesNeedsReview(
+          "review_id = ? AND field_id = ?",
+          [input.reviewId, field.id],
+          updatedAt,
+          field.revision
+        );
+      }
+      if (!existing || semanticChange) this.recordExtractionFieldRevision(field, updatedAt);
+      this.insertReviewAuditEvent({
+        reviewId: input.reviewId,
+        projectId: review.projectId,
+        actor: "user",
+        action: existing ? "extraction-field-revised" : "extraction-field-created",
+        entityType: "extraction-field",
+        entityId: field.id,
+        payload: { semanticChange, revision: field.revision },
+        createdAt: updatedAt
+      });
+    });
+    return this.listExtractionFields(input.reviewId, true).find((candidate) => candidate.id === field.id)!;
+  }
+
+  saveExtractionValue(input: {
+    id?: string;
+    reviewId: string;
+    paperId: string;
+    fieldId: string;
+    value: ExtractionValue["value"];
+    status: ExtractionValue["status"];
+    origin: ExtractionValue["origin"];
+    evidenceIds?: string[];
+    runItemId?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    confirmedAt?: string;
+  }): ExtractionValue {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const paper = this.getPaper(review.projectId, input.paperId);
+    if (!paper) throw new Error(`Paper not found in review project: ${input.paperId}`);
+    if (!this.isPaperEligibleForExtraction(input.reviewId, input.paperId)) {
+      throw new Error("Extraction values may only be saved for papers currently included at both screening stages.");
+    }
+    const field = this.listExtractionFields(input.reviewId, true).find((candidate) => candidate.id === input.fieldId);
+    if (!field || !field.active) throw new Error(`Active extraction field not found: ${input.fieldId}`);
+    this.assertExtractionValueMatchesField(field, input.value, input.status);
+    const existing = this.db
+      .prepare("SELECT * FROM extraction_values WHERE review_id = ? AND field_id = ? AND paper_id = ?")
+      .get(input.reviewId, input.fieldId, input.paperId) as Row | undefined;
+    if (input.id && existing && String(existing.id) !== input.id) {
+      throw new Error(`Extraction value identity does not match the existing review cell: ${input.id}`);
+    }
+    if (input.id) {
+      const identified = this.db.prepare("SELECT review_id FROM extraction_values WHERE id = ?").get(input.id) as
+        Row | undefined;
+      if (identified && String(identified.review_id) !== input.reviewId) {
+        throw new Error(`Extraction value belongs to another review: ${input.id}`);
+      }
+    }
+    const valueId = input.id ?? (existing ? String(existing.id) : id("value"));
+    const evidenceIds = input.evidenceIds ?? (existing ? this.listEvidenceIdsForValue(String(existing.id)) : []);
+    let runItemStale = false;
+    if (input.runItemId) {
+      const runItem = this.db
+        .prepare(
+          `SELECT item.review_id, item.paper_id, item.paper_snapshot_json, item.stale, run.stage
+           FROM review_run_items item
+           JOIN review_runs run ON run.id = item.run_id
+           WHERE item.id = ?`
+        )
+        .get(input.runItemId) as Row | undefined;
+      if (
+        !runItem ||
+        String(runItem.review_id) !== input.reviewId ||
+        this.reviewPaperIdentity(runItem.paper_id, runItem.paper_snapshot_json) !== input.paperId ||
+        String(runItem.stage) !== "extraction"
+      ) {
+        throw new Error("The linked review run item must belong to the same review, paper, and extraction stage.");
+      }
+      runItemStale = Boolean(runItem.stale);
+    }
+    const createdAt = input.createdAt ?? (existing ? String(existing.created_at) : nowIso());
+    const updatedAt = input.updatedAt ?? nowIso();
+    const effectiveStatus = input.origin === "ai" && runItemStale ? "needs-review" : input.status;
+    const confirmedAt = effectiveStatus === "confirmed" ? (input.confirmedAt ?? updatedAt) : undefined;
+    const value = extractionValueSchema.parse({
+      id: valueId,
+      reviewId: input.reviewId,
+      paperId: input.paperId,
+      fieldId: input.fieldId,
+      fieldRevision: field.revision,
+      value: input.value,
+      status: effectiveStatus,
+      origin: input.origin,
+      evidenceIds,
+      runItemId: input.runItemId,
+      createdAt,
+      updatedAt,
+      confirmedAt
+    });
+    this.withTransaction(() => {
+      if (evidenceIds.length) {
+        const placeholders = evidenceIds.map(() => "?").join(", ");
+        const evidenceRows = this.db
+          .prepare(
+            `SELECT id, paper_id, paper_snapshot_json
+             FROM review_evidence WHERE review_id = ? AND id IN (${placeholders})`
+          )
+          .all(input.reviewId, ...evidenceIds) as Row[];
+        if (evidenceRows.length !== new Set(evidenceIds).size)
+          throw new Error("One or more extraction evidence references are invalid.");
+        for (const evidenceRow of evidenceRows) {
+          if (this.reviewPaperIdentity(evidenceRow.paper_id, evidenceRow.paper_snapshot_json) !== input.paperId) {
+            throw new Error("Extraction evidence must belong to the same paper as the extraction value.");
+          }
+        }
+      }
+      this.db
+        .prepare(
+          `INSERT INTO extraction_values (
+             id, review_id, field_id, field_revision, paper_id, paper_snapshot_json,
+             run_item_id, value_json, status, provenance, confirmed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(review_id, field_id, paper_id) DO UPDATE SET
+             field_revision = excluded.field_revision,
+             paper_snapshot_json = excluded.paper_snapshot_json,
+             run_item_id = excluded.run_item_id,
+             value_json = excluded.value_json,
+             status = excluded.status,
+             provenance = excluded.provenance,
+             confirmed_at = excluded.confirmed_at,
+             updated_at = excluded.updated_at`
+        )
+        .run(
+          value.id,
+          value.reviewId,
+          value.fieldId,
+          value.fieldRevision,
+          value.paperId,
+          JSON.stringify(paper),
+          value.runItemId ?? null,
+          JSON.stringify(value.value),
+          value.status,
+          value.origin,
+          value.confirmedAt ?? null,
+          value.createdAt,
+          value.updatedAt
+        );
+      this.db.prepare("DELETE FROM review_extraction_value_evidence WHERE value_id = ?").run(value.id);
+      const linkEvidence = this.db.prepare(
+        `INSERT INTO review_extraction_value_evidence (value_id, evidence_id, created_at)
+         VALUES (?, ?, ?)`
+      );
+      for (const evidenceId of evidenceIds) linkEvidence.run(value.id, evidenceId, updatedAt);
+      this.recordExtractionValueRevision(value.id, updatedAt);
+      if (value.status === "confirmed" || value.status === "rejected" || value.status === "not-found") {
+        const action =
+          value.status === "confirmed"
+            ? "extraction-value-confirmed"
+            : value.status === "rejected"
+              ? "extraction-value-rejected"
+              : "extraction-value-not-found";
+        this.insertReviewAuditEvent({
+          reviewId: input.reviewId,
+          projectId: review.projectId,
+          actor: "user",
+          action,
+          entityType: "extraction-value",
+          entityId: value.id,
+          payload: {
+            paperId: value.paperId,
+            fieldId: value.fieldId,
+            origin: value.origin,
+            runItemId: value.runItemId
+          },
+          createdAt: updatedAt
+        });
+      }
+    });
+    return this.getExtractionValue(value.id)!;
+  }
+
+  getExtractionValue(valueId: string): ExtractionValue | undefined {
+    const row = this.db.prepare("SELECT * FROM extraction_values WHERE id = ?").get(valueId) as Row | undefined;
+    return row ? this.extractionValueFromRow(row) : undefined;
+  }
+
+  listExtractionValues(reviewId: string, paperId?: string): ExtractionValue[] {
+    const rows = paperId
+      ? this.db
+          .prepare("SELECT * FROM extraction_values WHERE review_id = ? AND paper_id = ? ORDER BY field_id")
+          .all(reviewId, paperId)
+      : this.db
+          .prepare("SELECT * FROM extraction_values WHERE review_id = ? ORDER BY paper_id, field_id")
+          .all(reviewId);
+    return (rows as Row[]).map((row) => this.extractionValueFromRow(row));
+  }
+
+  listExtractionValueHistory(valueId: string): ExtractionValueHistoryEntry[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM extraction_value_revisions WHERE value_id = ? ORDER BY change_revision")
+        .all(valueId) as Row[]
+    ).map((row) => this.extractionValueHistoryFromRow(row));
+  }
+
+  saveReviewEvidence(evidence: ReviewEvidence, extractionValueId?: string): ReviewEvidence {
+    const parsed = reviewEvidenceSchema.parse(evidence);
+    const review = this.getReviewById(parsed.reviewId);
+    if (!review) throw new Error(`Review not found: ${parsed.reviewId}`);
+    const existing = this.db.prepare("SELECT * FROM review_evidence WHERE id = ?").get(parsed.id) as Row | undefined;
+    if (existing && String(existing.review_id) !== parsed.reviewId) {
+      throw new Error(`Review evidence belongs to another review: ${parsed.id}`);
+    }
+    const paper = parsed.paperId ? this.getPaper(review.projectId, parsed.paperId) : undefined;
+    if (parsed.paperId && !paper) {
+      throw new Error(`Paper not found in review project: ${parsed.paperId}`);
+    }
+    if (parsed.artifactId && !this.getArtifact(review.projectId, parsed.artifactId)) {
+      throw new Error(`Artifact not found in review project: ${parsed.artifactId}`);
+    }
+    if (parsed.runId && this.getReviewRun(parsed.runId)?.reviewId !== parsed.reviewId) {
+      throw new Error(`Review run not found in review: ${parsed.runId}`);
+    }
+    const runItem = parsed.runItemId
+      ? (this.db
+          .prepare("SELECT review_id, run_id, paper_id, paper_snapshot_json FROM review_run_items WHERE id = ?")
+          .get(parsed.runItemId) as Row | undefined)
+      : undefined;
+    if (parsed.runItemId) {
+      if (!runItem || String(runItem.review_id) !== parsed.reviewId) {
+        throw new Error(`Review run item not found in review: ${parsed.runItemId}`);
+      }
+      if (parsed.runId && String(runItem.run_id) !== parsed.runId) {
+        throw new Error("Review evidence run and run item must match.");
+      }
+      if (
+        parsed.paperId &&
+        this.reviewPaperIdentity(runItem.paper_id, runItem.paper_snapshot_json) !== parsed.paperId
+      ) {
+        throw new Error("Review evidence must belong to the run item's paper.");
+      }
+    }
+    const extractionValue = extractionValueId
+      ? (this.db
+          .prepare("SELECT review_id, paper_id, paper_snapshot_json FROM extraction_values WHERE id = ?")
+          .get(extractionValueId) as Row | undefined)
+      : undefined;
+    if (extractionValueId) {
+      const value = extractionValue;
+      if (!value || String(value.review_id) !== parsed.reviewId) {
+        throw new Error(`Extraction value not found in review: ${extractionValueId}`);
+      }
+      if (parsed.paperId && this.reviewPaperIdentity(value.paper_id, value.paper_snapshot_json) !== parsed.paperId) {
+        throw new Error("Review evidence must belong to the extraction value's paper.");
+      }
+    }
+    const paperIdentity =
+      parsed.paperId ??
+      this.reviewPaperIdentity(runItem?.paper_id, runItem?.paper_snapshot_json) ??
+      this.reviewPaperIdentity(extractionValue?.paper_id, extractionValue?.paper_snapshot_json) ??
+      this.reviewPaperIdentity(existing?.paper_id, existing?.paper_snapshot_json);
+    const existingPaperIdentity = this.reviewPaperIdentity(existing?.paper_id, existing?.paper_snapshot_json);
+    if (existingPaperIdentity && paperIdentity && existingPaperIdentity !== paperIdentity) {
+      throw new Error("Review evidence paper identity is immutable.");
+    }
+    const paperSnapshot =
+      paper ??
+      this.reviewPaperSnapshot(runItem?.paper_snapshot_json) ??
+      this.reviewPaperSnapshot(extractionValue?.paper_snapshot_json) ??
+      this.reviewPaperSnapshot(existing?.paper_snapshot_json) ??
+      (paperIdentity ? { id: paperIdentity } : {});
+    if (parsed.sourceType === "artifact-chunk") {
+      if (!parsed.artifactId || !parsed.chunkId) {
+        throw new Error("Artifact-chunk evidence requires an artifact and chunk.");
+      }
+      const chunk = this.db
+        .prepare(
+          `SELECT chunk.paper_id
+           FROM document_chunks chunk
+           JOIN artifacts artifact ON artifact.id = chunk.artifact_id AND artifact.project_id = chunk.project_id
+           WHERE chunk.id = ? AND chunk.artifact_id = ? AND chunk.project_id = ?
+             AND length(trim(chunk.text)) > 0
+             AND artifact.type IN ('paper-pdf', 'markdown', 'table')
+             AND COALESCE(artifact.source, '') != 'research-chat'
+             AND json_extract(artifact.metadata_json, '$.paperId') = ?
+             AND chunk.paper_id = ?`
+        )
+        .get(parsed.chunkId, parsed.artifactId, review.projectId, paperIdentity ?? null, paperIdentity ?? null) as
+        Row | undefined;
+      if (!chunk) throw new Error("Artifact-chunk evidence must reference a trusted indexed chunk.");
+    } else if (!paperIdentity) {
+      throw new Error("Paper metadata and abstract evidence require a paper.");
+    }
+    this.db
+      .prepare(
+        `INSERT INTO review_evidence (
+           id, review_id, extraction_value_id, run_id, run_item_id, evidence_id,
+           source_type, paper_id, paper_snapshot_json, artifact_id, chunk_id, title, excerpt, page,
+           locator, doi, url, retrieval_score, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           extraction_value_id = COALESCE(excluded.extraction_value_id, review_evidence.extraction_value_id),
+           paper_snapshot_json = CASE
+             WHEN review_evidence.paper_snapshot_json = '{}' THEN excluded.paper_snapshot_json
+             ELSE review_evidence.paper_snapshot_json
+           END,
+           title = excluded.title,
+           excerpt = excluded.excerpt,
+           page = excluded.page,
+           locator = excluded.locator,
+           doi = excluded.doi,
+           url = excluded.url,
+           retrieval_score = excluded.retrieval_score`
+      )
+      .run(
+        parsed.id,
+        parsed.reviewId,
+        null,
+        parsed.runId ?? null,
+        parsed.runItemId ?? null,
+        parsed.evidenceId,
+        parsed.sourceType,
+        parsed.paperId ?? null,
+        JSON.stringify(paperSnapshot),
+        parsed.artifactId ?? null,
+        parsed.chunkId ?? null,
+        parsed.title,
+        parsed.excerpt,
+        parsed.page ?? null,
+        parsed.locator ?? null,
+        parsed.doi ?? null,
+        parsed.url ?? null,
+        parsed.retrievalScore ?? null,
+        parsed.createdAt
+      );
+    if (extractionValueId) {
+      this.db
+        .prepare(
+          `INSERT OR IGNORE INTO review_extraction_value_evidence (value_id, evidence_id, created_at)
+           VALUES (?, ?, ?)`
+        )
+        .run(extractionValueId, parsed.id, nowIso());
+      this.recordExtractionValueRevision(extractionValueId, nowIso());
+    }
+    return this.getReviewEvidence(parsed.id)!;
+  }
+
+  getReviewEvidence(evidenceId: string): ReviewEvidence | undefined {
+    const row = this.db.prepare("SELECT * FROM review_evidence WHERE id = ?").get(evidenceId) as Row | undefined;
+    return row ? this.reviewEvidenceFromRow(row) : undefined;
+  }
+
+  listReviewEvidence(
+    reviewId: string,
+    options: { runId?: string; runItemId?: string; extractionValueId?: string } = {}
+  ): ReviewEvidence[] {
+    const conditions = ["review_id = ?"];
+    const parameters: string[] = [reviewId];
+    if (options.runId) {
+      conditions.push("run_id = ?");
+      parameters.push(options.runId);
+    }
+    if (options.runItemId) {
+      conditions.push("run_item_id = ?");
+      parameters.push(options.runItemId);
+    }
+    if (options.extractionValueId) {
+      conditions.push("id IN (SELECT evidence_id FROM review_extraction_value_evidence WHERE value_id = ?)");
+      parameters.push(options.extractionValueId);
+    }
+    return (
+      this.db
+        .prepare(`SELECT * FROM review_evidence WHERE ${conditions.join(" AND ")} ORDER BY created_at, id`)
+        .all(...parameters) as Row[]
+    ).map((row) => this.reviewEvidenceFromRow(row));
+  }
+
+  saveReviewRun(run: ReviewRun): ReviewRun {
+    const parsed = reviewRunSchema.parse(run);
+    if (parsed.paperIds.length > MAX_REVIEW_BATCH_PAPERS) {
+      throw new Error(`Review runs support at most ${MAX_REVIEW_BATCH_PAPERS} papers.`);
+    }
+    const review = this.getReviewById(parsed.reviewId);
+    if (!review) throw new Error(`Review not found: ${parsed.reviewId}`);
+    const existing = this.getReviewRun(parsed.id);
+    if (existing && existing.reviewId !== parsed.reviewId) {
+      throw new Error(`Review run belongs to another review: ${parsed.id}`);
+    }
+    const revision = this.getReviewProtocolRevision(parsed.reviewId, parsed.protocolRevisionId);
+    if (!revision) throw new Error(`Protocol revision not found in review: ${parsed.protocolRevisionId}`);
+    const reviewFieldIds = new Set(this.listExtractionFields(parsed.reviewId, true).map((field) => field.id));
+    if (parsed.fieldIds.some((fieldId) => !reviewFieldIds.has(fieldId))) {
+      throw new Error("Review run references an extraction field outside its review.");
+    }
+    for (const paperId of parsed.paperIds) {
+      if (!this.getPaper(review.projectId, paperId)) throw new Error(`Paper not found in review project: ${paperId}`);
+      if (
+        parsed.stage === "full-text" &&
+        this.getCurrentScreeningDecision(parsed.reviewId, paperId, "title-abstract")?.decision !== "include"
+      ) {
+        throw new Error(`Paper must pass title/abstract screening before a full-text run: ${paperId}`);
+      }
+      if (parsed.stage === "extraction" && !this.isPaperEligibleForExtraction(parsed.reviewId, paperId)) {
+        throw new Error(`Paper must currently pass both screening stages before an extraction run: ${paperId}`);
+      }
+    }
+    this.withTransaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO review_runs (
+           id, review_id, project_id, protocol_revision_id, provider, model, stage, status,
+           selected_paper_ids_json, extraction_field_ids_json, total_items, completed_items, failed_items, cancelled_items,
+           error, started_at, completed_at, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           status = excluded.status,
+           completed_items = excluded.completed_items,
+           failed_items = excluded.failed_items,
+           cancelled_items = excluded.cancelled_items,
+           error = excluded.error,
+           started_at = excluded.started_at,
+           completed_at = excluded.completed_at,
+           updated_at = excluded.updated_at`
+        )
+        .run(
+          parsed.id,
+          parsed.reviewId,
+          review.projectId,
+          parsed.protocolRevisionId,
+          parsed.provider,
+          parsed.model,
+          parsed.stage,
+          parsed.status,
+          JSON.stringify(parsed.paperIds),
+          JSON.stringify(parsed.fieldIds),
+          parsed.paperIds.length,
+          parsed.completedCount,
+          parsed.failedCount,
+          parsed.cancelledCount,
+          parsed.error ?? null,
+          parsed.startedAt ?? null,
+          parsed.completedAt ?? null,
+          parsed.createdAt,
+          parsed.updatedAt
+        );
+    });
+    return this.getReviewRun(parsed.id)!;
+  }
+
+  getReviewRun(runId: string): ReviewRun | undefined {
+    const row = this.db.prepare("SELECT * FROM review_runs WHERE id = ?").get(runId) as Row | undefined;
+    return row ? this.reviewRunFromRow(row) : undefined;
+  }
+
+  listReviewRuns(reviewId: string): ReviewRun[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM review_runs WHERE review_id = ? ORDER BY created_at DESC, id DESC")
+        .all(reviewId) as Row[]
+    ).map((row) => this.reviewRunFromRow(row));
+  }
+
+  markInterruptedReviewRuns(): number {
+    const rows = this.db
+      .prepare("SELECT id, review_id, project_id FROM review_runs WHERE status IN ('queued', 'running')")
+      .all() as Row[];
+    if (!rows.length) return 0;
+    const updatedAt = nowIso();
+    const error = "Interrupted because Paper Pilot restarted before this review run completed.";
+    this.transaction(() => {
+      for (const row of rows) {
+        this.db
+          .prepare(
+            `UPDATE review_run_items
+             SET status = 'cancelled', error = COALESCE(error, ?), completed_at = ?, updated_at = ?
+             WHERE run_id = ? AND status IN ('queued', 'running')`
+          )
+          .run(error, updatedAt, updatedAt, String(row.id));
+        this.db
+          .prepare(
+            `UPDATE review_runs
+             SET status = 'failed', error = ?, completed_at = ?, updated_at = ?
+             WHERE id = ?`
+          )
+          .run(error, updatedAt, updatedAt, String(row.id));
+        this.insertReviewAuditEvent({
+          reviewId: String(row.review_id),
+          projectId: String(row.project_id),
+          actor: "system",
+          action: "run-cancelled",
+          entityType: "review-run",
+          entityId: String(row.id),
+          payload: { interruptedByRestart: true },
+          createdAt: updatedAt
+        });
+      }
+    });
+    return rows.length;
+  }
+
+  updateReviewRun(
+    runId: string,
+    patch: Partial<
+      Pick<
+        ReviewRun,
+        "status" | "completedCount" | "failedCount" | "cancelledCount" | "error" | "startedAt" | "completedAt"
+      >
+    >
+  ): ReviewRun {
+    const current = this.getReviewRun(runId);
+    if (!current) throw new Error(`Review run not found: ${runId}`);
+    return this.saveReviewRun({ ...current, ...patch, updatedAt: nowIso() });
+  }
+
+  saveReviewRunItem(item: ReviewRunItem): ReviewRunItem {
+    const parsed = reviewRunItemSchema.parse(item);
+    const run = this.getReviewRun(parsed.runId);
+    if (!run) throw new Error(`Review run not found: ${parsed.runId}`);
+    const review = this.getReviewById(run.reviewId)!;
+    const paper = this.getPaper(review.projectId, parsed.paperId);
+    if (!paper) throw new Error(`Paper not found in review project: ${parsed.paperId}`);
+    const existingById = this.db
+      .prepare("SELECT run_id, review_id, paper_id FROM review_run_items WHERE id = ?")
+      .get(parsed.id) as Row | undefined;
+    if (
+      existingById &&
+      (String(existingById.run_id) !== parsed.runId ||
+        String(existingById.review_id) !== run.reviewId ||
+        String(existingById.paper_id) !== parsed.paperId)
+    ) {
+      throw new Error(`Review run item identity does not match its run and paper: ${parsed.id}`);
+    }
+    const existingCell = this.db
+      .prepare("SELECT id FROM review_run_items WHERE run_id = ? AND paper_id = ?")
+      .get(parsed.runId, parsed.paperId) as Row | undefined;
+    if (existingCell && String(existingCell.id) !== parsed.id) {
+      throw new Error(`A review run item already exists for paper: ${parsed.paperId}`);
+    }
+    const recommendation = {
+      suggestedDecision: parsed.suggestedDecision,
+      suggestedReasonCriterionId: parsed.suggestedReasonCriterionId,
+      suggestedCustomReason: parsed.suggestedCustomReason,
+      rationale: parsed.rationale,
+      criterionAssessments: parsed.criterionAssessments,
+      extractionSuggestions: parsed.extractionSuggestions
+    };
+    const stale =
+      run.protocolRevisionId !== review.currentRevisionId ||
+      (run.stage === "full-text" &&
+        this.getCurrentScreeningDecision(run.reviewId, parsed.paperId, "title-abstract")?.decision !== "include") ||
+      (run.stage === "extraction" && !this.isPaperEligibleForExtraction(run.reviewId, parsed.paperId));
+    this.withTransaction(() => {
+      this.db
+        .prepare(
+          `INSERT INTO review_run_items (
+             id, run_id, review_id, paper_id, paper_snapshot_json, status,
+             recommendation_json, attempts, stale, error, started_at, completed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             status = excluded.status,
+             recommendation_json = excluded.recommendation_json,
+             attempts = excluded.attempts,
+             stale = excluded.stale,
+             error = excluded.error,
+             started_at = excluded.started_at,
+             completed_at = excluded.completed_at,
+             updated_at = excluded.updated_at`
+        )
+        .run(
+          parsed.id,
+          parsed.runId,
+          run.reviewId,
+          parsed.paperId,
+          JSON.stringify(paper),
+          parsed.status,
+          JSON.stringify(recommendation),
+          parsed.attemptCount,
+          stale ? 1 : 0,
+          parsed.error ?? null,
+          parsed.startedAt ?? null,
+          parsed.completedAt ?? null,
+          parsed.createdAt,
+          parsed.updatedAt
+        );
+      const suppliedEvidenceIds = new Set(parsed.evidence.map((evidence) => evidence.id));
+      for (const evidence of parsed.evidence) {
+        if (evidence.paperId && evidence.paperId !== parsed.paperId) {
+          throw new Error("Review run item evidence must belong to the selected paper.");
+        }
+        this.saveReviewEvidence({
+          ...evidence,
+          reviewId: run.reviewId,
+          runId: run.id,
+          runItemId: parsed.id,
+          paperId: parsed.paperId
+        });
+      }
+      const existingEvidence = this.listReviewEvidence(run.reviewId, { runItemId: parsed.id });
+      for (const evidence of existingEvidence) {
+        if (!suppliedEvidenceIds.has(evidence.id))
+          this.db.prepare("DELETE FROM review_evidence WHERE id = ?").run(evidence.id);
+      }
+      if (stale) {
+        this.markExtractionValuesNeedsReview("run_item_id = ?", [parsed.id], parsed.updatedAt);
+      }
+    });
+    return this.getReviewRunItem(parsed.id)!;
+  }
+
+  getReviewRunItem(itemId: string): ReviewRunItem | undefined {
+    const row = this.db.prepare("SELECT * FROM review_run_items WHERE id = ?").get(itemId) as Row | undefined;
+    return row ? this.reviewRunItemFromRow(row) : undefined;
+  }
+
+  listReviewRunItems(runId: string): ReviewRunItem[] {
+    return (
+      this.db.prepare("SELECT * FROM review_run_items WHERE run_id = ? ORDER BY rowid ASC").all(runId) as Row[]
+    ).map((row) => this.reviewRunItemFromRow(row));
+  }
+
+  updateReviewRunItem(
+    itemId: string,
+    patch: Partial<Omit<ReviewRunItem, "id" | "runId" | "paperId" | "createdAt">>
+  ): ReviewRunItem {
+    const current = this.getReviewRunItem(itemId);
+    if (!current) throw new Error(`Review run item not found: ${itemId}`);
+    return this.saveReviewRunItem({ ...current, ...patch, updatedAt: nowIso() });
+  }
+
+  appendReviewAuditEvent(
+    input: Omit<ReviewAuditEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }
+  ): ReviewAuditEvent {
+    const review = this.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const event = reviewAuditEventSchema.parse({
+      ...input,
+      id: input.id ?? id("audit"),
+      createdAt: input.createdAt ?? nowIso()
+    });
+    this.insertReviewAuditEvent({
+      reviewId: event.reviewId,
+      projectId: review.projectId,
+      actor: event.actor,
+      action: event.kind,
+      entityType: event.entityType,
+      entityId: event.entityId,
+      payload: event.payload,
+      createdAt: event.createdAt,
+      id: event.id
+    });
+    return event;
+  }
+
+  listReviewAuditEvents(reviewId: string): ReviewAuditEvent[] {
+    return (
+      this.db
+        .prepare("SELECT * FROM review_audit_events WHERE review_id = ? ORDER BY created_at ASC, rowid ASC")
+        .all(reviewId) as Row[]
+    ).map((row) => this.reviewAuditEventFromRow(row));
+  }
+
+  getReviewFlowSummary(reviewId: string): ReviewFlowSummary {
+    const review = this.getReviewById(reviewId);
+    if (!review) throw new Error(`Review not found: ${reviewId}`);
+    const batchTotals = this.db
+      .prepare(
+        `SELECT
+           COALESCE(SUM(identified_count), 0) AS identified,
+           COALESCE(SUM(filtered_count), 0) AS filtered,
+           COALESCE(SUM(invalid_count), 0) AS invalid,
+           COALESCE(SUM(duplicate_count), 0) AS duplicates,
+           COALESCE(SUM(merged_count), 0) AS merged,
+           COALESCE(SUM(new_records_count), 0) AS new_records,
+           COUNT(*) AS batch_count,
+           MIN(historical_counts_available) AS historical_counts_available
+         FROM discovery_batches WHERE review_id = ?`
+      )
+      .get(reviewId) as Row;
+    const currentDecisions = this.currentScreeningDecisionRows(reviewId);
+    const abstractDecisions = currentDecisions.filter((decision) => decision.stage === "title-abstract");
+    const fullTextsSoughtIds = new Set(
+      abstractDecisions.filter((decision) => decision.decision === "include").map((decision) => decision.paperId)
+    );
+    const staleFullTextPaperIds = new Set(
+      (
+        this.db
+          .prepare(
+            `SELECT COALESCE(paper_id, json_extract(paper_snapshot_json, '$.id')) AS paper_identity
+             FROM review_rereview_flags
+             WHERE review_id = ? AND stage = 'full-text' AND invalidates_downstream = 1 AND resolved_at IS NULL`
+          )
+          .all(reviewId) as Row[]
+      ).map((row) => String(row.paper_identity))
+    );
+    const fullTextDecisions = currentDecisions.filter(
+      (decision) =>
+        decision.stage === "full-text" &&
+        fullTextsSoughtIds.has(decision.paperId) &&
+        !staleFullTextPaperIds.has(decision.paperId)
+    );
+    const availableFullTextIds = new Set(
+      (
+        this.db
+          .prepare(
+            `SELECT DISTINCT chunk.paper_id
+             FROM document_chunks chunk
+             JOIN artifacts artifact ON artifact.id = chunk.artifact_id AND artifact.project_id = chunk.project_id
+             WHERE chunk.project_id = ?
+               AND chunk.paper_id IS NOT NULL
+               AND length(trim(chunk.text)) > 0
+               AND artifact.type IN ('paper-pdf', 'markdown', 'table')
+               AND COALESCE(artifact.source, '') != 'research-chat'
+               AND json_extract(artifact.metadata_json, '$.paperId') = chunk.paper_id`
+          )
+          .all(review.projectId) as Row[]
+      ).map((row) => String(row.paper_id))
+    );
+    const exclusionsByReason: Record<string, number> = {};
+    for (const decision of fullTextDecisions.filter((candidate) => candidate.decision === "exclude")) {
+      const reason = decision.reasonCriterionId
+        ? (this.listReviewCriteria(reviewId, decision.protocolRevisionId).find(
+            (criterion) => criterion.id === decision.reasonCriterionId
+          )?.label ?? "Unknown criterion")
+        : (decision.customReason ?? "Custom reason");
+      exclusionsByReason[reason] = (exclusionsByReason[reason] ?? 0) + 1;
+    }
+    const includedPaperIds = new Set(
+      fullTextDecisions.filter((decision) => decision.decision === "include").map((decision) => decision.paperId)
+    );
+    const fieldCount = this.listExtractionFields(reviewId).length;
+    const extractionRows = this.listExtractionValues(reviewId).filter((value) => includedPaperIds.has(value.paperId));
+    const totalCells = includedPaperIds.size * fieldCount;
+    const confirmedCells = extractionRows.filter((value) => value.status === "confirmed").length;
+    const notFoundCells = extractionRows.filter((value) => value.status === "not-found").length;
+    const needsReviewStatuses = new Set<ExtractionValue["status"]>(["suggested", "rejected", "needs-review"]);
+    const needsReviewCells = extractionRows.filter((value) => needsReviewStatuses.has(value.status)).length;
+    const completedCells = confirmedCells + notFoundCells;
+    const historicalCountsAvailable =
+      review.historicalCountsAvailable &&
+      (Number(batchTotals.batch_count ?? 0) === 0 || Boolean(batchTotals.historical_counts_available));
+    return reviewFlowSummarySchema.parse({
+      reviewId,
+      identifiedRecords: Number(batchTotals.identified ?? 0),
+      filteredRecords: Number(batchTotals.filtered ?? 0),
+      invalidRecords: Number(batchTotals.invalid ?? 0),
+      duplicateRecords: Number(batchTotals.duplicates ?? 0),
+      mergedRecords: Number(batchTotals.merged ?? 0),
+      newRecords: Number(batchTotals.new_records ?? 0),
+      uniqueRecordsScreened: new Set(abstractDecisions.map((decision) => decision.paperId)).size,
+      titleAbstractExclusions: abstractDecisions.filter((decision) => decision.decision === "exclude").length,
+      fullTextsSought: fullTextsSoughtIds.size,
+      fullTextsUnavailable: [...fullTextsSoughtIds].filter((paperId) => !availableFullTextIds.has(paperId)).length,
+      fullTextExclusionsByReason: exclusionsByReason,
+      includedPapers: includedPaperIds.size,
+      extraction: {
+        totalCells,
+        confirmedCells,
+        notFoundCells,
+        needsReviewCells,
+        completionPercent: totalCells ? Math.round((completedCells / totalCells) * 10_000) / 100 : 0
+      },
+      historicalCountsAvailable,
+      warnings: historicalCountsAvailable ? [] : ["Historical discovery and duplicate counts are unavailable."],
+      generatedAt: nowIso()
+    });
+  }
+
+  findPaperLinkedArtifactChunks(projectId: string, paperId: string, limit = 100): ChunkSearchRow[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT
+             dc.id AS chunkId,
+             dc.project_id AS projectId,
+             p.title AS projectTitle,
+             dc.artifact_id AS artifactId,
+             a.title AS artifactTitle,
+             a.type AS artifactType,
+             a.created_at AS artifactCreatedAt,
+             dc.paper_id AS paperId,
+             pp.title AS paperTitle,
+             dc.text,
+             dc.metadata_json AS metadataJson,
+             substr(dc.text, 1, 240) AS snippet,
+             1.0 AS score
+         FROM document_chunks dc
+         JOIN projects p ON p.id = dc.project_id
+         JOIN artifacts a ON a.id = dc.artifact_id
+         LEFT JOIN papers pp ON pp.id = dc.paper_id
+         WHERE dc.project_id = ? AND dc.paper_id = ? AND length(trim(dc.text)) > 0
+         ORDER BY dc.ordinal ASC LIMIT ?`
+        )
+        .all(projectId, paperId, Math.max(1, Math.min(limit, 500))) as Row[]
+    ).map((row) => this.chunkSearchFromRow(row));
   }
 
   createConversation(projectId: string, title = "New chat", mode: ChatMode = "grounded"): Conversation {
@@ -823,10 +3678,11 @@ export class PaperPilotDb {
   savePaper(projectId: string, paperInput: Paper): Paper {
     const paper = paperSchema.parse({ ...paperInput, projectId });
     const createdAt = nowIso();
-    const dedupeKey = paperDedupeKey(paper);
-    const normalizedTitle = dedupeKey.startsWith("title:") ? dedupeKey.slice(6) : paper.title.toLowerCase();
+    const paperId = paper.id || id("paper");
+    const dedupeKey = paperIdentityDedupeKey({ ...paper, id: paperId });
+    const normalizedTitle = normalizeBibliographicTitle(paper.title);
     const row = {
-      id: paper.id || id("paper"),
+      id: paperId,
       projectId,
       dedupeKey,
       title: paper.title,
@@ -894,6 +3750,12 @@ export class PaperPilotDb {
       .map((row) => this.paperFromRow(row as Row));
   }
 
+  getPaper(projectId: string, paperId: string): Paper | undefined {
+    const row = this.db.prepare("SELECT * FROM papers WHERE project_id = ? AND id = ?").get(projectId, paperId) as
+      Row | undefined;
+    return row ? this.paperFromRow(row) : undefined;
+  }
+
   listAllPapers(): Paper[] {
     return this.db
       .prepare(
@@ -924,8 +3786,8 @@ export class PaperPilotDb {
     if (!currentRow) throw new Error(`Paper not found: ${paperId}`);
     const current = this.paperFromRow(currentRow);
     const next = paperSchema.parse({ ...current, ...patch, projectId, id: paperId });
-    const dedupeKey = paperDedupeKey(next);
-    const normalizedTitle = dedupeKey.startsWith("title:") ? dedupeKey.slice(6) : next.title.toLowerCase();
+    const dedupeKey = paperIdentityDedupeKey(next);
+    const normalizedTitle = normalizeBibliographicTitle(next.title);
     const updatedAt = nowIso();
     this.db
       .prepare(
@@ -940,6 +3802,8 @@ export class PaperPilotDb {
           doi = @doi,
           url = @url,
           pdf_url = @pdfUrl,
+          source = @source,
+          source_paper_id = @sourcePaperId,
           venue = @venue,
           citation_count = @citationCount,
           is_open_access = @isOpenAccess,
@@ -949,6 +3813,7 @@ export class PaperPilotDb {
           user_status = @userStatus,
           tags_json = @tagsJson,
           notes = @notes,
+          raw_json = @rawJson,
           updated_at = @updatedAt
          WHERE project_id = @projectId AND id = @paperId`
       )
@@ -965,6 +3830,8 @@ export class PaperPilotDb {
         doi: next.doi ?? null,
         url: next.url ?? null,
         pdfUrl: next.pdfUrl ?? null,
+        source: next.source,
+        sourcePaperId: next.sourcePaperId ?? null,
         venue: next.venue ?? null,
         citationCount: next.citationCount ?? null,
         isOpenAccess: next.isOpenAccess ? 1 : 0,
@@ -974,6 +3841,7 @@ export class PaperPilotDb {
         userStatus: next.userStatus ?? "unread",
         tagsJson: JSON.stringify(next.tags ?? []),
         notes: next.notes ?? null,
+        rawJson: JSON.stringify(next.raw ?? {}),
         updatedAt
       });
     const row = this.db.prepare("SELECT * FROM papers WHERE project_id = ? AND id = ?").get(projectId, paperId) as
@@ -1493,6 +4361,603 @@ export class PaperPilotDb {
     return merged;
   }
 
+  private withTransaction<T>(operation: () => T): T {
+    return this.transaction(operation);
+  }
+
+  private insertReviewCriteria(
+    reviewId: string,
+    revisionId: string,
+    criteria: Array<{
+      id?: string;
+      stage: "title-abstract" | "full-text";
+      type: "inclusion" | "exclusion";
+      label: string;
+      description?: string;
+      order?: number;
+    }>,
+    createdAt: string
+  ): void {
+    const requestIds = new Set<string>();
+    const stageOrders = new Set<string>();
+    for (const [index, criterion] of criteria.entries()) {
+      if (criterion.id) {
+        if (requestIds.has(criterion.id)) throw new Error(`Duplicate review criterion request ID: ${criterion.id}`);
+        requestIds.add(criterion.id);
+      }
+      const order = criterion.order ?? index;
+      const stageOrder = `${criterion.stage}:${criterion.type}:${order}`;
+      if (stageOrders.has(stageOrder)) {
+        throw new Error(`Duplicate ${criterion.type} criterion order ${order} for stage ${criterion.stage}.`);
+      }
+      stageOrders.add(stageOrder);
+    }
+    const insert = this.db.prepare(
+      `INSERT INTO review_criteria (
+         id, review_id, protocol_revision_id, stage, kind, label, description, ordinal, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    criteria.forEach((criterion, index) => {
+      const parsed = reviewCriterionSchema.parse({
+        id: id("criterion"),
+        stage: criterion.stage,
+        type: criterion.type,
+        label: criterion.label,
+        description: criterion.description,
+        order: criterion.order ?? index
+      });
+      insert.run(
+        parsed.id,
+        reviewId,
+        revisionId,
+        parsed.stage,
+        parsed.type,
+        parsed.label,
+        parsed.description ?? null,
+        parsed.order,
+        createdAt
+      );
+    });
+  }
+
+  private insertReviewAuditEvent(input: {
+    id?: string;
+    reviewId: string;
+    projectId: string;
+    actor: "user" | "system" | "ai";
+    action: string;
+    entityType?: string;
+    entityId?: string;
+    payload?: Record<string, unknown>;
+    createdAt: string;
+  }): void {
+    this.db
+      .prepare(
+        `INSERT INTO review_audit_events (
+           id, review_id, project_id, actor, action, entity_type, entity_id, payload_json, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        input.id ?? id("audit"),
+        input.reviewId,
+        input.projectId,
+        input.actor,
+        input.action,
+        input.entityType ?? null,
+        input.entityId ?? null,
+        JSON.stringify(input.payload ?? {}),
+        input.createdAt
+      );
+  }
+
+  private reviewFromRow(row: Row): ReviewProtocol {
+    return reviewProtocolSchema.parse({
+      id: row.id,
+      projectId: row.project_id,
+      template: row.template,
+      currentRevisionId: row.current_protocol_revision_id,
+      currentRevisionNumber: Number(row.current_revision_number),
+      historicalCountsAvailable: Boolean(row.historical_counts_available),
+      activatedAt: row.activated_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    });
+  }
+
+  private reviewProtocolRevisionFromRow(row: Row): ReviewProtocolRevision {
+    return reviewProtocolRevisionSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      version: Number(row.revision),
+      researchQuestion: row.research_question,
+      objectives: parseJson<string[]>(row.objectives_json, []),
+      criteria: this.listReviewCriteria(String(row.review_id), String(row.id)),
+      changeNote: row.note ?? undefined,
+      createdAt: row.created_at
+    });
+  }
+
+  private reviewCriterionFromRow(row: Row): ReviewCriterion {
+    return reviewCriterionSchema.parse({
+      id: row.id,
+      stage: row.stage,
+      type: row.kind,
+      label: row.label,
+      description: row.description ?? undefined,
+      order: Number(row.ordinal)
+    });
+  }
+
+  private discoveryBatchFromRow(row: Row): DiscoveryBatch {
+    return discoveryBatchSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      kind: row.kind,
+      label: row.label,
+      sourceId: row.source ?? undefined,
+      fileName: row.file_name ?? undefined,
+      importFormat: row.import_format ?? undefined,
+      status: row.status,
+      counts: {
+        identified: Number(row.identified_count ?? 0),
+        filtered: Number(row.filtered_count ?? 0),
+        invalid: Number(row.invalid_count ?? 0),
+        duplicates: Number(row.duplicate_count ?? 0),
+        merged: Number(row.merged_count ?? 0),
+        newRecords: Number(row.new_records_count ?? 0)
+      },
+      historicalCountsAvailable: Boolean(row.historical_counts_available),
+      createdAt: row.created_at,
+      completedAt: row.completed_at ?? undefined,
+      error: row.error ?? undefined
+    });
+  }
+
+  private reviewCandidateOriginFromRow(row: Row): ReviewCandidateOrigin {
+    const paperSnapshot = parseJson<Record<string, unknown>>(row.paper_snapshot_json, {});
+    return {
+      id: String(row.id),
+      reviewId: String(row.review_id),
+      batchId: String(row.batch_id),
+      paperId: optionalString(row.paper_id) ?? optionalString(paperSnapshot.id),
+      matchedPaperId: optionalString(row.matched_paper_id),
+      sourceRecordId: optionalString(row.source_record_id),
+      resolution: row.resolution as ReviewCandidateOrigin["resolution"],
+      paperSnapshot,
+      recordSnapshot: parseJson<Record<string, unknown>>(row.record_snapshot_json, {}),
+      createdAt: String(row.created_at)
+    };
+  }
+
+  private screeningDecisionFromRow(row: Row): ScreeningDecision {
+    const paperSnapshot = parseJson<Record<string, unknown>>(row.paper_snapshot_json, {});
+    return screeningDecisionSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      paperId: row.paper_id ?? paperSnapshot.id,
+      stage: row.stage,
+      decision: row.decision,
+      protocolRevisionId: row.protocol_revision_id,
+      reasonCriterionId: row.reason_criterion_id ?? undefined,
+      customReason: row.custom_reason ?? undefined,
+      runItemId: row.run_item_id ?? undefined,
+      previousDecisionId: row.supersedes_decision_id ?? undefined,
+      createdAt: row.created_at
+    });
+  }
+
+  private extractionFieldFromRow(row: Row): ExtractionField {
+    return extractionFieldSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      name: row.name,
+      description: row.description ?? undefined,
+      type: row.field_type,
+      options: parseJson<string[]>(row.options_json, []),
+      order: Number(row.ordinal),
+      revision: Number(row.revision),
+      active: Boolean(row.active),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    });
+  }
+
+  private extractionFieldFromRevisionRow(row: Row): ExtractionField {
+    return extractionFieldSchema.parse({
+      id: row.field_id,
+      reviewId: row.review_id,
+      name: row.name,
+      description: row.description ?? undefined,
+      type: row.field_type,
+      options: parseJson<string[]>(row.options_json, []),
+      order: Number(row.ordinal),
+      revision: Number(row.revision),
+      active: Boolean(row.active),
+      createdAt: row.recorded_at,
+      updatedAt: row.recorded_at
+    });
+  }
+
+  private extractionValueFromRow(row: Row): ExtractionValue {
+    const snapshot = parseJson<Record<string, unknown>>(row.paper_snapshot_json, {});
+    return extractionValueSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      paperId: row.paper_id ?? snapshot.id,
+      fieldId: row.field_id,
+      fieldRevision: Number(row.field_revision),
+      value: parseJson<ExtractionValue["value"]>(row.value_json, null),
+      status: row.status,
+      origin: row.provenance,
+      evidenceIds: this.listEvidenceIdsForValue(String(row.id)),
+      runItemId: row.run_item_id ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      confirmedAt: row.confirmed_at ?? undefined
+    });
+  }
+
+  private extractionValueHistoryFromRow(row: Row): ExtractionValueHistoryEntry {
+    const paperSnapshot = parseJson<Record<string, unknown>>(row.paper_snapshot_json, {});
+    return {
+      ...extractionValueSchema.parse({
+        id: row.value_id,
+        reviewId: row.review_id,
+        paperId: row.paper_id ?? paperSnapshot.id,
+        fieldId: row.field_id,
+        fieldRevision: Number(row.field_revision),
+        value: parseJson<ExtractionValue["value"]>(row.value_json, null),
+        status: row.status,
+        origin: row.provenance,
+        evidenceIds: parseJson<string[]>(row.evidence_ids_json, []),
+        runItemId: row.run_item_id ?? undefined,
+        createdAt: row.recorded_at,
+        updatedAt: row.recorded_at,
+        confirmedAt: row.confirmed_at ?? undefined
+      }),
+      changeRevision: Number(row.change_revision),
+      paperSnapshot,
+      recordedAt: String(row.recorded_at)
+    };
+  }
+
+  private listEvidenceIdsForValue(valueId: string): string[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT evidence.id
+           FROM review_extraction_value_evidence link
+           JOIN review_evidence evidence ON evidence.id = link.evidence_id
+           WHERE link.value_id = ? ORDER BY evidence.created_at, evidence.id`
+        )
+        .all(valueId) as Row[]
+    ).map((row) => String(row.id));
+  }
+
+  private reviewEvidenceFromRow(row: Row): ReviewEvidence {
+    return reviewEvidenceSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      evidenceId: row.evidence_id,
+      runId: row.run_id ?? undefined,
+      runItemId: row.run_item_id ?? undefined,
+      paperId: row.paper_id ?? undefined,
+      artifactId: row.artifact_id ?? undefined,
+      chunkId: row.chunk_id ?? undefined,
+      sourceType: row.source_type,
+      title: row.title,
+      excerpt: row.excerpt,
+      locator: row.locator ?? undefined,
+      page: row.page == null ? undefined : Number(row.page),
+      doi: row.doi ?? undefined,
+      url: row.url ?? undefined,
+      retrievalScore: row.retrieval_score == null ? undefined : Number(row.retrieval_score),
+      createdAt: row.created_at
+    });
+  }
+
+  private reviewRunFromRow(row: Row): ReviewRun {
+    return reviewRunSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      stage: row.stage,
+      provider: row.provider,
+      model: row.model,
+      protocolRevisionId: row.protocol_revision_id,
+      status: row.status,
+      paperIds: parseJson<string[]>(row.selected_paper_ids_json, []),
+      fieldIds: parseJson<string[]>(row.extraction_field_ids_json, []),
+      completedCount: Number(row.completed_items ?? 0),
+      failedCount: Number(row.failed_items ?? 0),
+      cancelledCount: Number(row.cancelled_items ?? 0),
+      error: row.error ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      startedAt: row.started_at ?? undefined,
+      completedAt: row.completed_at ?? undefined
+    });
+  }
+
+  private reviewRunItemFromRow(row: Row): ReviewRunItem {
+    const snapshot = parseJson<Record<string, unknown>>(row.paper_snapshot_json, {});
+    const recommendation = parseJson<Record<string, unknown>>(row.recommendation_json, {});
+    return reviewRunItemSchema.parse({
+      id: row.id,
+      runId: row.run_id,
+      paperId: row.paper_id ?? snapshot.id,
+      status: row.status,
+      attemptCount: Number(row.attempts ?? 0),
+      suggestedDecision: recommendation.suggestedDecision,
+      suggestedReasonCriterionId: recommendation.suggestedReasonCriterionId,
+      suggestedCustomReason: recommendation.suggestedCustomReason,
+      rationale: recommendation.rationale,
+      criterionAssessments: recommendation.criterionAssessments ?? [],
+      extractionSuggestions: recommendation.extractionSuggestions ?? [],
+      evidence: this.listReviewEvidence(String(row.review_id), { runItemId: String(row.id) }),
+      stale: Boolean(row.stale),
+      error: row.error ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      startedAt: row.started_at ?? undefined,
+      completedAt: row.completed_at ?? undefined
+    });
+  }
+
+  private reviewAuditEventFromRow(row: Row): ReviewAuditEvent {
+    return reviewAuditEventSchema.parse({
+      id: row.id,
+      reviewId: row.review_id,
+      kind: row.action,
+      actor: row.actor,
+      entityType: row.entity_type ?? undefined,
+      entityId: row.entity_id ?? undefined,
+      payload: parseJson<Record<string, unknown>>(row.payload_json, {}),
+      createdAt: row.created_at
+    });
+  }
+
+  private currentScreeningDecisionRows(reviewId: string): ScreeningDecision[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT * FROM (
+           SELECT d.*, ROW_NUMBER() OVER (
+             PARTITION BY COALESCE(d.paper_id, json_extract(d.paper_snapshot_json, '$.id')), d.stage
+             ORDER BY d.created_at DESC, d.rowid DESC
+           ) AS decision_rank
+           FROM review_screening_decisions d WHERE d.review_id = ?
+         ) WHERE decision_rank = 1`
+        )
+        .all(reviewId) as Row[]
+    ).map((row) => this.screeningDecisionFromRow(row));
+  }
+
+  private reviewPaperSnapshot(value: unknown): Record<string, unknown> | undefined {
+    const snapshot =
+      typeof value === "string"
+        ? parseJson<Record<string, unknown>>(value, {})
+        : value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : {};
+    return Object.keys(snapshot).length ? { ...snapshot } : undefined;
+  }
+
+  private reviewPaperIdentity(paperId: unknown, snapshotJson: unknown): string | undefined {
+    return optionalString(paperId) ?? optionalString(this.reviewPaperSnapshot(snapshotJson)?.id);
+  }
+
+  private isTrustedReviewArtifactChunk(
+    projectId: string,
+    artifactId: string,
+    chunkId: string,
+    paperId: string
+  ): boolean {
+    return Boolean(
+      this.db
+        .prepare(
+          `SELECT 1
+           FROM document_chunks chunk
+           JOIN artifacts artifact ON artifact.id = chunk.artifact_id AND artifact.project_id = chunk.project_id
+           WHERE chunk.project_id = ? AND chunk.artifact_id = ? AND chunk.id = ?
+             AND chunk.paper_id = ?
+             AND length(trim(chunk.text)) > 0
+             AND artifact.type IN ('paper-pdf', 'markdown', 'table')
+             AND COALESCE(artifact.source, '') != 'research-chat'
+             AND json_extract(artifact.metadata_json, '$.paperId') = ?
+           LIMIT 1`
+        )
+        .get(projectId, artifactId, chunkId, paperId, paperId)
+    );
+  }
+
+  private hasOpenFullTextRereviewFlag(reviewId: string, paperId: string): boolean {
+    return Boolean(
+      this.db
+        .prepare(
+          `SELECT 1 FROM review_rereview_flags
+           WHERE review_id = ? AND stage = 'full-text' AND resolved_at IS NULL
+             AND invalidates_downstream = 1
+             AND COALESCE(paper_id, json_extract(paper_snapshot_json, '$.id')) = ?
+           LIMIT 1`
+        )
+        .get(reviewId, paperId)
+    );
+  }
+
+  private isPaperEligibleForExtraction(reviewId: string, paperId: string): boolean {
+    return (
+      this.getCurrentScreeningDecision(reviewId, paperId, "title-abstract")?.decision === "include" &&
+      this.getCurrentScreeningDecision(reviewId, paperId, "full-text")?.decision === "include" &&
+      !this.hasOpenFullTextRereviewFlag(reviewId, paperId)
+    );
+  }
+
+  private invalidateDownstreamReviewState(
+    reviewId: string,
+    paperId: string,
+    paperSnapshot: Paper,
+    createdAt: string
+  ): void {
+    const review = this.getReviewById(reviewId)!;
+    const fullTextDecision = this.getCurrentScreeningDecision(reviewId, paperId, "full-text");
+    if (fullTextDecision && !this.hasOpenFullTextRereviewFlag(reviewId, paperId)) {
+      this.db
+        .prepare(
+          `INSERT INTO review_rereview_flags (
+             id, review_id, paper_id, paper_snapshot_json, stage, protocol_revision_id,
+             invalidates_downstream, created_at
+           ) VALUES (?, ?, ?, ?, 'full-text', ?, 1, ?)`
+        )
+        .run(id("rereview"), reviewId, paperId, JSON.stringify(paperSnapshot), review.currentRevisionId, createdAt);
+      this.insertReviewAuditEvent({
+        reviewId,
+        projectId: review.projectId,
+        actor: "system",
+        action: "decision-marked-for-review",
+        entityType: "screening-decision",
+        entityId: fullTextDecision.id,
+        payload: { paperId, stage: "full-text", cause: "title-abstract-no-longer-included" },
+        createdAt
+      });
+    }
+    this.db
+      .prepare(
+        `UPDATE review_run_items
+         SET stale = 1, updated_at = ?
+         WHERE review_id = ?
+           AND COALESCE(paper_id, json_extract(paper_snapshot_json, '$.id')) = ?
+           AND EXISTS (
+             SELECT 1 FROM review_runs run
+             WHERE run.id = review_run_items.run_id AND run.stage IN ('full-text', 'extraction')
+           )`
+      )
+      .run(createdAt, reviewId, paperId);
+    this.markExtractionValuesNeedsReview(
+      "review_id = ? AND COALESCE(paper_id, json_extract(paper_snapshot_json, '$.id')) = ?",
+      [reviewId, paperId],
+      createdAt
+    );
+  }
+
+  private markExtractionValuesNeedsReview(
+    condition: string,
+    parameters: Array<string | number>,
+    updatedAt: string,
+    fieldRevision?: number
+  ): void {
+    const rows = this.db.prepare(`SELECT * FROM extraction_values WHERE ${condition}`).all(...parameters) as Row[];
+    for (const row of rows) {
+      if (String(row.status) === "rejected") continue;
+      const nextFieldRevision = fieldRevision ?? Number(row.field_revision);
+      if (String(row.status) !== "needs-review" || Number(row.field_revision) !== nextFieldRevision) {
+        this.db
+          .prepare(
+            `UPDATE extraction_values
+             SET status = 'needs-review', field_revision = ?, confirmed_at = NULL, updated_at = ?
+             WHERE id = ?`
+          )
+          .run(nextFieldRevision, updatedAt, String(row.id));
+        this.recordExtractionValueRevision(String(row.id), updatedAt);
+      }
+    }
+  }
+
+  private recordExtractionFieldRevision(field: ExtractionField, recordedAt: string): void {
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO extraction_field_revisions (
+           field_id, review_id, revision, name, description, field_type, options_json,
+           ordinal, active, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        field.id,
+        field.reviewId,
+        field.revision,
+        field.name,
+        field.description ?? null,
+        field.type,
+        JSON.stringify(field.options),
+        field.order,
+        field.active ? 1 : 0,
+        recordedAt
+      );
+  }
+
+  private recordExtractionValueRevision(valueId: string, recordedAt: string): void {
+    const row = this.db.prepare("SELECT * FROM extraction_values WHERE id = ?").get(valueId) as Row | undefined;
+    if (!row) return;
+    const evidenceIds = this.listEvidenceIdsForValue(valueId);
+    const latest = this.db
+      .prepare(
+        `SELECT * FROM extraction_value_revisions
+         WHERE value_id = ? ORDER BY change_revision DESC LIMIT 1`
+      )
+      .get(valueId) as Row | undefined;
+    if (
+      latest &&
+      Number(latest.field_revision) === Number(row.field_revision) &&
+      String(latest.value_json ?? "null") === String(row.value_json ?? "null") &&
+      String(latest.status) === String(row.status) &&
+      String(latest.provenance) === String(row.provenance) &&
+      optionalString(latest.run_item_id) === optionalString(row.run_item_id) &&
+      optionalString(latest.confirmed_at) === optionalString(row.confirmed_at) &&
+      JSON.stringify(parseJson<string[]>(latest.evidence_ids_json, [])) === JSON.stringify(evidenceIds)
+    ) {
+      return;
+    }
+    const changeRevision = latest ? Number(latest.change_revision) + 1 : 1;
+    this.db
+      .prepare(
+        `INSERT INTO extraction_value_revisions (
+           value_id, change_revision, review_id, field_id, field_revision, paper_id,
+           paper_snapshot_json, run_item_id, value_json, status, provenance,
+           evidence_ids_json, confirmed_at, recorded_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        valueId,
+        changeRevision,
+        String(row.review_id),
+        String(row.field_id),
+        Number(row.field_revision),
+        optionalString(row.paper_id) ?? null,
+        String(row.paper_snapshot_json),
+        optionalString(row.run_item_id) ?? null,
+        row.value_json == null ? null : String(row.value_json),
+        String(row.status),
+        String(row.provenance),
+        JSON.stringify(evidenceIds),
+        optionalString(row.confirmed_at) ?? null,
+        recordedAt
+      );
+  }
+
+  private assertExtractionValueMatchesField(
+    field: ExtractionField,
+    value: ExtractionValue["value"],
+    status: ExtractionValue["status"]
+  ): void {
+    if (status === "not-found") {
+      if (value !== null) throw new Error("Not-found extraction values must be null.");
+      return;
+    }
+    if (status === "confirmed" && isBlankExtractionValue(value)) {
+      throw new Error("Confirmed extraction values cannot be blank. Use Not found instead.");
+    }
+    if (value === null) return;
+    const invalid = () => new Error(`Extraction value does not match ${field.type} field ${field.name}.`);
+    if ((field.type === "short-text" || field.type === "long-text") && typeof value !== "string") throw invalid();
+    if (field.type === "number" && (typeof value !== "number" || !Number.isFinite(value))) throw invalid();
+    if (field.type === "boolean" && typeof value !== "boolean") throw invalid();
+    if (field.type === "single-select") {
+      if (typeof value !== "string" || !field.options.includes(value)) throw invalid();
+    }
+    if (field.type === "multi-select") {
+      if (!Array.isArray(value) || value.some((entry) => !field.options.includes(entry))) throw invalid();
+    }
+  }
+
   private loadVectorExtension(): void {
     try {
       this.db.enableLoadExtension(true);
@@ -1552,18 +5017,11 @@ export class PaperPilotDb {
           String(row.project_id)
         );
     };
-    if (!wrapTransaction) {
+    if (!wrapTransaction || this.transactionDepth > 0) {
       run();
       return;
     }
-    this.db.exec("BEGIN");
-    try {
-      run();
-      this.db.exec("COMMIT");
-    } catch (error) {
-      this.db.exec("ROLLBACK");
-      throw error;
-    }
+    this.transaction(run);
   }
 
   private projectFromRow(row: Row): Project {
@@ -1737,6 +5195,30 @@ function parseJsonRecord(value: unknown): Record<string, unknown> | undefined {
   } catch {
     return undefined;
   }
+}
+
+function parseJsonRecordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? { ...(value as Record<string, unknown>) } : {};
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== "string" || !value.trim()) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function paperIdentityDedupeKey(paper: PaperIdentityInput & { id: string }): string {
+  const forcedIdentity = paper.raw?.forceSeparateIdentity;
+  if (typeof forcedIdentity === "string" && forcedIdentity.trim()) return `record:${forcedIdentity.trim()}`;
+  return (
+    doiIdentityKey(paper) ??
+    sourceIdentifierIdentityKey(paper) ??
+    bibliographicFingerprint(paper) ??
+    `record:${paper.id}`
+  );
 }
 
 function parseJsonArray(value: unknown): string[] {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { PaperPilotDb } from "./db.js";
 import { registerIpc } from "./ipc.js";
+import { registerReviewIpc } from "./review-ipc.js";
 import { SourceRegistry } from "./sources/registry.js";
 import { AiService } from "./services/ai-service.js";
 import { ArtifactService } from "./services/artifact-service.js";
@@ -16,6 +17,8 @@ import { PaperScoringService } from "./services/paper-scoring-service.js";
 import { PythonService } from "./services/python-service.js";
 import { SearchService } from "./services/search-service.js";
 import { ResearchChatService } from "./services/research-chat-service.js";
+import { ReviewAgentService } from "./services/review-agent-service.js";
+import { ReviewImportManager } from "./services/review-import-manager.js";
 import { SettingsService } from "./services/settings-service.js";
 import { createUpdateService } from "./services/update-service.js";
 
@@ -119,6 +122,8 @@ app.whenReady().then(() => {
   );
   const ai = new AiService(db, settings, credentials, artifacts, jobs);
   const researchChat = new ResearchChatService(db, artifacts, settings, credentials, registry, crawl, ai, jobs);
+  const reviewImports = new ReviewImportManager(db);
+  const reviewAgent = new ReviewAgentService(db, settings, credentials);
   const updates = createUpdateService({
     currentVersion: app.getVersion(),
     isPackaged: app.isPackaged,
@@ -129,6 +134,7 @@ app.whenReady().then(() => {
     db,
     registry,
     researchChat,
+    reviewAgent,
     crawl,
     ai,
     artifacts,
@@ -140,6 +146,14 @@ app.whenReady().then(() => {
     search,
     updates,
     dataRoot
+  });
+  registerReviewIpc({
+    db,
+    imports: reviewImports,
+    agent: reviewAgent,
+    artifacts,
+    fullText,
+    settings
   });
   mainWindow = createWindow();
   mainWindow.on("closed", () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,13 +16,23 @@ import {
   conversationSchema,
   credentialUpsertSchema,
   crawlConfigSchema,
+  discoveryBatchSchema,
+  extractionFieldSchema,
+  extractionValueSchema,
   messageSchema,
   paperSchema,
   paperUpdateSchema,
   projectSchema,
   projectUpdateSchema,
   reindexRequestSchema,
+  reviewAuditEventSchema,
+  reviewEvidenceSchema,
+  reviewProtocolRevisionSchema,
+  reviewProtocolSchema,
+  reviewRunItemSchema,
+  reviewRunSchema,
   searchRequestSchema,
+  screeningDecisionSchema,
   startChatRunRequestSchema,
   type Artifact,
   type Citation,
@@ -42,6 +52,7 @@ import type { PaperScoringService } from "./services/paper-scoring-service.js";
 import type { PythonService } from "./services/python-service.js";
 import type { SearchService } from "./services/search-service.js";
 import type { ResearchChatService } from "./services/research-chat-service.js";
+import type { ReviewAgentService } from "./services/review-agent-service.js";
 import type { SettingsService } from "./services/settings-service.js";
 import type { UpdateService } from "./services/update-service.js";
 
@@ -52,6 +63,7 @@ export interface IpcServices {
   db: PaperPilotDb;
   registry: SourceRegistry;
   researchChat: ResearchChatService;
+  reviewAgent: ReviewAgentService;
   crawl: CrawlService;
   ai: AiService;
   artifacts: ArtifactService;
@@ -143,6 +155,9 @@ export function registerIpc(services: IpcServices): void {
     if (services.researchChat.isProjectActive(parsed.projectId)) {
       throw new Error("Stop active research responses before deleting this project.");
     }
+    if (services.reviewAgent.isProjectActive(parsed.projectId)) {
+      throw new Error("Stop the active evidence-review run before deleting this project.");
+    }
     services.db.deleteProject(parsed.projectId);
     await rm(projectDataPath(services.dataRoot, parsed.projectId), { recursive: true, force: true });
     return { ok: true };
@@ -154,6 +169,9 @@ export function registerIpc(services: IpcServices): void {
       .parse(input);
     const project = services.db.getProject(parsed.projectId);
     if (!project) throw new Error(`Project not found: ${parsed.projectId}`);
+    if (services.reviewAgent.isProjectActive(parsed.projectId)) {
+      throw new Error("Stop the active evidence-review run before duplicating this project.");
+    }
     return copyProject(services, parsed.projectId, parsed.title ?? `Copy of ${project.title}`);
   });
 
@@ -161,6 +179,9 @@ export function registerIpc(services: IpcServices): void {
     const parsed = z.object({ projectId: z.string() }).parse(input);
     const project = services.db.getProject(parsed.projectId);
     if (!project) throw new Error(`Project not found: ${parsed.projectId}`);
+    if (services.reviewAgent.isProjectActive(parsed.projectId)) {
+      throw new Error("Stop the active evidence-review run before exporting this project.");
+    }
     const result = await dialog.showSaveDialog({
       title: "Export project",
       defaultPath: `${safeFilename(project.title)}.paperpilot.json`,
@@ -619,8 +640,79 @@ function titleBarOverlayOptions(theme: "light" | "dark") {
   };
 }
 
+const reviewCandidateOriginPortabilitySchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  batchId: z.string(),
+  paperId: z.string().optional(),
+  matchedPaperId: z.string().optional(),
+  sourceRecordId: z.string().optional(),
+  resolution: z.enum(["created", "duplicate", "merged", "kept-separate", "skipped", "invalid", "filtered"]),
+  paperSnapshot: z.record(z.string(), z.unknown()),
+  recordSnapshot: z.record(z.string(), z.unknown()),
+  createdAt: z.string()
+});
+
+const reviewRereviewFlagPortabilitySchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  paperId: z.string(),
+  stage: z.enum(["title-abstract", "full-text"]),
+  protocolRevisionId: z.string(),
+  paperSnapshot: z.record(z.string(), z.unknown()),
+  invalidatesDownstream: z.boolean().optional(),
+  createdAt: z.string(),
+  resolvedAt: z.string().optional()
+});
+
+const discoveryBatchPortabilitySchema = discoveryBatchSchema.extend({
+  config: z.record(z.string(), z.unknown()).default({})
+});
+
+const screeningDecisionPortabilitySchema = screeningDecisionSchema.extend({
+  paperSnapshot: z.record(z.string(), z.unknown())
+});
+
+const extractionValuePortabilitySchema = extractionValueSchema.extend({
+  paperSnapshot: z.record(z.string(), z.unknown())
+});
+
+const reviewRunItemPortabilitySchema = reviewRunItemSchema.omit({ evidence: true }).extend({
+  evidenceIds: z.array(z.string()).default([]),
+  paperSnapshot: z.record(z.string(), z.unknown()),
+  stale: z.boolean().default(false)
+});
+
+const extractionFieldHistoryPortabilitySchema = extractionFieldSchema.extend({ recordedAt: z.string() });
+const extractionValueHistoryPortabilitySchema = extractionValueSchema.extend({
+  changeRevision: z.number().int().positive(),
+  paperSnapshot: z.record(z.string(), z.unknown()),
+  recordedAt: z.string()
+});
+const reviewEvidencePortabilitySchema = reviewEvidenceSchema.extend({
+  paperSnapshot: z.record(z.string(), z.unknown()).optional()
+});
+
+export const reviewPortabilityStateSchema = z.object({
+  review: reviewProtocolSchema,
+  revisions: z.array(reviewProtocolRevisionSchema),
+  discoveryBatches: z.array(discoveryBatchPortabilitySchema),
+  candidateOrigins: z.array(reviewCandidateOriginPortabilitySchema),
+  rereviewFlags: z.array(reviewRereviewFlagPortabilitySchema),
+  screeningDecisions: z.array(screeningDecisionPortabilitySchema),
+  extractionFields: z.array(extractionFieldSchema),
+  extractionFieldHistory: z.array(extractionFieldHistoryPortabilitySchema).optional(),
+  extractionValues: z.array(extractionValuePortabilitySchema),
+  extractionValueHistory: z.array(extractionValueHistoryPortabilitySchema).optional(),
+  evidence: z.array(reviewEvidencePortabilitySchema),
+  runs: z.array(reviewRunSchema),
+  runItems: z.array(reviewRunItemPortabilitySchema),
+  auditEvents: z.array(reviewAuditEventSchema)
+});
+export type ReviewPortabilityState = z.infer<typeof reviewPortabilityStateSchema>;
+
 const projectExportBundleSchema = z.object({
-  version: z.union([z.literal(1), z.literal(2)]),
+  version: z.union([z.literal(1), z.literal(2), z.literal(3)]),
   exportedAt: z.string(),
   project: projectSchema,
   conversations: z.array(conversationSchema).optional(),
@@ -633,7 +725,8 @@ const projectExportBundleSchema = z.object({
       filename: z.string(),
       contentBase64: z.string()
     })
-  )
+  ),
+  review: reviewPortabilityStateSchema.optional()
 });
 type ProjectExportBundle = z.infer<typeof projectExportBundleSchema>;
 
@@ -647,8 +740,14 @@ export async function buildProjectExportBundle(services: IpcServices, projectId:
       contentBase64: (await readFile(artifact.path)).toString("base64")
     }))
   );
+  const review = services.db.getReview(projectId);
+  const reviewState = review
+    ? terminalReviewPortabilityState(
+        reviewPortabilityStateSchema.parse(services.db.exportReviewPortabilityState(review.id))
+      )
+    : undefined;
   return {
-    version: 2,
+    version: 3,
     exportedAt: new Date().toISOString(),
     project,
     conversations: services.db.listConversations(projectId),
@@ -659,7 +758,8 @@ export async function buildProjectExportBundle(services: IpcServices, projectId:
       .flatMap((conversation) => services.db.listChatRuns(conversation.id))
       .flatMap((run) => services.db.listCitations(run.id)),
     papers: services.db.listPapers(projectId),
-    artifacts
+    artifacts,
+    review: reviewState
   };
 }
 
@@ -672,6 +772,7 @@ async function copyProject(services: IpcServices, projectId: string, title: stri
 
 export async function importProjectBundle(services: IpcServices, bundleInput: unknown) {
   const bundle = projectExportBundleSchema.parse(bundleInput);
+  prevalidateProjectBundle(bundle);
   for (const artifact of bundle.artifacts) {
     const content = Buffer.from(artifact.contentBase64, "base64");
     if (sha256(content) !== artifact.hash) throw new Error(`Artifact checksum mismatch: ${artifact.title}`);
@@ -682,120 +783,887 @@ export async function importProjectBundle(services: IpcServices, bundleInput: un
     bundle.project.policy,
     bundle.project.description
   );
-  if (bundle.project.pinnedAt) services.db.setProjectPinned(project.id, true);
-  const paperIdMap = new Map<string, string>();
-  for (const paperInput of bundle.papers ?? []) {
-    const parsed = paperSchema.parse({ ...paperInput, id: id("paper"), projectId: project.id });
-    const saved = services.db.savePaper(project.id, parsed);
-    paperIdMap.set(paperInput.id, saved.id);
+  const writtenArtifactPaths = new Set<string>();
+  try {
+    if (bundle.project.pinnedAt) services.db.setProjectPinned(project.id, true);
+    const paperIdMap = new Map<string, string>();
+    for (const paperInput of bundle.papers ?? []) {
+      const parsed = paperSchema.parse({ ...paperInput, id: id("paper"), projectId: project.id });
+      const saved = services.db.savePaper(project.id, parsed);
+      paperIdMap.set(paperInput.id, saved.id);
+    }
+    const artifactIdMap = new Map<string, string>();
+    for (const artifactInput of orderArtifactsForImport(bundle.artifacts ?? [])) {
+      const metadata = { ...(artifactInput.metadata ?? {}) };
+      const paperId = typeof metadata.paperId === "string" ? paperIdMap.get(metadata.paperId) : undefined;
+      if (paperId) metadata.paperId = paperId;
+      const parentArtifactId = artifactInput.parentArtifactId
+        ? artifactIdMap.get(artifactInput.parentArtifactId)
+        : undefined;
+      const artifact = await services.artifacts.writeArtifact({
+        projectId: project.id,
+        type: artifactInput.type,
+        title: artifactInput.title,
+        content: Buffer.from(artifactInput.contentBase64, "base64"),
+        extension: extname(artifactInput.filename || artifactInput.path) || undefined,
+        source: artifactInput.source,
+        parentArtifactId,
+        metadata,
+        indexText: artifactInput.type !== "chat-answer"
+      });
+      writtenArtifactPaths.add(artifact.path);
+      artifactIdMap.set(artifactInput.id, artifact.id);
+    }
+    const defaultConversation = services.db.ensureDefaultConversation(project.id);
+    const conversationIdMap = new Map<string, string>();
+    for (const [index, conversationInput] of (bundle.conversations ?? []).entries()) {
+      const conversation =
+        index === 0
+          ? services.db.updateConversation(defaultConversation.id, {
+              title: conversationInput.title,
+              mode: conversationInput.mode
+            })
+          : services.db.createConversation(project.id, conversationInput.title, conversationInput.mode);
+      conversationIdMap.set(conversationInput.id, conversation.id);
+    }
+    const runIdMap = new Map((bundle.runs ?? []).map((run) => [run.id, id("run")]));
+    const citationIdMap = new Map((bundle.citations ?? []).map((citation) => [citation.id, id("cite")]));
+    const messageIdMap = new Map<string, string>();
+    for (const message of bundle.messages ?? []) {
+      const metadata = remapResearchMetadata(message.metadata, paperIdMap, artifactIdMap, citationIdMap);
+      const saved = services.db.appendMessage({
+        projectId: project.id,
+        conversationId: message.conversationId
+          ? (conversationIdMap.get(message.conversationId) ?? defaultConversation.id)
+          : defaultConversation.id,
+        runId: message.runId ? runIdMap.get(message.runId) : undefined,
+        role: message.role,
+        content: message.content,
+        status: message.status,
+        metadata,
+        createdAt: message.createdAt
+      });
+      messageIdMap.set(message.id, saved.id);
+    }
+    for (const artifactInput of bundle.artifacts ?? []) {
+      if (artifactInput.type !== "chat-answer") continue;
+      const mappedArtifactId = artifactIdMap.get(artifactInput.id);
+      if (!mappedArtifactId) continue;
+      const imported = services.db.getArtifact(project.id, mappedArtifactId);
+      if (!imported) continue;
+      const metadata = remapResearchMetadata(imported.metadata, paperIdMap, artifactIdMap, citationIdMap);
+      if (typeof metadata.conversationId === "string") {
+        metadata.conversationId = conversationIdMap.get(metadata.conversationId) ?? metadata.conversationId;
+      }
+      if (typeof metadata.runId === "string") metadata.runId = runIdMap.get(metadata.runId) ?? metadata.runId;
+      if (typeof metadata.messageId === "string") {
+        metadata.messageId = messageIdMap.get(metadata.messageId) ?? metadata.messageId;
+      }
+      services.db.updateArtifact(project.id, mappedArtifactId, { metadata });
+    }
+    for (const run of bundle.runs ?? []) {
+      services.db.saveChatRun({
+        ...run,
+        id: runIdMap.get(run.id)!,
+        projectId: project.id,
+        conversationId: conversationIdMap.get(run.conversationId) ?? defaultConversation.id,
+        userMessageId: messageIdMap.get(run.userMessageId) ?? run.userMessageId,
+        assistantMessageId: run.assistantMessageId ? messageIdMap.get(run.assistantMessageId) : undefined,
+        outputArtifactId: run.outputArtifactId ? artifactIdMap.get(run.outputArtifactId) : undefined,
+        sourceRefs: remapSourceRefs(run.sourceRefs, paperIdMap, artifactIdMap),
+        status: run.status === "running" || run.status === "queued" ? "failed" : run.status,
+        error:
+          run.status === "running" || run.status === "queued"
+            ? "Imported run was incomplete in the source project."
+            : run.error,
+        createdAt: run.createdAt,
+        updatedAt: run.updatedAt
+      });
+    }
+    const citationsByRun = new Map<string, Citation[]>();
+    for (const citation of bundle.citations ?? []) {
+      const mappedRunId = runIdMap.get(citation.runId);
+      if (!mappedRunId) continue;
+      const artifactId = citation.artifactId ? artifactIdMap.get(citation.artifactId) : undefined;
+      const mapped: Citation = {
+        ...citation,
+        id: citationIdMap.get(citation.id)!,
+        runId: mappedRunId,
+        messageId: citation.messageId ? messageIdMap.get(citation.messageId) : undefined,
+        paperId: citation.paperId ? paperIdMap.get(citation.paperId) : undefined,
+        artifactId,
+        chunkId: artifactId ? findImportedChunkId(services.db, project.id, artifactId, citation) : undefined
+      };
+      citationsByRun.set(mappedRunId, [...(citationsByRun.get(mappedRunId) ?? []), mapped]);
+    }
+    for (const [runId, citations] of citationsByRun) {
+      services.db.replaceCitations(runId, citations);
+    }
+    if (bundle.review) {
+      const remappedReview = remapReviewPortabilityState({
+        db: services.db,
+        projectId: project.id,
+        state: bundle.review,
+        paperIdMap,
+        artifactIdMap
+      });
+      services.db.importReviewPortabilityState(project.id, remappedReview);
+    }
+    return services.db.getProject(project.id) ?? project;
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    try {
+      for (const artifact of services.db.listArtifacts(project.id)) writtenArtifactPaths.add(artifact.path);
+    } catch (cleanupError) {
+      rollbackErrors.push(cleanupError);
+    }
+    try {
+      if (services.db.getProject(project.id)) services.db.deleteProject(project.id);
+    } catch (cleanupError) {
+      rollbackErrors.push(cleanupError);
+    }
+    const fileResults = await Promise.allSettled([...writtenArtifactPaths].map((path) => rm(path, { force: true })));
+    rollbackErrors.push(
+      ...fileResults.flatMap((result) => (result.status === "rejected" ? [result.reason as unknown] : []))
+    );
+    if (services.dataRoot) {
+      try {
+        await rm(projectDataPath(services.dataRoot, project.id), { recursive: true, force: true });
+      } catch (cleanupError) {
+        rollbackErrors.push(cleanupError);
+      }
+    }
+    if (rollbackErrors.length) {
+      throw new AggregateError([error, ...rollbackErrors], "Project import failed and rollback was incomplete.", {
+        cause: error
+      });
+    }
+    throw error;
   }
-  const artifactIdMap = new Map<string, string>();
-  for (const artifactInput of bundle.artifacts ?? []) {
-    const metadata = { ...(artifactInput.metadata ?? {}) };
-    const paperId = typeof metadata.paperId === "string" ? paperIdMap.get(metadata.paperId) : undefined;
-    if (paperId) metadata.paperId = paperId;
-    const parentArtifactId = artifactInput.parentArtifactId
-      ? artifactIdMap.get(artifactInput.parentArtifactId)
+}
+
+function prevalidateProjectBundle(bundle: ProjectExportBundle): void {
+  if (bundle.version < 3 && bundle.review) {
+    throw new Error("Evidence-review state requires project export bundle version 3.");
+  }
+  const paperIds = uniqueIds(bundle.papers, "paper");
+  const artifactIds = uniqueIds(bundle.artifacts, "artifact");
+  const conversations = bundle.conversations ?? [];
+  const conversationIds = uniqueIds(conversations, "conversation");
+  const messages = bundle.messages ?? [];
+  const messageIds = uniqueIds(messages, "message");
+  const runs = bundle.runs ?? [];
+  const runIds = uniqueIds(runs, "chat run");
+  const citations = bundle.citations ?? [];
+  uniqueIds(citations, "citation");
+
+  for (const paper of bundle.papers) {
+    if (paper.projectId && paper.projectId !== bundle.project.id) {
+      throw new Error(`Project paper belongs to a different project: ${paper.id}`);
+    }
+  }
+  for (const artifact of bundle.artifacts) {
+    if (artifact.projectId !== bundle.project.id) {
+      throw new Error(`Project artifact belongs to a different project: ${artifact.id}`);
+    }
+    if (artifact.parentArtifactId && !artifactIds.has(artifact.parentArtifactId)) {
+      throw new Error(`Project artifact references a missing parent: ${artifact.id}`);
+    }
+  }
+  // This also detects parent cycles before any files are written.
+  orderArtifactsForImport(bundle.artifacts);
+
+  for (const conversation of conversations) {
+    if (conversation.projectId !== bundle.project.id) {
+      throw new Error(`Conversation belongs to a different project: ${conversation.id}`);
+    }
+  }
+  for (const message of messages) {
+    if (message.projectId !== bundle.project.id)
+      throw new Error(`Message belongs to a different project: ${message.id}`);
+    if (message.conversationId && conversations.length && !conversationIds.has(message.conversationId)) {
+      throw new Error(`Message references a missing conversation: ${message.id}`);
+    }
+    if (message.runId && !runIds.has(message.runId)) throw new Error(`Message references a missing run: ${message.id}`);
+  }
+  for (const run of runs) {
+    if (run.projectId !== bundle.project.id) throw new Error(`Chat run belongs to a different project: ${run.id}`);
+    if (conversations.length && !conversationIds.has(run.conversationId)) {
+      throw new Error(`Chat run references a missing conversation: ${run.id}`);
+    }
+    if (!messageIds.has(run.userMessageId) || (run.assistantMessageId && !messageIds.has(run.assistantMessageId))) {
+      throw new Error(`Chat run references a missing message: ${run.id}`);
+    }
+    if (run.outputArtifactId && !artifactIds.has(run.outputArtifactId)) {
+      throw new Error(`Chat run references a missing output artifact: ${run.id}`);
+    }
+    for (const sourceRef of run.sourceRefs) {
+      if (sourceRef.type === "paper" && !paperIds.has(sourceRef.id)) {
+        throw new Error(`Chat run references a missing paper: ${run.id}`);
+      }
+      if (sourceRef.type === "artifact" && !artifactIds.has(sourceRef.id)) {
+        throw new Error(`Chat run references a missing artifact: ${run.id}`);
+      }
+    }
+  }
+  for (const citation of citations) {
+    if (!runIds.has(citation.runId)) throw new Error(`Citation references a missing run: ${citation.id}`);
+    if (citation.messageId && !messageIds.has(citation.messageId)) {
+      throw new Error(`Citation references a missing message: ${citation.id}`);
+    }
+    if (citation.paperId && !paperIds.has(citation.paperId)) {
+      throw new Error(`Citation references a missing paper: ${citation.id}`);
+    }
+    if (citation.artifactId && !artifactIds.has(citation.artifactId)) {
+      throw new Error(`Citation references a missing artifact: ${citation.id}`);
+    }
+  }
+
+  if (bundle.review) prevalidateReviewState(bundle.review, bundle.project.id, paperIds, bundle.artifacts);
+}
+
+function prevalidateReviewState(
+  state: ReviewPortabilityState,
+  sourceProjectId: string,
+  livePaperIds: ReadonlySet<string>,
+  liveArtifacts: readonly ProjectExportBundle["artifacts"][number][]
+): void {
+  if (state.review.projectId !== sourceProjectId) throw new Error("Portable review belongs to a different project.");
+  const revisionIds = uniqueIds(state.revisions, "review protocol revision");
+  if (!revisionIds.has(state.review.currentRevisionId)) {
+    throw new Error("Portable review state does not include its current protocol revision.");
+  }
+  const revisionVersions = new Set<number>();
+  const criteriaByRevision = new Map<string, Set<string>>();
+  const allCriterionIds = new Set<string>();
+  for (const revision of state.revisions) {
+    if (revision.reviewId !== state.review.id)
+      throw new Error(`Protocol revision has the wrong review: ${revision.id}`);
+    if (revisionVersions.has(revision.version))
+      throw new Error(`Duplicate protocol revision version: ${revision.version}`);
+    revisionVersions.add(revision.version);
+    const criterionIds = uniqueIds(revision.criteria, `criterion in protocol revision ${revision.id}`);
+    for (const criterionId of criterionIds) {
+      if (allCriterionIds.has(criterionId)) throw new Error(`Duplicate review criterion id: ${criterionId}`);
+      allCriterionIds.add(criterionId);
+    }
+    criteriaByRevision.set(revision.id, criterionIds);
+  }
+  if (
+    state.review.currentRevisionNumber !==
+    state.revisions.find((item) => item.id === state.review.currentRevisionId)?.version
+  ) {
+    throw new Error("Portable review current revision number does not match its revision record.");
+  }
+
+  const batchIds = uniqueIds(state.discoveryBatches, "discovery batch");
+  for (const batch of state.discoveryBatches) {
+    if (batch.reviewId !== state.review.id) throw new Error(`Discovery batch has the wrong review: ${batch.id}`);
+  }
+  uniqueIds(state.candidateOrigins, "candidate origin");
+  for (const origin of state.candidateOrigins) {
+    if (origin.reviewId !== state.review.id || !batchIds.has(origin.batchId)) {
+      throw new Error(`Candidate origin is outside the portable review: ${origin.id}`);
+    }
+    if (origin.paperId)
+      assertPortablePaper(origin.paperId, origin.paperSnapshot, livePaperIds, `candidate origin ${origin.id}`);
+    // matchedPaperId is provenance, not a live relationship: retain the opaque source identity even after deletion.
+  }
+
+  const runIds = uniqueIds(state.runs, "review run");
+  const runById = new Map(state.runs.map((run) => [run.id, run]));
+  const fieldIds = uniqueIds(state.extractionFields, "extraction field");
+  for (const field of state.extractionFields) {
+    if (field.reviewId !== state.review.id) throw new Error(`Extraction field has the wrong review: ${field.id}`);
+  }
+  for (const field of state.extractionFieldHistory ?? []) {
+    if (field.reviewId !== state.review.id || !fieldIds.has(field.id)) {
+      throw new Error(`Extraction field history is outside the portable review: ${field.id}`);
+    }
+  }
+  for (const run of state.runs) {
+    if (run.reviewId !== state.review.id || !revisionIds.has(run.protocolRevisionId)) {
+      throw new Error(`Review run is outside the portable review: ${run.id}`);
+    }
+    if (run.status === "queued" || run.status === "running") {
+      throw new Error(`Portable review run is not terminal: ${run.id}`);
+    }
+    if (run.fieldIds.some((fieldId) => !fieldIds.has(fieldId))) {
+      throw new Error(`Review run references an unavailable extraction field: ${run.id}`);
+    }
+  }
+
+  const runItemIds = uniqueIds(state.runItems, "review run item");
+  const runItemById = new Map(state.runItems.map((item) => [item.id, item]));
+  const snapshotPaperIds = new Set<string>();
+  const rememberSnapshot = (value: Record<string, unknown>): void => {
+    const snapshotId = typeof value.id === "string" ? value.id : undefined;
+    if (snapshotId) snapshotPaperIds.add(snapshotId);
+  };
+  state.candidateOrigins.forEach((origin) => rememberSnapshot(origin.paperSnapshot));
+  state.rereviewFlags.forEach((flag) => rememberSnapshot(flag.paperSnapshot));
+  state.screeningDecisions.forEach((decision) => rememberSnapshot(decision.paperSnapshot));
+  state.extractionValues.forEach((value) => rememberSnapshot(value.paperSnapshot));
+  (state.extractionValueHistory ?? []).forEach((value) => rememberSnapshot(value.paperSnapshot));
+  state.evidence.forEach((evidence) => {
+    if (evidence.paperSnapshot) rememberSnapshot(evidence.paperSnapshot);
+  });
+  state.runItems.forEach((item) => rememberSnapshot(item.paperSnapshot));
+
+  for (const item of state.runItems) {
+    const run = runById.get(item.runId);
+    if (!run) throw new Error(`Review run item references a missing run: ${item.id}`);
+    if (item.status === "queued" || item.status === "running") {
+      throw new Error(`Portable review run item is not terminal: ${item.id}`);
+    }
+    assertPortablePaper(item.paperId, item.paperSnapshot, livePaperIds, `review run item ${item.id}`);
+    if (!run.paperIds.includes(item.paperId)) throw new Error(`Review run item paper is outside its run: ${item.id}`);
+    const criterionIds = criteriaByRevision.get(run.protocolRevisionId)!;
+    if (item.suggestedReasonCriterionId && !criterionIds.has(item.suggestedReasonCriterionId)) {
+      throw new Error(`Review run item references a missing reason criterion: ${item.id}`);
+    }
+    for (const assessment of item.criterionAssessments) {
+      if (!criterionIds.has(assessment.criterionId)) {
+        throw new Error(`Review run item references a missing criterion assessment: ${item.id}`);
+      }
+    }
+    for (const suggestion of item.extractionSuggestions) {
+      if (!fieldIds.has(suggestion.fieldId)) {
+        throw new Error(`Review run item references a missing extraction field: ${item.id}`);
+      }
+    }
+  }
+  for (const run of state.runs) {
+    for (const paperId of run.paperIds) {
+      if (!livePaperIds.has(paperId) && !snapshotPaperIds.has(paperId)) {
+        throw new Error(`Review run references a paper without a retained snapshot: ${run.id}`);
+      }
+    }
+  }
+
+  const decisionIds = uniqueIds(state.screeningDecisions, "screening decision");
+  const decisionById = new Map(state.screeningDecisions.map((decision) => [decision.id, decision]));
+  for (const decision of state.screeningDecisions) {
+    if (decision.reviewId !== state.review.id || !revisionIds.has(decision.protocolRevisionId)) {
+      throw new Error(`Screening decision is outside the portable review: ${decision.id}`);
+    }
+    assertPortablePaper(decision.paperId, decision.paperSnapshot, livePaperIds, `screening decision ${decision.id}`);
+    if (decision.previousDecisionId && !decisionIds.has(decision.previousDecisionId)) {
+      throw new Error(`Screening decision references missing history: ${decision.id}`);
+    }
+    const previous = decision.previousDecisionId ? decisionById.get(decision.previousDecisionId) : undefined;
+    if (previous && (previous.paperId !== decision.paperId || previous.stage !== decision.stage)) {
+      throw new Error(`Screening decision history crosses papers or stages: ${decision.id}`);
+    }
+    const revisionCriterionIds = criteriaByRevision.get(decision.protocolRevisionId)!;
+    if (decision.reasonCriterionId && !revisionCriterionIds.has(decision.reasonCriterionId)) {
+      throw new Error(`Screening decision references a missing reason criterion: ${decision.id}`);
+    }
+    if (decision.reasonCriterionId) {
+      const criterion = state.revisions
+        .find((revision) => revision.id === decision.protocolRevisionId)!
+        .criteria.find((candidate) => candidate.id === decision.reasonCriterionId)!;
+      if (criterion.stage !== decision.stage || criterion.type !== "exclusion") {
+        throw new Error(`Screening decision uses an invalid exclusion criterion: ${decision.id}`);
+      }
+    }
+    if (decision.runItemId && !runItemIds.has(decision.runItemId)) {
+      throw new Error(`Screening decision references a missing review run item: ${decision.id}`);
+    }
+  }
+
+  uniqueIds(state.rereviewFlags, "re-review flag");
+  for (const flag of state.rereviewFlags) {
+    if (flag.reviewId !== state.review.id || !revisionIds.has(flag.protocolRevisionId)) {
+      throw new Error(`Re-review flag is outside the portable review: ${flag.id}`);
+    }
+    assertPortablePaper(flag.paperId, flag.paperSnapshot, livePaperIds, `re-review flag ${flag.id}`);
+  }
+
+  const evidenceIds = uniqueIds(state.evidence, "review evidence");
+  const artifactById = new Map(liveArtifacts.map((artifact) => [artifact.id, artifact]));
+  for (const evidence of state.evidence) {
+    if (evidence.reviewId !== state.review.id) throw new Error(`Review evidence has the wrong review: ${evidence.id}`);
+    if (evidence.runId && !runIds.has(evidence.runId))
+      throw new Error(`Review evidence references a missing run: ${evidence.id}`);
+    if (evidence.runItemId && !runItemIds.has(evidence.runItemId)) {
+      throw new Error(`Review evidence references a missing run item: ${evidence.id}`);
+    }
+    if (evidence.runItemId) {
+      const item = runItemById.get(evidence.runItemId)!;
+      if (
+        (evidence.runId && evidence.runId !== item.runId) ||
+        (evidence.paperId && evidence.paperId !== item.paperId)
+      ) {
+        throw new Error(`Review evidence ownership does not match its run item: ${evidence.id}`);
+      }
+    }
+    if (evidence.paperId && !livePaperIds.has(evidence.paperId) && !snapshotPaperIds.has(evidence.paperId)) {
+      throw new Error(`Review evidence references a paper without a retained snapshot: ${evidence.id}`);
+    }
+    if (evidence.sourceType === "artifact-chunk" && evidence.artifactId) {
+      const artifact = artifactById.get(evidence.artifactId);
+      const evidencePaperId = evidence.paperId ?? metadataString(evidence.paperSnapshot?.id);
+      if (!artifact) throw new Error(`Review evidence references a missing artifact: ${evidence.id}`);
+      if (!evidence.chunkId)
+        throw new Error(`Review evidence references a live artifact without a chunk: ${evidence.id}`);
+      if (
+        !evidencePaperId ||
+        (artifact.type !== "paper-pdf" && artifact.type !== "markdown" && artifact.type !== "table") ||
+        artifact.source === "research-chat" ||
+        metadataString(artifact.metadata.paperId) !== evidencePaperId
+      ) {
+        throw new Error(`Review evidence references an untrusted or mismatched artifact: ${evidence.id}`);
+      }
+    }
+  }
+  for (const item of state.runItems) {
+    for (const evidenceId of item.evidenceIds) {
+      if (!evidenceIds.has(evidenceId)) throw new Error(`Review run item references missing evidence: ${item.id}`);
+      if (state.evidence.find((entry) => entry.id === evidenceId)?.runItemId !== item.id) {
+        throw new Error(`Review run item references evidence owned by another item: ${item.id}`);
+      }
+    }
+    const ownedApplicationEvidenceIds = new Set(
+      state.evidence
+        .filter((entry) => entry.runItemId === item.id && item.evidenceIds.includes(entry.id))
+        .map((entry) => entry.evidenceId)
+    );
+    for (const assessment of item.criterionAssessments) {
+      if (assessment.evidenceIds.some((evidenceId) => !ownedApplicationEvidenceIds.has(evidenceId))) {
+        throw new Error(`Review criterion assessment references missing evidence: ${item.id}`);
+      }
+    }
+    for (const suggestion of item.extractionSuggestions) {
+      if (suggestion.evidenceIds.some((evidenceId) => !ownedApplicationEvidenceIds.has(evidenceId))) {
+        throw new Error(`Review extraction suggestion references missing evidence: ${item.id}`);
+      }
+    }
+  }
+
+  uniqueIds(state.extractionValues, "extraction value");
+  const extractionValueIds = new Set(state.extractionValues.map((value) => value.id));
+  for (const value of state.extractionValues) {
+    if (value.reviewId !== state.review.id || !fieldIds.has(value.fieldId)) {
+      throw new Error(`Extraction value is outside the portable review: ${value.id}`);
+    }
+    assertPortablePaper(value.paperId, value.paperSnapshot, livePaperIds, `extraction value ${value.id}`);
+    if (value.runItemId && !runItemIds.has(value.runItemId)) {
+      throw new Error(`Extraction value references a missing run item: ${value.id}`);
+    }
+    if (value.runItemId && runItemById.get(value.runItemId)?.paperId !== value.paperId) {
+      throw new Error(`Extraction value references a run item for another paper: ${value.id}`);
+    }
+    if (value.evidenceIds.some((evidenceId) => !evidenceIds.has(evidenceId))) {
+      throw new Error(`Extraction value references missing evidence: ${value.id}`);
+    }
+  }
+  for (const value of state.extractionValueHistory ?? []) {
+    if (!extractionValueIds.has(value.id) || value.reviewId !== state.review.id || !fieldIds.has(value.fieldId)) {
+      throw new Error(`Extraction value history is outside the portable review: ${value.id}`);
+    }
+    assertPortablePaper(value.paperId, value.paperSnapshot, livePaperIds, `extraction value history ${value.id}`);
+    if (value.runItemId && !runItemIds.has(value.runItemId)) {
+      throw new Error(`Extraction value history references a missing run item: ${value.id}`);
+    }
+    if (value.evidenceIds.some((evidenceId) => !evidenceIds.has(evidenceId))) {
+      throw new Error(`Extraction value history references missing evidence: ${value.id}`);
+    }
+  }
+  uniqueIds(state.auditEvents, "review audit event");
+  for (const event of state.auditEvents) {
+    if (event.reviewId !== state.review.id) throw new Error(`Audit event has the wrong review: ${event.id}`);
+  }
+
+  for (const decision of state.screeningDecisions) {
+    if (!decision.runItemId) continue;
+    const item = runItemById.get(decision.runItemId)!;
+    const run = runById.get(item.runId)!;
+    if (item.paperId !== decision.paperId || run.stage !== decision.stage) {
+      throw new Error(`Screening decision references a run item for another paper: ${decision.id}`);
+    }
+  }
+}
+
+function uniqueIds<T extends { id: string }>(values: readonly T[], label: string): Set<string> {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (ids.has(value.id)) throw new Error(`Duplicate ${label} id: ${value.id}`);
+    ids.add(value.id);
+  }
+  return ids;
+}
+
+function assertPortablePaper(
+  paperId: string,
+  snapshot: Record<string, unknown>,
+  livePaperIds: ReadonlySet<string>,
+  label: string
+): void {
+  if (livePaperIds.has(paperId)) return;
+  const parsed = paperSchema.safeParse(snapshot);
+  if (!parsed.success || parsed.data.id !== paperId) {
+    throw new Error(`${label} references a deleted paper without a valid retained snapshot: ${paperId}`);
+  }
+}
+
+function orderArtifactsForImport(artifacts: ProjectExportBundle["artifacts"]): ProjectExportBundle["artifacts"] {
+  const byId = new Map(artifacts.map((artifact) => [artifact.id, artifact]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const ordered: ProjectExportBundle["artifacts"] = [];
+  const visit = (artifact: ProjectExportBundle["artifacts"][number]): void => {
+    if (visited.has(artifact.id)) return;
+    if (visiting.has(artifact.id)) throw new Error(`Artifact parent cycle detected at: ${artifact.id}`);
+    visiting.add(artifact.id);
+    if (artifact.parentArtifactId) {
+      const parent = byId.get(artifact.parentArtifactId);
+      if (!parent) throw new Error(`Project artifact references a missing parent: ${artifact.id}`);
+      visit(parent);
+    }
+    visiting.delete(artifact.id);
+    visited.add(artifact.id);
+    ordered.push(artifact);
+  };
+  artifacts.forEach(visit);
+  return ordered;
+}
+
+function terminalReviewPortabilityState(state: ReviewPortabilityState): ReviewPortabilityState {
+  const runs = state.runs.filter((run) => run.status !== "queued" && run.status !== "running");
+  const runIds = new Set(runs.map((run) => run.id));
+  const runItems = state.runItems.filter((item) => runIds.has(item.runId));
+  const runItemIds = new Set(runItems.map((item) => item.id));
+  return reviewPortabilityStateSchema.parse({
+    ...state,
+    runs,
+    runItems,
+    screeningDecisions: state.screeningDecisions.map((decision) => ({
+      ...decision,
+      runItemId: decision.runItemId && runItemIds.has(decision.runItemId) ? decision.runItemId : undefined
+    })),
+    extractionValues: state.extractionValues.map((value) => ({
+      ...value,
+      runItemId: value.runItemId && runItemIds.has(value.runItemId) ? value.runItemId : undefined
+    })),
+    evidence: state.evidence.map((evidence) => ({
+      ...evidence,
+      runId: evidence.runId && runIds.has(evidence.runId) ? evidence.runId : undefined,
+      runItemId: evidence.runItemId && runItemIds.has(evidence.runItemId) ? evidence.runItemId : undefined
+    }))
+  });
+}
+
+interface ReviewRemapInput {
+  db: PaperPilotDb;
+  projectId: string;
+  state: ReviewPortabilityState;
+  paperIdMap: Map<string, string>;
+  artifactIdMap: Map<string, string>;
+}
+
+interface ReviewIdentifierMaps {
+  projectId: string;
+  reviewIds: Map<string, string>;
+  revisionIds: Map<string, string>;
+  criterionIds: Map<string, string>;
+  batchIds: Map<string, string>;
+  originIds: Map<string, string>;
+  decisionIds: Map<string, string>;
+  rereviewIds: Map<string, string>;
+  fieldIds: Map<string, string>;
+  valueIds: Map<string, string>;
+  evidenceIds: Map<string, string>;
+  runIds: Map<string, string>;
+  runItemIds: Map<string, string>;
+  auditIds: Map<string, string>;
+  paperIds: Map<string, string>;
+  artifactIds: Map<string, string>;
+  chunkIds: Map<string, string>;
+}
+
+function remapReviewPortabilityState(input: ReviewRemapInput): ReviewPortabilityState {
+  const state = terminalReviewPortabilityState(input.state);
+  const maps: ReviewIdentifierMaps = {
+    projectId: input.projectId,
+    reviewIds: new Map([[state.review.id, id("review")]]),
+    revisionIds: idMap(state.revisions, "protocol"),
+    criterionIds: idMap(
+      state.revisions.flatMap((revision) => revision.criteria),
+      "criterion"
+    ),
+    batchIds: idMap(state.discoveryBatches, "batch"),
+    originIds: idMap(state.candidateOrigins, "origin"),
+    decisionIds: idMap(state.screeningDecisions, "decision"),
+    rereviewIds: idMap(state.rereviewFlags, "rereview"),
+    fieldIds: idMap(state.extractionFields, "field"),
+    valueIds: idMap(state.extractionValues, "value"),
+    evidenceIds: idMap(state.evidence, "review_evidence"),
+    runIds: idMap(state.runs, "review_run"),
+    runItemIds: idMap(state.runItems, "review_item"),
+    auditIds: idMap(state.auditEvents, "audit"),
+    paperIds: input.paperIdMap,
+    artifactIds: input.artifactIdMap,
+    chunkIds: new Map()
+  };
+  const mappedReviewId = requiredMappedId(maps.reviewIds, state.review.id, "review");
+
+  const evidence = state.evidence.map((item) => {
+    const mappedArtifactId = item.artifactId ? maps.artifactIds.get(item.artifactId) : undefined;
+    const mappedChunkId = mappedArtifactId
+      ? findImportedReviewChunkId(input.db, input.projectId, mappedArtifactId, item)
       : undefined;
-    const artifact = await services.artifacts.writeArtifact({
-      projectId: project.id,
-      type: artifactInput.type,
-      title: artifactInput.title,
-      content: Buffer.from(artifactInput.contentBase64, "base64"),
-      extension: extname(artifactInput.filename || artifactInput.path) || undefined,
-      source: artifactInput.source,
-      parentArtifactId,
-      metadata,
-      indexText: artifactInput.type !== "chat-answer"
-    });
-    artifactIdMap.set(artifactInput.id, artifact.id);
-  }
-  const defaultConversation = services.db.ensureDefaultConversation(project.id);
-  const conversationIdMap = new Map<string, string>();
-  for (const [index, conversationInput] of (bundle.conversations ?? []).entries()) {
-    const conversation =
-      index === 0
-        ? services.db.updateConversation(defaultConversation.id, {
-            title: conversationInput.title,
-            mode: conversationInput.mode
-          })
-        : services.db.createConversation(project.id, conversationInput.title, conversationInput.mode);
-    conversationIdMap.set(conversationInput.id, conversation.id);
-  }
-  const runIdMap = new Map((bundle.runs ?? []).map((run) => [run.id, id("run")]));
-  const citationIdMap = new Map((bundle.citations ?? []).map((citation) => [citation.id, id("cite")]));
-  const messageIdMap = new Map<string, string>();
-  for (const message of bundle.messages ?? []) {
-    const metadata = remapResearchMetadata(message.metadata, paperIdMap, artifactIdMap, citationIdMap);
-    const saved = services.db.appendMessage({
-      projectId: project.id,
-      conversationId: message.conversationId
-        ? (conversationIdMap.get(message.conversationId) ?? defaultConversation.id)
-        : defaultConversation.id,
-      runId: message.runId ? runIdMap.get(message.runId) : undefined,
-      role: message.role,
-      content: message.content,
-      status: message.status,
-      metadata,
-      createdAt: message.createdAt
-    });
-    messageIdMap.set(message.id, saved.id);
-  }
-  for (const artifactInput of bundle.artifacts ?? []) {
-    if (artifactInput.type !== "chat-answer") continue;
-    const mappedArtifactId = artifactIdMap.get(artifactInput.id);
-    if (!mappedArtifactId) continue;
-    const imported = services.db.getArtifact(project.id, mappedArtifactId);
-    if (!imported) continue;
-    const metadata = remapResearchMetadata(imported.metadata, paperIdMap, artifactIdMap, citationIdMap);
-    if (typeof metadata.conversationId === "string") {
-      metadata.conversationId = conversationIdMap.get(metadata.conversationId) ?? metadata.conversationId;
-    }
-    if (typeof metadata.runId === "string") metadata.runId = runIdMap.get(metadata.runId) ?? metadata.runId;
-    if (typeof metadata.messageId === "string") {
-      metadata.messageId = messageIdMap.get(metadata.messageId) ?? metadata.messageId;
-    }
-    services.db.updateArtifact(project.id, mappedArtifactId, { metadata });
-  }
-  for (const run of bundle.runs ?? []) {
-    services.db.saveChatRun({
-      ...run,
-      id: runIdMap.get(run.id)!,
-      projectId: project.id,
-      conversationId: conversationIdMap.get(run.conversationId) ?? defaultConversation.id,
-      userMessageId: messageIdMap.get(run.userMessageId) ?? run.userMessageId,
-      assistantMessageId: run.assistantMessageId ? messageIdMap.get(run.assistantMessageId) : undefined,
-      outputArtifactId: run.outputArtifactId ? artifactIdMap.get(run.outputArtifactId) : undefined,
-      sourceRefs: remapSourceRefs(run.sourceRefs, paperIdMap, artifactIdMap),
-      status: run.status === "running" || run.status === "queued" ? "failed" : run.status,
-      error:
-        run.status === "running" || run.status === "queued"
-          ? "Imported run was incomplete in the source project."
-          : run.error,
-      createdAt: run.createdAt,
-      updatedAt: run.updatedAt
-    });
-  }
-  const citationsByRun = new Map<string, Citation[]>();
-  for (const citation of bundle.citations ?? []) {
-    const mappedRunId = runIdMap.get(citation.runId);
-    if (!mappedRunId) continue;
-    const artifactId = citation.artifactId ? artifactIdMap.get(citation.artifactId) : undefined;
-    const mapped: Citation = {
-      ...citation,
-      id: citationIdMap.get(citation.id)!,
-      runId: mappedRunId,
-      messageId: citation.messageId ? messageIdMap.get(citation.messageId) : undefined,
-      paperId: citation.paperId ? paperIdMap.get(citation.paperId) : undefined,
-      artifactId,
-      chunkId: artifactId ? findImportedChunkId(services.db, project.id, artifactId, citation) : undefined
+    if (item.chunkId && mappedChunkId) maps.chunkIds.set(item.chunkId, mappedChunkId);
+    return {
+      ...item,
+      id: requiredMappedId(maps.evidenceIds, item.id, "review evidence"),
+      reviewId: mappedReviewId,
+      runId: item.runId ? maps.runIds.get(item.runId) : undefined,
+      runItemId: item.runItemId ? maps.runItemIds.get(item.runItemId) : undefined,
+      paperId: item.paperId ? maps.paperIds.get(item.paperId) : undefined,
+      artifactId: mappedArtifactId,
+      chunkId: mappedChunkId,
+      paperSnapshot: item.paperSnapshot ? remapPaperSnapshot(item.paperSnapshot, maps) : undefined
     };
-    citationsByRun.set(mappedRunId, [...(citationsByRun.get(mappedRunId) ?? []), mapped]);
+  });
+
+  const remapped = {
+    review: {
+      ...state.review,
+      id: mappedReviewId,
+      projectId: input.projectId,
+      currentRevisionId: requiredMappedId(maps.revisionIds, state.review.currentRevisionId, "current protocol revision")
+    },
+    revisions: state.revisions.map((revision) => ({
+      ...revision,
+      id: requiredMappedId(maps.revisionIds, revision.id, "protocol revision"),
+      reviewId: mappedReviewId,
+      criteria: revision.criteria.map((criterion) => ({
+        ...criterion,
+        id: requiredMappedId(maps.criterionIds, criterion.id, "review criterion")
+      }))
+    })),
+    discoveryBatches: state.discoveryBatches.map((batch) => ({
+      ...batch,
+      id: requiredMappedId(maps.batchIds, batch.id, "discovery batch"),
+      reviewId: mappedReviewId,
+      config: remapPortableRecord(batch.config, maps)
+    })),
+    candidateOrigins: state.candidateOrigins.map((origin) => ({
+      ...origin,
+      id: requiredMappedId(maps.originIds, origin.id, "candidate origin"),
+      reviewId: mappedReviewId,
+      batchId: requiredMappedId(maps.batchIds, origin.batchId, "candidate origin batch"),
+      paperId: origin.paperId ? (maps.paperIds.get(origin.paperId) ?? origin.paperId) : undefined,
+      matchedPaperId: origin.matchedPaperId
+        ? (maps.paperIds.get(origin.matchedPaperId) ?? origin.matchedPaperId)
+        : undefined,
+      paperSnapshot: remapPaperSnapshot(origin.paperSnapshot, maps),
+      recordSnapshot: {
+        ...remapPortableRecord(origin.recordSnapshot, maps),
+        ...(origin.matchedPaperId && !maps.paperIds.has(origin.matchedPaperId)
+          ? { unavailableMatchedPaperId: origin.matchedPaperId }
+          : {})
+      }
+    })),
+    rereviewFlags: state.rereviewFlags.map((flag) => ({
+      ...flag,
+      id: requiredMappedId(maps.rereviewIds, flag.id, "re-review flag"),
+      reviewId: mappedReviewId,
+      paperId: maps.paperIds.get(flag.paperId) ?? flag.paperId,
+      protocolRevisionId: requiredMappedId(maps.revisionIds, flag.protocolRevisionId, "re-review protocol revision"),
+      paperSnapshot: remapPaperSnapshot(flag.paperSnapshot, maps)
+    })),
+    screeningDecisions: state.screeningDecisions.map((decision) => ({
+      ...decision,
+      id: requiredMappedId(maps.decisionIds, decision.id, "screening decision"),
+      reviewId: mappedReviewId,
+      paperId: maps.paperIds.get(decision.paperId) ?? decision.paperId,
+      protocolRevisionId: requiredMappedId(maps.revisionIds, decision.protocolRevisionId, "decision protocol revision"),
+      reasonCriterionId: decision.reasonCriterionId ? maps.criterionIds.get(decision.reasonCriterionId) : undefined,
+      previousDecisionId: decision.previousDecisionId ? maps.decisionIds.get(decision.previousDecisionId) : undefined,
+      runItemId: decision.runItemId ? maps.runItemIds.get(decision.runItemId) : undefined,
+      paperSnapshot: remapPaperSnapshot(decision.paperSnapshot, maps)
+    })),
+    extractionFields: state.extractionFields.map((field) => ({
+      ...field,
+      id: requiredMappedId(maps.fieldIds, field.id, "extraction field"),
+      reviewId: mappedReviewId
+    })),
+    extractionFieldHistory: (state.extractionFieldHistory ?? []).map((field) => ({
+      ...field,
+      id: requiredMappedId(maps.fieldIds, field.id, "historical extraction field"),
+      reviewId: mappedReviewId
+    })),
+    extractionValues: state.extractionValues.map((value) => ({
+      ...value,
+      id: requiredMappedId(maps.valueIds, value.id, "extraction value"),
+      reviewId: mappedReviewId,
+      paperId: maps.paperIds.get(value.paperId) ?? value.paperId,
+      fieldId: requiredMappedId(maps.fieldIds, value.fieldId, "extraction value field"),
+      evidenceIds: value.evidenceIds.flatMap((evidenceId) => {
+        const mapped = maps.evidenceIds.get(evidenceId);
+        return mapped ? [mapped] : [];
+      }),
+      runItemId: value.runItemId ? maps.runItemIds.get(value.runItemId) : undefined,
+      paperSnapshot: remapPaperSnapshot(value.paperSnapshot, maps)
+    })),
+    extractionValueHistory: (state.extractionValueHistory ?? []).map((value) => ({
+      ...value,
+      id: requiredMappedId(maps.valueIds, value.id, "historical extraction value"),
+      reviewId: mappedReviewId,
+      paperId: maps.paperIds.get(value.paperId) ?? value.paperId,
+      fieldId: requiredMappedId(maps.fieldIds, value.fieldId, "historical extraction value field"),
+      evidenceIds: value.evidenceIds.map((evidenceId) =>
+        requiredMappedId(maps.evidenceIds, evidenceId, "historical extraction value evidence")
+      ),
+      runItemId: value.runItemId ? maps.runItemIds.get(value.runItemId) : undefined,
+      paperSnapshot: remapPaperSnapshot(value.paperSnapshot, maps)
+    })),
+    evidence,
+    runs: state.runs.map((run) => ({
+      ...run,
+      id: requiredMappedId(maps.runIds, run.id, "review run"),
+      reviewId: mappedReviewId,
+      protocolRevisionId: requiredMappedId(maps.revisionIds, run.protocolRevisionId, "run protocol revision"),
+      paperIds: run.paperIds.map((paperId) => maps.paperIds.get(paperId) ?? paperId),
+      fieldIds: run.fieldIds.map((fieldId) => requiredMappedId(maps.fieldIds, fieldId, "run extraction field"))
+    })),
+    runItems: state.runItems.map((item) => ({
+      ...item,
+      id: requiredMappedId(maps.runItemIds, item.id, "review run item"),
+      runId: requiredMappedId(maps.runIds, item.runId, "review run item run"),
+      paperId: maps.paperIds.get(item.paperId) ?? item.paperId,
+      suggestedReasonCriterionId: item.suggestedReasonCriterionId
+        ? maps.criterionIds.get(item.suggestedReasonCriterionId)
+        : undefined,
+      criterionAssessments: item.criterionAssessments.map((assessment) => ({
+        ...assessment,
+        criterionId: requiredMappedId(maps.criterionIds, assessment.criterionId, "assessed review criterion")
+      })),
+      extractionSuggestions: item.extractionSuggestions.map((suggestion) => ({
+        ...suggestion,
+        fieldId: requiredMappedId(maps.fieldIds, suggestion.fieldId, "suggested extraction field")
+      })),
+      evidenceIds: item.evidenceIds.flatMap((evidenceId) => {
+        const mapped = maps.evidenceIds.get(evidenceId);
+        return mapped ? [mapped] : [];
+      }),
+      paperSnapshot: remapPaperSnapshot(item.paperSnapshot, maps)
+    })),
+    auditEvents: state.auditEvents.map((event) => ({
+      ...event,
+      id: requiredMappedId(maps.auditIds, event.id, "review audit event"),
+      reviewId: mappedReviewId,
+      entityId: remapAuditEntityId(event.entityType, event.entityId, maps),
+      payload: remapPortableRecord(event.payload, maps)
+    }))
+  };
+  return reviewPortabilityStateSchema.parse(remapped);
+}
+
+function idMap<T extends { id: string }>(values: T[], prefix: string): Map<string, string> {
+  return new Map(values.map((value) => [value.id, id(prefix)]));
+}
+
+function requiredMappedId(map: Map<string, string>, value: string, label: string): string {
+  const mapped = map.get(value);
+  if (!mapped) throw new Error(`Project review references an unavailable ${label}: ${value}`);
+  return mapped;
+}
+
+function metadataString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function remapPaperSnapshot(snapshot: Record<string, unknown>, maps: ReviewIdentifierMaps): Record<string, unknown> {
+  const remapped = remapPortableRecord(snapshot, maps);
+  if (typeof snapshot.id === "string") remapped.id = maps.paperIds.get(snapshot.id) ?? snapshot.id;
+  remapped.projectId = maps.projectId;
+  return remapped;
+}
+
+function remapPortableRecord(value: Record<string, unknown>, maps: ReviewIdentifierMaps): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, remapPortableValue(key, item, maps)]));
+}
+
+function remapPortableValue(key: string, value: unknown, maps: ReviewIdentifierMaps): unknown {
+  if (Array.isArray(value)) {
+    const singularKey = key.endsWith("Ids") ? `${key.slice(0, -3)}Id` : key;
+    return value.map((item) => remapPortableValue(singularKey, item, maps));
   }
-  for (const [runId, citations] of citationsByRun) {
-    services.db.replaceCitations(runId, citations);
-  }
-  return services.db.getProject(project.id) ?? project;
+  if (value && typeof value === "object") return remapPortableRecord(value as Record<string, unknown>, maps);
+  if (typeof value !== "string") return value;
+  const map = identifierMapForKey(key, maps);
+  return map?.get(value) ?? (key === "projectId" ? maps.projectId : value);
+}
+
+function identifierMapForKey(key: string, maps: ReviewIdentifierMaps): Map<string, string> | undefined {
+  if (key === "reviewId") return maps.reviewIds;
+  if (key === "revisionId" || key === "protocolRevisionId" || key === "currentRevisionId") return maps.revisionIds;
+  if (key === "criterionId" || key === "reasonCriterionId") return maps.criterionIds;
+  if (key === "batchId") return maps.batchIds;
+  if (key === "originId") return maps.originIds;
+  if (key === "decisionId" || key === "previousDecisionId" || key === "supersedesDecisionId") return maps.decisionIds;
+  if (key === "rereviewId") return maps.rereviewIds;
+  if (key === "fieldId") return maps.fieldIds;
+  if (key === "valueId" || key === "extractionValueId") return maps.valueIds;
+  if (key === "evidenceId" || key === "reviewEvidenceId") return maps.evidenceIds;
+  if (key === "runId") return maps.runIds;
+  if (key === "runItemId") return maps.runItemIds;
+  if (key === "paperId" || key === "matchedPaperId") return maps.paperIds;
+  if (key === "artifactId") return maps.artifactIds;
+  if (key === "chunkId") return maps.chunkIds;
+  return undefined;
+}
+
+function remapAuditEntityId(
+  entityType: string | undefined,
+  entityId: string | undefined,
+  maps: ReviewIdentifierMaps
+): string | undefined {
+  if (!entityId) return undefined;
+  const map =
+    entityType === "review"
+      ? maps.reviewIds
+      : entityType === "protocol-revision"
+        ? maps.revisionIds
+        : entityType === "review-criterion"
+          ? maps.criterionIds
+          : entityType === "discovery-batch"
+            ? maps.batchIds
+            : entityType === "candidate-origin"
+              ? maps.originIds
+              : entityType === "screening-decision"
+                ? maps.decisionIds
+                : entityType === "extraction-field"
+                  ? maps.fieldIds
+                  : entityType === "extraction-value"
+                    ? maps.valueIds
+                    : entityType === "review-evidence"
+                      ? maps.evidenceIds
+                      : entityType === "review-run"
+                        ? maps.runIds
+                        : entityType === "review-run-item"
+                          ? maps.runItemIds
+                          : entityType === "paper"
+                            ? maps.paperIds
+                            : entityType === "artifact"
+                              ? maps.artifactIds
+                              : undefined;
+  return map?.get(entityId) ?? entityId;
+}
+
+function findImportedReviewChunkId(
+  db: PaperPilotDb,
+  projectId: string,
+  artifactId: string,
+  evidence: ReviewPortabilityState["evidence"][number]
+): string | undefined {
+  const excerpt = evidence.excerpt.replace(/\s+/g, " ").trim().slice(0, 160);
+  if (!excerpt) return undefined;
+  const chunks = db.listArtifactChunks(projectId, artifactId, 10_000);
+  return chunks.find((chunk) => chunk.text.replace(/\s+/g, " ").includes(excerpt))?.chunkId;
 }
 
 function remapResearchMetadata(
@@ -942,7 +1810,8 @@ function bibField(name: string, value: string): string {
 }
 
 function csvCell(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`;
+  const safeValue = /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
+  return `"${safeValue.replace(/"/g, '""')}"`;
 }
 
 function isTextArtifact(mime: string, type: string): boolean {

--- a/src/main/review-ipc.ts
+++ b/src/main/review-ipc.ts
@@ -1,0 +1,653 @@
+import electron from "electron";
+import type { IpcMainInvokeEvent } from "electron";
+import { mkdtemp, open, rename, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import {
+  activateReviewRequestSchema,
+  artifactSchema,
+  attachReviewPaperPdfRequestSchema,
+  cancelReviewRunRequestSchema,
+  discoveryBatchSchema,
+  exportReviewRequestSchema,
+  extractionFieldSchema,
+  extractionValueSchema,
+  fetchReviewPaperFullTextRequestSchema,
+  getReviewSummaryRequestSchema,
+  markReviewPapersForReviewRequestSchema,
+  paperSchema,
+  referenceImportCommitRequestSchema,
+  referenceImportCommitResponseSchema,
+  referenceImportMappingSchema,
+  referenceImportPreviewRequestSchema,
+  referenceImportPreviewSchema,
+  reorderExtractionFieldsRequestSchema,
+  retryReviewRunRequestSchema,
+  reviseReviewProtocolRequestSchema,
+  reviewFlowSummarySchema,
+  reviewEvidenceSchema,
+  reviewPaperPageSchema,
+  reviewPaperQuerySchema,
+  reviewProtocolRevisionSchema,
+  reviewProtocolSchema,
+  reviewRunEventSchema,
+  reviewRunItemSchema,
+  reviewRunSchema,
+  saveExtractionValueRequestSchema,
+  saveScreeningDecisionRequestSchema,
+  screeningDecisionSchema,
+  startReviewRunRequestSchema,
+  upsertExtractionFieldRequestSchema,
+  type ReviewProtocol,
+  type ReviewRunEvent,
+  type ScreeningDecision
+} from "../shared/schemas.js";
+import type { PaperPilotDb } from "./db.js";
+import type { ArtifactService } from "./services/artifact-service.js";
+import type { FullTextService } from "./services/full-text-service.js";
+import type { ReviewAgentService } from "./services/review-agent-service.js";
+import { renderReviewExportPackage } from "./services/review-export-service.js";
+import type { ReviewImportManager } from "./services/review-import-manager.js";
+import type { SettingsService } from "./services/settings-service.js";
+import { ensureDir, safeFilename } from "./utils.js";
+
+export interface ReviewIpcServices {
+  db: PaperPilotDb;
+  imports: ReviewImportManager;
+  agent: ReviewAgentService;
+  artifacts: ArtifactService;
+  fullText: FullTextService;
+  settings: SettingsService;
+}
+
+type ReviewIpcHandler = (event: IpcMainInvokeEvent, input: unknown) => unknown;
+
+/** Minimal runtime surface keeps IPC registration testable without launching Electron. */
+export interface ReviewIpcRuntime {
+  handle(channel: string, listener: ReviewIpcHandler): void;
+  showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
+  showMessageBox(options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue>;
+}
+
+const reviewStateSchema = z.object({
+  protocol: reviewProtocolSchema,
+  revision: reviewProtocolRevisionSchema
+});
+const reviewIdSchema = z.string().min(1);
+const extractionValueListRequestSchema = z.object({
+  reviewId: z.string(),
+  paperIds: z.array(z.string()).max(500).optional()
+});
+const reviewEvidenceListRequestSchema = z.object({
+  reviewId: z.string(),
+  evidenceIds: z.array(z.string()).max(1_000).optional()
+});
+const remapReferenceImportRequestSchema = z.object({
+  previewId: z.string().min(1),
+  mapping: referenceImportMappingSchema
+});
+const fileActionResponseSchema = z.object({
+  ok: z.boolean(),
+  artifactId: z.string().optional(),
+  warning: z.string().optional()
+});
+const exportResponseSchema = z.object({
+  ok: z.boolean(),
+  path: z.string().optional(),
+  fileCount: z.number().int().nonnegative().optional()
+});
+const markForReviewResponseSchema = z.object({ ok: z.literal(true), marked: z.number().int().nonnegative() });
+const cancelRunResponseSchema = z.object({ cancelled: z.boolean() });
+
+export function registerReviewIpc(services: ReviewIpcServices, providedRuntime?: ReviewIpcRuntime): void {
+  const runtime = providedRuntime ?? electronReviewIpcRuntime();
+
+  runtime.handle("review:get", (_event, projectIdInput) => {
+    const projectId = z.string().parse(projectIdInput);
+    const protocol = services.db.getReview(projectId);
+    if (!protocol) return undefined;
+    return parseReviewState(services.db, protocol);
+  });
+
+  runtime.handle("review:activate", (_event, input) => {
+    const parsed = activateReviewRequestSchema.parse(input);
+    const protocol = services.db.createReview(parsed);
+    return parseReviewState(services.db, protocol);
+  });
+
+  runtime.handle("review:listProtocolRevisions", (_event, reviewIdInput) => {
+    const reviewId = reviewIdSchema.parse(reviewIdInput);
+    requireReview(services.db, reviewId);
+    return z.array(reviewProtocolRevisionSchema).parse(services.db.listReviewProtocolRevisions(reviewId));
+  });
+
+  runtime.handle("review:reviseProtocol", (_event, input) => {
+    const parsed = reviseReviewProtocolRequestSchema.parse(input);
+    const review = requireReview(services.db, parsed.reviewId);
+    if (review.currentRevisionNumber !== parsed.expectedVersion) {
+      throw new Error(
+        `The review protocol changed from version ${parsed.expectedVersion} to ${review.currentRevisionNumber}. Reload before saving.`
+      );
+    }
+    return reviewProtocolRevisionSchema.parse(
+      services.db.reviseReviewProtocol({
+        reviewId: parsed.reviewId,
+        researchQuestion: parsed.researchQuestion,
+        objectives: parsed.objectives,
+        criteria: parsed.criteria,
+        changeNote: parsed.changeNote
+      })
+    );
+  });
+
+  runtime.handle("review:listPapers", (_event, input) => {
+    const parsed = reviewPaperQuerySchema.parse(input);
+    return reviewPaperPageSchema.parse(services.db.listReviewPapers(parsed));
+  });
+
+  runtime.handle("review:listDiscoveryBatches", (_event, reviewIdInput) => {
+    const reviewId = reviewIdSchema.parse(reviewIdInput);
+    requireReview(services.db, reviewId);
+    return z.array(discoveryBatchSchema).parse(services.db.listDiscoveryBatches(reviewId));
+  });
+
+  runtime.handle("review:previewImport", async (_event, input) => {
+    const parsed = referenceImportPreviewRequestSchema.parse(input);
+    requireReviewInProject(services.db, parsed.reviewId, parsed.projectId);
+    const selection = await runtime.showOpenDialog({
+      title: "Preview reference import",
+      properties: ["openFile"],
+      filters: [
+        { name: "Reference files", extensions: ["ris", "bib", "bibtex", "csv"] },
+        { name: "All files", extensions: ["*"] }
+      ]
+    });
+    const filePath = selection.filePaths[0];
+    if (selection.canceled || !filePath) return undefined;
+    try {
+      const preview = await services.imports.preview({ ...parsed, filePath });
+      return referenceImportPreviewSchema.parse(preview);
+    } catch (error) {
+      throw redactSelectedPath(error, filePath);
+    }
+  });
+
+  runtime.handle("review:remapImport", async (_event, input) => {
+    const parsed = remapReferenceImportRequestSchema.parse(input);
+    return referenceImportPreviewSchema.parse(await services.imports.remap(parsed.previewId, parsed.mapping));
+  });
+
+  runtime.handle("review:commitImport", async (_event, input) => {
+    const parsed = referenceImportCommitRequestSchema.parse(input);
+    requireReviewInProject(services.db, parsed.reviewId, parsed.projectId);
+    return referenceImportCommitResponseSchema.parse(await services.imports.commit(parsed));
+  });
+
+  runtime.handle("review:saveDecision", (_event, input) => {
+    const parsed = saveScreeningDecisionRequestSchema.parse(input);
+    return screeningDecisionSchema.parse(services.db.setScreeningDecision(parsed));
+  });
+
+  runtime.handle("review:markForReview", (_event, input) => {
+    const parsed = markReviewPapersForReviewRequestSchema.parse(input);
+    requireReview(services.db, parsed.reviewId);
+    const stages: Array<"title-abstract" | "full-text"> = parsed.stage
+      ? [parsed.stage]
+      : ["title-abstract", "full-text"];
+    const marked = stages.reduce(
+      (total, stage) =>
+        total + services.db.markScreeningForRereview({ reviewId: parsed.reviewId, paperIds: parsed.paperIds, stage }),
+      0
+    );
+    return markForReviewResponseSchema.parse({ ok: true, marked });
+  });
+
+  runtime.handle("review:listExtractionFields", (_event, reviewIdInput) => {
+    const reviewId = reviewIdSchema.parse(reviewIdInput);
+    requireReview(services.db, reviewId);
+    return z.array(extractionFieldSchema).parse(services.db.listExtractionFields(reviewId));
+  });
+
+  runtime.handle("review:upsertExtractionField", (_event, input) => {
+    const parsed = upsertExtractionFieldRequestSchema.parse(input);
+    const existing = parsed.fieldId
+      ? services.db.listExtractionFields(parsed.reviewId, true).find((candidate) => candidate.id === parsed.fieldId)
+      : undefined;
+    if (parsed.fieldId && !existing) throw new Error(`Extraction field not found: ${parsed.fieldId}`);
+    if (existing && parsed.expectedRevision !== undefined && existing.revision !== parsed.expectedRevision) {
+      throw new Error(
+        `Extraction field ${existing.name} changed from revision ${parsed.expectedRevision} to ${existing.revision}. Reload before saving.`
+      );
+    }
+    if (!parsed.fieldId && parsed.expectedRevision !== undefined) {
+      throw new Error("A new extraction field cannot specify an expected revision.");
+    }
+    return extractionFieldSchema.parse(
+      services.db.saveExtractionField({
+        id: parsed.fieldId,
+        reviewId: parsed.reviewId,
+        name: parsed.name,
+        description: parsed.description,
+        type: parsed.type,
+        options: parsed.options,
+        order: parsed.order
+      })
+    );
+  });
+
+  runtime.handle("review:reorderExtractionFields", (_event, input) => {
+    const parsed = reorderExtractionFieldsRequestSchema.parse(input);
+    const fields = services.db.listExtractionFields(parsed.reviewId);
+    const expectedIds = new Set(fields.map((field) => field.id));
+    if (
+      parsed.fieldIds.length !== expectedIds.size ||
+      new Set(parsed.fieldIds).size !== parsed.fieldIds.length ||
+      parsed.fieldIds.some((fieldId) => !expectedIds.has(fieldId))
+    ) {
+      throw new Error("Extraction field order must include every active field exactly once.");
+    }
+    const byId = new Map(fields.map((field) => [field.id, field]));
+    for (const [order, fieldId] of parsed.fieldIds.entries()) {
+      const field = byId.get(fieldId)!;
+      services.db.saveExtractionField({
+        id: field.id,
+        reviewId: field.reviewId,
+        name: field.name,
+        description: field.description,
+        type: field.type,
+        options: field.options,
+        order,
+        active: field.active
+      });
+    }
+    return z.array(extractionFieldSchema).parse(services.db.listExtractionFields(parsed.reviewId));
+  });
+
+  runtime.handle("review:listExtractionValues", (_event, input) => {
+    const parsed = extractionValueListRequestSchema.parse(input);
+    requireReview(services.db, parsed.reviewId);
+    const values = services.db.listExtractionValues(parsed.reviewId);
+    const requestedIds = parsed.paperIds ? new Set(parsed.paperIds) : undefined;
+    return z
+      .array(extractionValueSchema)
+      .parse(requestedIds ? values.filter((value) => requestedIds.has(value.paperId)) : values);
+  });
+
+  runtime.handle("review:listEvidence", (_event, input) => {
+    const parsed = reviewEvidenceListRequestSchema.parse(input);
+    requireReview(services.db, parsed.reviewId);
+    const evidence = services.db.listReviewEvidence(parsed.reviewId);
+    const requestedIds = parsed.evidenceIds ? new Set(parsed.evidenceIds) : undefined;
+    return z
+      .array(reviewEvidenceSchema)
+      .parse(requestedIds ? evidence.filter((entry) => requestedIds.has(entry.id)) : evidence);
+  });
+
+  runtime.handle("review:saveExtractionValue", (_event, input) => {
+    const parsed = saveExtractionValueRequestSchema.parse(input);
+    const field = services.db
+      .listExtractionFields(parsed.reviewId)
+      .find((candidate) => candidate.id === parsed.fieldId);
+    if (!field) throw new Error(`Active extraction field not found: ${parsed.fieldId}`);
+    if (field.revision !== parsed.expectedFieldRevision) {
+      throw new Error(
+        `Extraction field ${field.name} changed from revision ${parsed.expectedFieldRevision} to ${field.revision}. Reload before saving.`
+      );
+    }
+    const existing = services.db
+      .listExtractionValues(parsed.reviewId, parsed.paperId)
+      .find((value) => value.fieldId === parsed.fieldId);
+    const confirmsAiSuggestion =
+      existing?.origin === "ai" &&
+      existing.status === "suggested" &&
+      parsed.status === "confirmed" &&
+      JSON.stringify(existing.value) === JSON.stringify(parsed.value) &&
+      sameStringSet(existing.evidenceIds, parsed.evidenceIds);
+    const rejectsAiSuggestion =
+      existing?.origin === "ai" &&
+      (existing.status === "suggested" || existing.status === "needs-review") &&
+      parsed.status === "rejected";
+    const acceptsAiNotFoundSuggestion =
+      existing?.origin === "ai" &&
+      (existing.status === "suggested" || existing.status === "needs-review") &&
+      existing.value === null &&
+      parsed.status === "not-found";
+    const preservesAiProvenance = rejectsAiSuggestion || confirmsAiSuggestion;
+    const retainsOriginatingRun = preservesAiProvenance || acceptsAiNotFoundSuggestion;
+    return extractionValueSchema.parse(
+      services.db.saveExtractionValue({
+        id: existing?.id,
+        reviewId: parsed.reviewId,
+        paperId: parsed.paperId,
+        fieldId: parsed.fieldId,
+        value: rejectsAiSuggestion ? existing.value : parsed.value,
+        status: parsed.status,
+        origin: preservesAiProvenance ? "ai" : "manual",
+        evidenceIds: rejectsAiSuggestion ? existing.evidenceIds : parsed.evidenceIds,
+        runItemId: retainsOriginatingRun ? existing?.runItemId : undefined,
+        createdAt: existing?.createdAt
+      })
+    );
+  });
+
+  runtime.handle("review:startRun", async (event, input) => {
+    const parsed = startReviewRunRequestSchema.parse(input);
+    await confirmHostedReviewRun(services, runtime, parsed.reviewId);
+    return reviewRunSchema.parse(await services.agent.start(parsed, senderEmitter(event)));
+  });
+
+  runtime.handle("review:cancelRun", (_event, input) => {
+    const parsed = cancelReviewRunRequestSchema.parse(input);
+    return cancelRunResponseSchema.parse({ cancelled: services.agent.cancel(parsed.runId) });
+  });
+
+  runtime.handle("review:retryRun", async (event, input) => {
+    const parsed = retryReviewRunRequestSchema.parse(input);
+    const run = services.db.getReviewRun(parsed.runId);
+    if (!run) throw new Error(`Review run not found: ${parsed.runId}`);
+    await confirmHostedReviewRun(services, runtime, run.reviewId);
+    return reviewRunSchema.parse(await services.agent.retry(parsed.runId, senderEmitter(event)));
+  });
+
+  runtime.handle("review:listRuns", (_event, reviewIdInput) => {
+    const reviewId = reviewIdSchema.parse(reviewIdInput);
+    requireReview(services.db, reviewId);
+    return z.array(reviewRunSchema).parse(services.db.listReviewRuns(reviewId));
+  });
+
+  runtime.handle("review:listRunItems", (_event, runIdInput) => {
+    const runId = z.string().parse(runIdInput);
+    if (!services.db.getReviewRun(runId)) throw new Error(`Review run not found: ${runId}`);
+    return z.array(reviewRunItemSchema).parse(services.db.listReviewRunItems(runId));
+  });
+
+  runtime.handle("review:getSummary", (_event, input) => {
+    const parsed = getReviewSummaryRequestSchema.parse(input);
+    return reviewFlowSummarySchema.parse(services.db.getReviewFlowSummary(parsed.reviewId));
+  });
+
+  runtime.handle("review:fetchFullText", async (_event, input) => {
+    const parsed = fetchReviewPaperFullTextRequestSchema.parse(input);
+    const { paper } = requireReviewPaper(services.db, parsed);
+    const result = await services.fullText.fetchOpenAccessPdf(parsed.projectId, paper);
+    const artifact = result.artifact ? artifactSchema.parse(result.artifact) : undefined;
+    if (artifact) {
+      services.db.appendReviewAuditEvent({
+        reviewId: parsed.reviewId,
+        kind: "paper-pdf-attached",
+        actor: "system",
+        entityType: "paper",
+        entityId: paper.id,
+        payload: { artifactId: artifact.id, method: "open-access-fetch" }
+      });
+    }
+    return fileActionResponseSchema.parse({
+      ok: Boolean(artifact),
+      artifactId: artifact?.id,
+      warning: result.warning ?? (artifact ? undefined : "No trusted open-access PDF URL is available for this paper.")
+    });
+  });
+
+  runtime.handle("review:attachPdf", async (_event, input) => {
+    const parsed = attachReviewPaperPdfRequestSchema.parse(input);
+    const { paper } = requireReviewPaper(services.db, parsed);
+    const selection = await runtime.showOpenDialog({
+      title: `Attach PDF — ${paper.title}`,
+      properties: ["openFile"],
+      filters: [{ name: "PDF documents", extensions: ["pdf"] }]
+    });
+    const filePath = selection.filePaths[0];
+    if (selection.canceled || !filePath) return fileActionResponseSchema.parse({ ok: false });
+    try {
+      await assertPdfFile(filePath);
+      const artifact = artifactSchema.parse(
+        await services.artifacts.importFile({
+          projectId: parsed.projectId,
+          type: "paper-pdf",
+          title: paper.title,
+          sourcePath: filePath,
+          source: "review-pdf-attachment",
+          metadata: {
+            paperId: paper.id,
+            doi: paper.doi,
+            sourcePaperId: paper.sourcePaperId
+          },
+          indexText: true
+        })
+      );
+      services.db.appendReviewAuditEvent({
+        reviewId: parsed.reviewId,
+        kind: "paper-pdf-attached",
+        actor: "user",
+        entityType: "paper",
+        entityId: paper.id,
+        payload: { artifactId: artifact.id, method: "manual-attachment" }
+      });
+      return fileActionResponseSchema.parse({ ok: true, artifactId: artifact.id });
+    } catch (error) {
+      throw redactSelectedPath(error, filePath);
+    }
+  });
+
+  runtime.handle("review:export", async (_event, input) => {
+    const parsed = exportReviewRequestSchema.parse(input);
+    const review = requireReview(services.db, parsed.reviewId);
+    const revision = services.db.getReviewProtocolRevision(review.id);
+    if (!revision) throw new Error(`Current protocol revision not found for review: ${review.id}`);
+    const project = services.db.getProject(review.projectId);
+    if (!project) throw new Error(`Project not found: ${review.projectId}`);
+    const selection = await runtime.showOpenDialog({
+      title: "Export evidence review package",
+      defaultPath: `${safeFilename(project.title)}-evidence-review`,
+      properties: ["openDirectory", "createDirectory"]
+    });
+    const selectedDirectory = selection.filePaths[0];
+    if (selection.canceled || !selectedDirectory) return exportResponseSchema.parse({ ok: false });
+
+    const portabilityState = services.db.exportReviewPortabilityState(review.id);
+    const flowSummary = reviewFlowSummarySchema.parse({
+      ...services.db.getReviewFlowSummary(review.id),
+      generatedAt: stableReviewStateTimestamp(portabilityState)
+    });
+    const includedPaperIds = currentEligibleIncludedPaperIds(portabilityState);
+    const includedPapers = services.db.listPapers(review.projectId).filter((paper) => includedPaperIds.has(paper.id));
+    const packageFiles = renderReviewExportPackage({
+      protocol: reviewProtocolSchema.parse(review),
+      revision: reviewProtocolRevisionSchema.parse(revision),
+      revisions: portabilityState.revisions,
+      batches: z.array(discoveryBatchSchema).parse(portabilityState.discoveryBatches),
+      candidateOrigins: portabilityState.candidateOrigins,
+      screeningDecisions: portabilityState.screeningDecisions,
+      includedPapers: z.array(paperSchema).parse(includedPapers),
+      includedPaperIds: [...includedPaperIds],
+      extractionFields: z.array(extractionFieldSchema).parse(portabilityState.extractionFields),
+      extractionFieldHistory: portabilityState.extractionFieldHistory ?? [],
+      extractionValues: portabilityState.extractionValues,
+      extractionValueHistory: portabilityState.extractionValueHistory ?? [],
+      evidence: portabilityState.evidence,
+      runs: z.array(reviewRunSchema).parse(portabilityState.runs),
+      runItems: portabilityState.runItems,
+      auditEvents: portabilityState.auditEvents,
+      flowSummary
+    });
+    const suffix = flowSummary.generatedAt.replace(/[:.]/g, "-");
+    const targetDirectory = await availableExportDirectory(
+      join(selectedDirectory, `${safeFilename(project.title)}-evidence-review-${suffix}`)
+    );
+    await ensureDir(selectedDirectory);
+    const stagingDirectory = await mkdtemp(join(selectedDirectory, ".paper-pilot-review-export-"));
+    try {
+      await Promise.all(
+        [...packageFiles].map(([fileName, content]) => writeFile(join(stagingDirectory, fileName), content, "utf8"))
+      );
+      await rename(stagingDirectory, targetDirectory);
+    } catch (error) {
+      await rm(stagingDirectory, { recursive: true, force: true });
+      throw error;
+    }
+    return exportResponseSchema.parse({ ok: true, path: targetDirectory, fileCount: packageFiles.size });
+  });
+}
+
+function stableReviewStateTimestamp(state: ReturnType<PaperPilotDb["exportReviewPortabilityState"]>): string {
+  const timestamps = [
+    state.review.activatedAt,
+    state.review.createdAt,
+    state.review.updatedAt,
+    ...state.revisions.map((revision) => revision.createdAt),
+    ...state.discoveryBatches.flatMap((batch) => [batch.createdAt, batch.completedAt]),
+    ...state.candidateOrigins.map((origin) => origin.createdAt),
+    ...state.rereviewFlags.flatMap((flag) => [flag.createdAt, flag.resolvedAt]),
+    ...state.screeningDecisions.map((decision) => decision.createdAt),
+    ...state.extractionFields.flatMap((field) => [field.createdAt, field.updatedAt]),
+    ...(state.extractionFieldHistory ?? []).map((field) => field.recordedAt),
+    ...state.extractionValues.flatMap((value) => [value.createdAt, value.updatedAt, value.confirmedAt]),
+    ...(state.extractionValueHistory ?? []).map((value) => value.recordedAt),
+    ...state.evidence.map((evidence) => evidence.createdAt),
+    ...state.runs.flatMap((run) => [run.createdAt, run.updatedAt, run.startedAt, run.completedAt]),
+    ...state.runItems.flatMap((item) => [item.createdAt, item.updatedAt, item.startedAt, item.completedAt]),
+    ...state.auditEvents.map((event) => event.createdAt)
+  ].filter((value): value is string => Boolean(value));
+  return timestamps.sort().at(-1) ?? state.review.activatedAt;
+}
+
+async function availableExportDirectory(basePath: string): Promise<string> {
+  for (let suffix = 1; ; suffix += 1) {
+    const candidate = suffix === 1 ? basePath : `${basePath}-${suffix}`;
+    try {
+      await stat(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return candidate;
+      throw error;
+    }
+  }
+}
+
+function electronReviewIpcRuntime(): ReviewIpcRuntime {
+  return {
+    handle: (channel, listener) => {
+      electron.ipcMain.handle(channel, (event, input) => listener(event, input));
+    },
+    showOpenDialog: (options) => electron.dialog.showOpenDialog(options),
+    showMessageBox: (options) => electron.dialog.showMessageBox(options)
+  };
+}
+
+function parseReviewState(db: PaperPilotDb, protocolInput: ReviewProtocol) {
+  const protocol = reviewProtocolSchema.parse(protocolInput);
+  const revision = db.getReviewProtocolRevision(protocol.id, protocol.currentRevisionId);
+  if (!revision) throw new Error(`Current protocol revision not found for review: ${protocol.id}`);
+  return reviewStateSchema.parse({ protocol, revision });
+}
+
+function requireReview(db: PaperPilotDb, reviewId: string): ReviewProtocol {
+  const review = db.getReviewById(reviewId);
+  if (!review) throw new Error(`Review not found: ${reviewId}`);
+  return reviewProtocolSchema.parse(review);
+}
+
+function requireReviewInProject(db: PaperPilotDb, reviewId: string, projectId: string): ReviewProtocol {
+  const review = requireReview(db, reviewId);
+  if (review.projectId !== projectId) throw new Error("Review not found in the selected project.");
+  return review;
+}
+
+function requireReviewPaper(db: PaperPilotDb, input: { reviewId: string; projectId: string; paperId: string }) {
+  const review = requireReviewInProject(db, input.reviewId, input.projectId);
+  const paper = db.getPaper(input.projectId, input.paperId);
+  if (!paper) throw new Error(`Paper not found in review project: ${input.paperId}`);
+  return { review, paper: paperSchema.parse(paper) };
+}
+
+function senderEmitter(event: IpcMainInvokeEvent): (runEvent: ReviewRunEvent) => void {
+  return (runEvent) => {
+    const validated = reviewRunEventSchema.parse(runEvent);
+    if (!event.sender.isDestroyed()) event.sender.send("review:run-event", validated);
+  };
+}
+
+async function confirmHostedReviewRun(
+  services: ReviewIpcServices,
+  runtime: ReviewIpcRuntime,
+  reviewId: string
+): Promise<void> {
+  const review = requireReview(services.db, reviewId);
+  const project = services.db.getProject(review.projectId);
+  if (!project) throw new Error(`Project not found: ${review.projectId}`);
+  const settings = await services.settings.get();
+  if (settings.ai.provider === "ollama" || !project.policy.warnOnPaidModelRuns) return;
+  const confirmation = await runtime.showMessageBox({
+    type: "warning",
+    title: "Run hosted review assistance?",
+    message: `This batch will use ${settings.ai.provider} with ${settings.ai.model}.`,
+    detail:
+      "The selected papers' review evidence will be sent to the configured hosted provider and may incur charges.",
+    buttons: ["Cancel", "Run review"],
+    defaultId: 0,
+    cancelId: 0,
+    noLink: true
+  });
+  if (confirmation.response !== 1) throw new Error("Hosted review run cancelled before contacting the provider.");
+}
+
+async function assertPdfFile(filePath: string): Promise<void> {
+  const handle = await open(filePath, "r");
+  try {
+    const header = Buffer.alloc(5);
+    const result = await handle.read(header, 0, header.length, 0);
+    if (result.bytesRead < 5 || header.toString("ascii") !== "%PDF-") {
+      throw new Error("The selected file is not a valid PDF document.");
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+function currentScreeningDecisions(decisions: readonly ScreeningDecision[]): ScreeningDecision[] {
+  const current = new Map<string, ScreeningDecision>();
+  for (const decision of decisions) current.set(`${decision.paperId}\u0000${decision.stage}`, decision);
+  return [...current.values()];
+}
+
+/**
+ * Keep package membership aligned with the review-flow summary and extraction
+ * queue: a current full-text inclusion is only eligible while the current
+ * title/abstract decision is also Include and no unresolved downstream
+ * invalidation is open for full-text screening.
+ */
+function currentEligibleIncludedPaperIds(state: ReturnType<PaperPilotDb["exportReviewPortabilityState"]>): Set<string> {
+  const currentDecisions = currentScreeningDecisions(state.screeningDecisions);
+  const titleAbstractIncluded = new Set(
+    currentDecisions
+      .filter((decision) => decision.stage === "title-abstract" && decision.decision === "include")
+      .map((decision) => decision.paperId)
+  );
+  const invalidatedFullText = new Set(
+    state.rereviewFlags
+      .filter(
+        (flag) => flag.stage === "full-text" && flag.invalidatesDownstream === true && flag.resolvedAt === undefined
+      )
+      .map((flag) => flag.paperId)
+  );
+  return new Set(
+    currentDecisions
+      .filter(
+        (decision) =>
+          decision.stage === "full-text" &&
+          decision.decision === "include" &&
+          titleAbstractIncluded.has(decision.paperId) &&
+          !invalidatedFullText.has(decision.paperId)
+      )
+      .map((decision) => decision.paperId)
+  );
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value) => right.includes(value));
+}
+
+function redactSelectedPath(error: unknown, selectedPath: string): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  const redacted = message.split(selectedPath).join("the selected file");
+  return new Error(redacted);
+}

--- a/src/main/services/crawl-service.ts
+++ b/src/main/services/crawl-service.ts
@@ -3,7 +3,6 @@ import {
   type CrawlConfig,
   crawlConfigSchema,
   type Paper,
-  paperDedupeKey,
   type SourceDiagnostic,
   type SourceId
 } from "../../shared/schemas.js";
@@ -17,7 +16,9 @@ import type { FullTextService } from "./full-text-service.js";
 import type { JobQueue } from "./job-queue.js";
 import type { PaperScoringService } from "./paper-scoring-service.js";
 import type { SettingsService } from "./settings-service.js";
+import { mergeAuthoritativeSourceIdentifiers, PaperIdentityResolver } from "./paper-identity.js";
 import { requiresApproval } from "./policy.js";
+import { id } from "../utils.js";
 
 export interface CrawlRunResult {
   jobId: string;
@@ -46,9 +47,11 @@ export class CrawlService {
   ): Promise<CrawlRunResult> {
     const project = this.db.getProject(projectId);
     if (!project) throw new Error(`Project not found: ${projectId}`);
+    const activeReview = this.db.getReview(projectId);
     let config = crawlConfigSchema.parse({
       topic: project.topic ?? input.topic ?? "scientific literature",
       ...input,
+      openAccessOnly: input.openAccessOnly ?? (activeReview ? false : undefined),
       maxPapers: Math.min(input.maxPapers ?? project.policy.maxCrawlPapers, project.policy.maxCrawlPapers)
     });
     const disabledSourceIds = new Set((await this.settings?.get())?.sources.disabledSourceIds ?? []);
@@ -89,6 +92,7 @@ export class CrawlService {
     const connectorResults: Array<{ sourceId: SourceId; result?: CrawlResult; error?: string }> = [];
     const sourceDiagnostics: SourceDiagnostic[] = [];
     const saved = new Map<string, Paper>();
+    const identityResolver = new PaperIdentityResolver(this.db.listPapers(projectId));
     const sourceIds = config.sourceIds;
     const credentialMap = this.credentials.getMany(sourceIds);
 
@@ -96,6 +100,26 @@ export class CrawlService {
       const sourceId = sourceIds[index];
       const definition = this.registry.get(sourceId).definition;
       const startedAt = Date.now();
+      const discoveryBatch = activeReview
+        ? this.db.saveDiscoveryBatch({
+            reviewId: activeReview.id,
+            kind: "crawl",
+            label: `${definition.displayName}: ${config.topic}`,
+            sourceId,
+            status: "running",
+            counts: {},
+            config,
+            historicalCountsAvailable: true
+          })
+        : undefined;
+      const batchCounts = {
+        identified: 0,
+        filtered: 0,
+        invalid: 0,
+        duplicates: 0,
+        merged: 0,
+        newRecords: 0
+      };
       this.jobs.update(job.id, {
         progress: index / Math.max(sourceIds.length, 1),
         detail: `Running ${definition.displayName}`
@@ -124,10 +148,76 @@ export class CrawlService {
           attemptedUrl: diagnosticUrl(result.provenance),
           graceful: true
         });
+        batchCounts.identified = result.papers.length;
         for (const paper of result.papers) {
-          if (config.openAccessOnly && !paper.isOpenAccess && !paper.pdfUrl) continue;
-          const savedPaper = this.db.savePaper(projectId, paper);
-          saved.set(paperDedupeKey(savedPaper), savedPaper);
+          if (config.openAccessOnly && !paper.isOpenAccess && !paper.pdfUrl) {
+            batchCounts.filtered += 1;
+            if (discoveryBatch) {
+              this.db.recordReviewCandidateOrigin({
+                reviewId: activeReview!.id,
+                batchId: discoveryBatch.id,
+                sourceRecordId: paper.sourcePaperId,
+                resolution: "filtered",
+                recordSnapshot: paper
+              });
+            }
+            continue;
+          }
+          const match = identityResolver.resolve(paper);
+          let savedPaper: Paper;
+          let matchedPaperId: string | undefined;
+          let resolution: "merged" | "duplicate" | "created" | "kept-separate";
+          if (match.kind === "exact") {
+            matchedPaperId = match.candidate.id;
+            if (wouldEnrichPaper(match.candidate, paper)) {
+              savedPaper = this.db.updatePaper(
+                projectId,
+                match.candidate.id,
+                mergeCrawlerPaperMetadata(match.candidate, paper)
+              );
+              identityResolver.replace(match.candidate, savedPaper);
+              batchCounts.merged += 1;
+              resolution = "merged";
+            } else {
+              savedPaper = match.candidate;
+              batchCounts.duplicates += 1;
+              resolution = "duplicate";
+            }
+          } else {
+            const keptSeparate = match.kind === "ambiguous";
+            const separateId = keptSeparate ? id("paper") : paper.id;
+            savedPaper = this.db.savePaper(projectId, {
+              ...paper,
+              id: separateId,
+              raw: keptSeparate ? { ...(paper.raw ?? {}), forceSeparateIdentity: separateId } : paper.raw
+            });
+            identityResolver.add(savedPaper);
+            matchedPaperId = keptSeparate ? match.candidates[0]?.id : undefined;
+            batchCounts.newRecords += 1;
+            resolution = keptSeparate ? "kept-separate" : "created";
+          }
+          saved.set(savedPaper.id, savedPaper);
+          if (discoveryBatch) {
+            this.db.recordReviewCandidateOrigin({
+              reviewId: activeReview!.id,
+              batchId: discoveryBatch.id,
+              paperId: savedPaper.id,
+              matchedPaperId,
+              sourceRecordId: paper.sourcePaperId,
+              resolution,
+              paperSnapshot: savedPaper,
+              recordSnapshot: paper
+            });
+          }
+        }
+        if (discoveryBatch) {
+          this.db.saveDiscoveryBatch({
+            ...discoveryBatch,
+            status: "completed",
+            counts: batchCounts,
+            config,
+            completedAt: new Date().toISOString()
+          });
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -143,6 +233,16 @@ export class CrawlService {
           error: message,
           graceful: false
         });
+        if (discoveryBatch) {
+          this.db.saveDiscoveryBatch({
+            ...discoveryBatch,
+            status: "failed",
+            counts: batchCounts,
+            error: message,
+            config,
+            completedAt: new Date().toISOString()
+          });
+        }
       }
     }
 
@@ -203,7 +303,7 @@ export class CrawlService {
     this.jobs.update(job.id, {
       status: "completed",
       progress: 1,
-      detail: `Found ${papers.length} open-access papers and downloaded ${fullTextArtifacts.length} PDFs.`,
+      detail: `Retained ${papers.length} papers and downloaded ${fullTextArtifacts.length} PDFs.`,
       result: {
         paperCount: papers.length,
         artifactIds: [metadataArtifact.id, markdownArtifact.id, ...fullTextArtifacts.map((artifact) => artifact.id)]
@@ -287,6 +387,45 @@ function diagnosticUrl(provenance: Record<string, unknown> | undefined): string 
     if (typeof value === "string" && value.trim()) return value;
   }
   return undefined;
+}
+
+function wouldEnrichPaper(previous: Paper, incoming: Paper): boolean {
+  const patch = mergeCrawlerPaperMetadata(previous, incoming);
+  return (
+    (!previous.abstract && Boolean(patch.abstract)) ||
+    (!previous.authors.length && Boolean(patch.authors?.length)) ||
+    (previous.year === undefined && patch.year !== undefined) ||
+    (!previous.publishedAt && Boolean(patch.publishedAt)) ||
+    (!previous.pdfUrl && Boolean(patch.pdfUrl)) ||
+    (!previous.url && Boolean(patch.url)) ||
+    (!previous.venue && Boolean(patch.venue)) ||
+    (!previous.doi && Boolean(patch.doi)) ||
+    (patch.citationCount ?? 0) > (previous.citationCount ?? 0) ||
+    (!previous.isOpenAccess && Boolean(patch.isOpenAccess)) ||
+    (!previous.license && Boolean(patch.license)) ||
+    patch.sourcePaperId !== previous.sourcePaperId ||
+    JSON.stringify(patch.raw ?? {}) !== JSON.stringify(previous.raw ?? {})
+  );
+}
+
+function mergeCrawlerPaperMetadata(current: Paper, incoming: Paper): Partial<Paper> {
+  const identity = mergeAuthoritativeSourceIdentifiers(current, incoming);
+  return {
+    abstract: current.abstract || incoming.abstract,
+    authors: current.authors.length ? current.authors : incoming.authors,
+    year: current.year ?? incoming.year,
+    publishedAt: current.publishedAt ?? incoming.publishedAt,
+    doi: current.doi ?? incoming.doi,
+    url: current.url ?? incoming.url,
+    pdfUrl: current.pdfUrl ?? incoming.pdfUrl,
+    venue: current.venue ?? incoming.venue,
+    citationCount: Math.max(current.citationCount ?? 0, incoming.citationCount ?? 0) || undefined,
+    isOpenAccess: current.isOpenAccess || incoming.isOpenAccess,
+    license: current.license ?? incoming.license,
+    fieldsOfStudy: [...new Set([...current.fieldsOfStudy, ...incoming.fieldsOfStudy])],
+    sourcePaperId: identity.sourcePaperId,
+    raw: identity.raw
+  };
 }
 
 function googleScholarDiagnosticUrl(topic: string): string {

--- a/src/main/services/paper-identity.ts
+++ b/src/main/services/paper-identity.ts
@@ -1,0 +1,563 @@
+/**
+ * Conservative paper identity helpers used by reference imports and crawlers.
+ *
+ * A title by itself is deliberately never considered enough evidence for an
+ * automatic merge. Callers must surface ambiguous results to a human.
+ */
+
+export interface PaperIdentityInput {
+  id?: string;
+  title: string;
+  authors?: readonly string[];
+  year?: number;
+  doi?: string;
+  source?: string;
+  sourcePaperId?: string;
+  sourceAuthority?: string;
+  raw?: Record<string, unknown>;
+}
+
+export type PaperIdentityStrategy = "doi" | "source-identifier" | "bibliographic-fingerprint";
+
+export type PaperIdentityAmbiguity = PaperIdentityStrategy | "title-only" | "conflicting-identifiers";
+
+export interface AuthoritativeSourceIdentifier {
+  authority: string;
+  identifier: string;
+}
+
+export type PaperIdentityMatch<T extends PaperIdentityInput> =
+  | {
+      kind: "exact";
+      strategy: PaperIdentityStrategy;
+      key: string;
+      candidate: T;
+    }
+  | {
+      kind: "ambiguous";
+      strategy: PaperIdentityAmbiguity;
+      key?: string;
+      candidates: T[];
+      reasons: string[];
+    }
+  | {
+      kind: "none";
+      candidates: [];
+    };
+
+export function normalizeDoi(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  let normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  try {
+    normalized = decodeURIComponent(normalized);
+  } catch {
+    // Invalid URL encoding is not safe identity evidence. The import itself can
+    // still proceed with the DOI omitted.
+    return undefined;
+  }
+
+  normalized = normalized
+    .replace(/^doi\s*:\s*/i, "")
+    .replace(/^(?:https?:\/\/)?(?:www\.)?(?:dx\.)?doi\.org\//i, "")
+    .replace(/^urn:doi:/i, "")
+    .trim()
+    .replace(/[\s.,;:]+$/g, "");
+
+  const match = /^10\.\d{4,9}\/(.+)$/u.exec(normalized);
+  if (!match || normalized.length > 2_048) return undefined;
+  const suffix = match[1];
+  if (/\s/u.test(suffix) || /[\u0000-\u001f\u007f]/u.test(suffix)) return undefined;
+  if (!/[\p{Letter}\p{Number}]/u.test(suffix)) return undefined;
+
+  return normalized;
+}
+
+export function normalizeSourceAuthority(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = foldText(value)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  if (!normalized || normalized === "reference-import") return undefined;
+
+  const aliases: Record<string, string> = {
+    arxiv: "arxiv",
+    crossref: "crossref",
+    doi: "crossref",
+    openalex: "openalex",
+    "open-alex": "openalex",
+    pmid: "pubmed",
+    pubmed: "pubmed",
+    "semantic-scholar": "semantic-scholar",
+    semanticscholar: "semantic-scholar",
+    s2: "semantic-scholar",
+    "europe-pmc": "europe-pmc",
+    europepmc: "europe-pmc",
+    core: "core"
+  };
+  return aliases[normalized] ?? normalized;
+}
+
+export function normalizeSourceIdentifier(value: string | undefined, authority?: string): string | undefined {
+  if (!value) return undefined;
+  const normalizedAuthority = normalizeSourceAuthority(authority);
+  let normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  try {
+    normalized = decodeURIComponent(normalized);
+  } catch {
+    // Keep the literal identifier when it is not valid URL encoding.
+  }
+
+  normalized = normalized
+    .replace(/^https?:\/\/(?:www\.)?openalex\.org\//, "")
+    .replace(/^https?:\/\/(?:www\.)?pubmed\.ncbi\.nlm\.nih\.gov\//, "")
+    .replace(/^https?:\/\/(?:www\.)?arxiv\.org\/(?:abs|pdf)\//, "")
+    .replace(/\.pdf$/i, "")
+    .replace(/\/+$/g, "")
+    .trim();
+
+  if (normalizedAuthority === "arxiv") {
+    normalized = normalized.replace(/^arxiv\s*:\s*/, "").replace(/v\d+$/i, "");
+  } else if (normalizedAuthority === "pubmed") {
+    normalized = normalized.replace(/^pmid\s*:\s*/, "");
+  } else if (normalizedAuthority === "openalex") {
+    normalized = normalized.replace(/^openalex\s*:\s*/, "");
+  }
+
+  return normalized.replace(/\s+/g, "") || undefined;
+}
+
+export function normalizeBibliographicTitle(value: string): string {
+  return foldText(value)
+    .replace(/[^\p{Letter}\p{Number}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function normalizeFirstAuthor(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const cleaned = foldText(value)
+    .replace(/\b(?:orcid|https?):\S+/g, " ")
+    .replace(/[^\p{Letter}\p{Number}, ]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return undefined;
+
+  const commaParts = cleaned
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  let family: string;
+  let given: string;
+  if (commaParts.length > 1) {
+    family = commaParts[0];
+    given = commaParts.slice(1).join(" ");
+  } else {
+    const tokens = cleaned.split(" ").filter(Boolean);
+    family = tokens.at(-1) ?? "";
+    given = tokens.slice(0, -1).join(" ");
+  }
+  if (!family) return undefined;
+  const initials = given
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => [...part][0])
+    .join("");
+  return `${family.replace(/\s+/g, "")}:${initials}`;
+}
+
+export function doiIdentityKey(input: Pick<PaperIdentityInput, "doi">): string | undefined {
+  const doi = normalizeDoi(input.doi);
+  return doi ? `doi:${doi}` : undefined;
+}
+
+export function sourceIdentifierIdentityKey(
+  input: Pick<PaperIdentityInput, "source" | "sourcePaperId" | "sourceAuthority" | "raw">
+): string | undefined {
+  return sourceIdentifierIdentityKeys(input)[0];
+}
+
+/**
+ * Returns every authoritative identifier retained for a paper. The first item
+ * is the paper's primary source identifier; later items are identifiers learned
+ * from other connectors/imports and retained in raw metadata.
+ */
+export function sourceIdentifierIdentityKeys(
+  input: Pick<PaperIdentityInput, "source" | "sourcePaperId" | "sourceAuthority" | "raw">
+): string[] {
+  return authoritativeSourceIdentifiers(input).map(({ authority, identifier }) => `source:${authority}:${identifier}`);
+}
+
+export function authoritativeSourceIdentifiers(
+  input: Pick<PaperIdentityInput, "source" | "sourcePaperId" | "sourceAuthority" | "raw">
+): AuthoritativeSourceIdentifier[] {
+  const identifiers: AuthoritativeSourceIdentifier[] = [];
+  const primaryAuthority = normalizeSourceAuthority(identitySourceAuthority(input));
+  const primaryIdentifier = normalizeSourceIdentifier(input.sourcePaperId, primaryAuthority);
+  if (primaryAuthority && primaryIdentifier) {
+    identifiers.push({ authority: primaryAuthority, identifier: primaryIdentifier });
+  }
+
+  const retained = input.raw?.identitySourceIdentifiers;
+  if (Array.isArray(retained)) {
+    for (const item of retained) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const candidate = item as Record<string, unknown>;
+      const authority = normalizeSourceAuthority(
+        typeof candidate.authority === "string" ? candidate.authority : undefined
+      );
+      const identifier = normalizeSourceIdentifier(
+        typeof candidate.identifier === "string" ? candidate.identifier : undefined,
+        authority
+      );
+      if (authority && identifier) identifiers.push({ authority, identifier });
+    }
+  }
+  return uniqueSourceIdentifiers(identifiers);
+}
+
+/**
+ * Retains newly learned source identities without ever placing an identifier
+ * in a primary source namespace that does not own it.
+ */
+export function mergeAuthoritativeSourceIdentifiers(
+  current: Pick<PaperIdentityInput, "source" | "sourcePaperId" | "sourceAuthority" | "raw">,
+  incoming: Pick<PaperIdentityInput, "source" | "sourcePaperId" | "sourceAuthority" | "raw">
+): { sourcePaperId?: string; raw: Record<string, unknown> } {
+  const raw: Record<string, unknown> = { ...(current.raw ?? {}) };
+  const currentAuthority = normalizeSourceAuthority(identitySourceAuthority(current));
+  let sourcePaperId = current.sourcePaperId;
+  let retained = authoritativeSourceIdentifiers(current);
+
+  for (const identity of authoritativeSourceIdentifiers(incoming)) {
+    if (retained.some((candidate) => sameSourceIdentifier(candidate, identity))) continue;
+
+    const mayBecomePrimary =
+      !sourcePaperId &&
+      (currentAuthority === identity.authority || (!currentAuthority && current.source === "reference-import"));
+    if (mayBecomePrimary) {
+      sourcePaperId = identity.identifier;
+      if (!currentAuthority) raw.sourceAuthority = identity.authority;
+    } else {
+      retained.push(identity);
+    }
+  }
+
+  retained = uniqueSourceIdentifiers(retained).filter((identity) => {
+    const primaryAuthority = normalizeSourceAuthority(
+      typeof raw.sourceAuthority === "string" && current.source === "reference-import"
+        ? raw.sourceAuthority
+        : current.source
+    );
+    const primaryIdentifier = normalizeSourceIdentifier(sourcePaperId, primaryAuthority);
+    return identity.authority !== primaryAuthority || identity.identifier !== primaryIdentifier;
+  });
+  if (retained.length) raw.identitySourceIdentifiers = retained;
+  else delete raw.identitySourceIdentifiers;
+  return { sourcePaperId, raw };
+}
+
+export function bibliographicFingerprint(
+  input: Pick<PaperIdentityInput, "title" | "year" | "authors">
+): string | undefined {
+  const title = normalizeBibliographicTitle(input.title);
+  const author = normalizeFirstAuthor(input.authors?.[0]);
+  if (!title || !input.year || !author) return undefined;
+  return `bibliographic:${title}|${input.year}|${author}`;
+}
+
+export function resolvePaperIdentity<T extends PaperIdentityInput>(
+  incoming: PaperIdentityInput,
+  candidates: readonly T[]
+): PaperIdentityMatch<T> {
+  return new PaperIdentityResolver(candidates).resolve(incoming);
+}
+
+export class PaperIdentityResolver<T extends PaperIdentityInput> {
+  private readonly candidates: T[];
+  private readonly candidatePositions = new Map<T, number>();
+  private readonly idPositions = new Map<string, number>();
+  private readonly indexedIds = new Map<T, string | undefined>();
+  private readonly doiIndex = new Map<string, Set<T>>();
+  private readonly sourceIndex = new Map<string, Set<T>>();
+  private readonly fingerprintIndex = new Map<string, Set<T>>();
+  private readonly titleIndex = new Map<string, Set<T>>();
+
+  constructor(candidates: readonly T[] = []) {
+    this.candidates = [];
+    for (const candidate of candidates) this.add(candidate);
+  }
+
+  resolve(incoming: PaperIdentityInput): PaperIdentityMatch<T> {
+    const doiKey = doiIdentityKey(incoming);
+    const sourceKeys = sourceIdentifierIdentityKeys(incoming);
+    const sourceKey = sourceKeys[0];
+    const fingerprint = bibliographicFingerprint(incoming);
+    const doiMatches = doiKey ? this.lookup(this.doiIndex, [doiKey]) : [];
+    const sourceMatches = this.lookup(this.sourceIndex, sourceKeys);
+
+    if (doiMatches.length > 1) {
+      return ambiguous("doi", doiKey, doiMatches, "More than one paper has the same normalized DOI.");
+    }
+    if (doiMatches.length === 1) {
+      const conflictingSources = sourceMatches.filter((candidate) => candidate !== doiMatches[0]);
+      if (conflictingSources.length) {
+        return ambiguous(
+          "conflicting-identifiers",
+          undefined,
+          uniqueCandidates([...doiMatches, ...conflictingSources]),
+          "The DOI and authoritative source identifier point to different papers."
+        );
+      }
+      return { kind: "exact", strategy: "doi", key: doiKey!, candidate: doiMatches[0] };
+    }
+
+    if (sourceMatches.length > 1) {
+      return ambiguous(
+        "source-identifier",
+        sourceKey,
+        sourceMatches,
+        "More than one paper has the same authoritative source identifier."
+      );
+    }
+    if (sourceMatches.length === 1) {
+      if (hasConflictingDoi(incoming, sourceMatches[0])) {
+        return ambiguous(
+          "conflicting-identifiers",
+          sourceKey,
+          sourceMatches,
+          "The source identifier matches, but the papers have different DOIs."
+        );
+      }
+      return {
+        kind: "exact",
+        strategy: "source-identifier",
+        key: sourceKey!,
+        candidate: sourceMatches[0]
+      };
+    }
+
+    const fingerprintMatches = fingerprint ? this.lookup(this.fingerprintIndex, [fingerprint]) : [];
+    if (fingerprintMatches.length > 1) {
+      return ambiguous(
+        "bibliographic-fingerprint",
+        fingerprint,
+        fingerprintMatches,
+        "More than one paper has the same title, year, and first-author fingerprint."
+      );
+    }
+    if (fingerprintMatches.length === 1) {
+      const candidate = fingerprintMatches[0];
+      if (hasConflictingDoi(incoming, candidate) || hasConflictingSourceIdentifier(incoming, candidate)) {
+        return ambiguous(
+          "conflicting-identifiers",
+          fingerprint,
+          fingerprintMatches,
+          "The bibliographic fingerprint matches, but a persistent identifier conflicts."
+        );
+      }
+      return {
+        kind: "exact",
+        strategy: "bibliographic-fingerprint",
+        key: fingerprint!,
+        candidate
+      };
+    }
+
+    const title = normalizeBibliographicTitle(incoming.title);
+    const titleMatches = title ? this.lookup(this.titleIndex, [`title:${title}`]) : [];
+    if (titleMatches.length) {
+      return ambiguous(
+        "title-only",
+        `title:${title}`,
+        titleMatches,
+        "A title match alone is not sufficient for an automatic merge."
+      );
+    }
+
+    return { kind: "none", candidates: [] };
+  }
+
+  add(candidate: T): void {
+    if (this.candidatePositions.has(candidate)) {
+      throw new Error("Cannot add the same paper identity candidate more than once.");
+    }
+    const id = candidateIdentityId(candidate);
+    if (id !== undefined && this.idPositions.has(id)) {
+      throw new Error(`Cannot add duplicate paper identity candidate ID: ${id}`);
+    }
+
+    const position = this.candidates.length;
+    this.candidates.push(candidate);
+    this.candidatePositions.set(candidate, position);
+    this.indexedIds.set(candidate, id);
+    if (id !== undefined) this.idPositions.set(id, position);
+    this.indexCandidate(candidate);
+  }
+
+  replace(previous: T, next: T): void {
+    const previousId = candidateIdentityId(previous);
+    const position =
+      this.candidatePositions.get(previous) ??
+      (previousId === undefined ? undefined : this.idPositions.get(previousId));
+    if (position === undefined) {
+      this.add(next);
+      return;
+    }
+
+    const current = this.candidates[position];
+    const nextId = candidateIdentityId(next);
+    const nextPosition = this.candidatePositions.get(next);
+    if (nextPosition !== undefined && nextPosition !== position) {
+      throw new Error("Cannot replace a paper identity candidate with a candidate that is already indexed.");
+    }
+    const duplicateIdPosition = nextId === undefined ? undefined : this.idPositions.get(nextId);
+    if (duplicateIdPosition !== undefined && duplicateIdPosition !== position) {
+      throw new Error(`Cannot replace paper identity candidate with duplicate ID: ${nextId}`);
+    }
+
+    this.removeCandidate(current);
+    this.candidatePositions.delete(current);
+    const currentId = this.indexedIds.get(current);
+    this.indexedIds.delete(current);
+    if (currentId !== undefined) this.idPositions.delete(currentId);
+
+    this.candidates[position] = next;
+    this.candidatePositions.set(next, position);
+    this.indexedIds.set(next, nextId);
+    if (nextId !== undefined) this.idPositions.set(nextId, position);
+    this.indexCandidate(next);
+  }
+
+  list(): readonly T[] {
+    return this.candidates;
+  }
+
+  private lookup(index: Map<string, Set<T>>, keys: readonly string[]): T[] {
+    const matches = new Set<T>();
+    for (const key of keys) {
+      for (const candidate of index.get(key) ?? []) matches.add(candidate);
+    }
+    return [...matches];
+  }
+
+  private indexCandidate(candidate: T): void {
+    const doi = doiIdentityKey(candidate);
+    if (doi) addToIndex(this.doiIndex, doi, candidate);
+    for (const key of sourceIdentifierIdentityKeys(candidate)) addToIndex(this.sourceIndex, key, candidate);
+    const fingerprint = bibliographicFingerprint(candidate);
+    if (fingerprint) addToIndex(this.fingerprintIndex, fingerprint, candidate);
+    const title = normalizeBibliographicTitle(candidate.title);
+    if (title) addToIndex(this.titleIndex, `title:${title}`, candidate);
+  }
+
+  private removeCandidate(candidate: T): void {
+    const doi = doiIdentityKey(candidate);
+    if (doi) removeFromIndex(this.doiIndex, doi, candidate);
+    for (const key of sourceIdentifierIdentityKeys(candidate)) removeFromIndex(this.sourceIndex, key, candidate);
+    const fingerprint = bibliographicFingerprint(candidate);
+    if (fingerprint) removeFromIndex(this.fingerprintIndex, fingerprint, candidate);
+    const title = normalizeBibliographicTitle(candidate.title);
+    if (title) removeFromIndex(this.titleIndex, `title:${title}`, candidate);
+  }
+}
+
+function hasConflictingDoi(left: PaperIdentityInput, right: PaperIdentityInput): boolean {
+  const leftDoi = normalizeDoi(left.doi);
+  const rightDoi = normalizeDoi(right.doi);
+  return Boolean(leftDoi && rightDoi && leftDoi !== rightDoi);
+}
+
+function candidateIdentityId(candidate: PaperIdentityInput): string | undefined {
+  return typeof candidate.id === "string" ? candidate.id : undefined;
+}
+
+function hasConflictingSourceIdentifier(left: PaperIdentityInput, right: PaperIdentityInput): boolean {
+  const leftByAuthority = groupSourceIdentifiers(authoritativeSourceIdentifiers(left));
+  const rightByAuthority = groupSourceIdentifiers(authoritativeSourceIdentifiers(right));
+  for (const [authority, leftIdentifiers] of leftByAuthority) {
+    const rightIdentifiers = rightByAuthority.get(authority);
+    if (!rightIdentifiers?.size) continue;
+    if (![...leftIdentifiers].some((identifier) => rightIdentifiers.has(identifier))) return true;
+  }
+  return false;
+}
+
+function identitySourceAuthority(
+  input: Pick<PaperIdentityInput, "source" | "sourceAuthority" | "raw">
+): string | undefined {
+  if (input.sourceAuthority) return input.sourceAuthority;
+  if (input.source && input.source !== "reference-import") return input.source;
+  const rawAuthority = input.raw?.sourceAuthority;
+  if (typeof rawAuthority === "string" && rawAuthority.trim()) return rawAuthority;
+  const imported = input.raw?.referenceImport;
+  if (imported && typeof imported === "object" && !Array.isArray(imported)) {
+    const provenanceAuthority = (imported as Record<string, unknown>).sourceAuthority;
+    if (typeof provenanceAuthority === "string" && provenanceAuthority.trim()) return provenanceAuthority;
+  }
+  return undefined;
+}
+
+function ambiguous<T extends PaperIdentityInput>(
+  strategy: PaperIdentityAmbiguity,
+  key: string | undefined,
+  candidates: readonly T[],
+  reason: string
+): PaperIdentityMatch<T> {
+  return {
+    kind: "ambiguous",
+    strategy,
+    key,
+    candidates: [...candidates],
+    reasons: [reason]
+  };
+}
+
+function uniqueCandidates<T>(candidates: readonly T[]): T[] {
+  return [...new Set(candidates)];
+}
+
+function uniqueSourceIdentifiers(
+  identifiers: readonly AuthoritativeSourceIdentifier[]
+): AuthoritativeSourceIdentifier[] {
+  const unique = new Map<string, AuthoritativeSourceIdentifier>();
+  for (const identity of identifiers) unique.set(`${identity.authority}:${identity.identifier}`, identity);
+  return [...unique.values()];
+}
+
+function sameSourceIdentifier(left: AuthoritativeSourceIdentifier, right: AuthoritativeSourceIdentifier): boolean {
+  return left.authority === right.authority && left.identifier === right.identifier;
+}
+
+function groupSourceIdentifiers(identities: readonly AuthoritativeSourceIdentifier[]): Map<string, Set<string>> {
+  const grouped = new Map<string, Set<string>>();
+  for (const identity of identities) {
+    const identifiers = grouped.get(identity.authority) ?? new Set<string>();
+    identifiers.add(identity.identifier);
+    grouped.set(identity.authority, identifiers);
+  }
+  return grouped;
+}
+
+function addToIndex<T>(index: Map<string, Set<T>>, key: string, candidate: T): void {
+  const bucket = index.get(key) ?? new Set<T>();
+  bucket.add(candidate);
+  index.set(key, bucket);
+}
+
+function removeFromIndex<T>(index: Map<string, Set<T>>, key: string, candidate: T): void {
+  const bucket = index.get(key);
+  if (!bucket) return;
+  bucket.delete(candidate);
+  if (!bucket.size) index.delete(key);
+}
+
+function foldText(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}

--- a/src/main/services/paper-scoring-service.ts
+++ b/src/main/services/paper-scoring-service.ts
@@ -1,4 +1,4 @@
-import type { Paper, PaperScore, SourceId } from "../../shared/schemas.js";
+import type { Paper, PaperScore } from "../../shared/schemas.js";
 import type { PaperPilotDb } from "../db.js";
 
 const SCORE_VERSION = "heuristic-v1";
@@ -13,7 +13,7 @@ const SCORE_WEIGHTS: PaperScore["components"] = {
   metadata: 7
 };
 
-const SOURCE_SCORES: Record<SourceId, number> = {
+const SOURCE_SCORES: Record<Paper["source"], number> = {
   openalex: 82,
   crossref: 66,
   "semantic-scholar": 78,
@@ -22,7 +22,8 @@ const SOURCE_SCORES: Record<SourceId, number> = {
   "europe-pmc": 84,
   core: 72,
   unpaywall: 64,
-  "google-scholar": 52
+  "google-scholar": 52,
+  "reference-import": 55
 };
 
 const TOP_VENUE_PATTERNS = [

--- a/src/main/services/reference-import-service.ts
+++ b/src/main/services/reference-import-service.ts
@@ -1,0 +1,925 @@
+import type { Paper } from "../../shared/schemas.js";
+import { normalizeDoi, normalizeSourceAuthority } from "./paper-identity.js";
+
+export const REFERENCE_IMPORT_MAX_BYTES = 50 * 1024 * 1024;
+export const REFERENCE_IMPORT_MAX_RECORDS = 50_000;
+
+export type ReferenceImportFormat = "ris" | "bibtex" | "csv";
+
+export const referenceImportFields = [
+  "title",
+  "authors",
+  "abstract",
+  "year",
+  "doi",
+  "url",
+  "pdfUrl",
+  "venue",
+  "sourcePaperId",
+  "sourceAuthority",
+  "citationCount"
+] as const;
+export type ReferenceImportField = (typeof referenceImportFields)[number];
+
+export type CsvColumnMapping = Partial<Record<ReferenceImportField, string | null>>;
+export type AppliedCsvColumnMapping = Partial<Record<ReferenceImportField, string>>;
+
+export interface ReferenceImportLimits {
+  maxBytes: number;
+  maxRecords: number;
+}
+
+export interface ReferenceImportPaper extends Pick<
+  Paper,
+  | "title"
+  | "abstract"
+  | "authors"
+  | "year"
+  | "doi"
+  | "url"
+  | "pdfUrl"
+  | "sourcePaperId"
+  | "venue"
+  | "citationCount"
+  | "isOpenAccess"
+  | "fieldsOfStudy"
+  | "raw"
+> {
+  source: "reference-import";
+  /** Namespace for an authoritative source identifier, for example arxiv or pubmed. */
+  sourceAuthority?: string;
+}
+
+export interface ReferenceImportProvenance {
+  source: "reference-import";
+  format: ReferenceImportFormat;
+  recordNumber: number;
+  sourceIdentifier?: string;
+  sourceAuthority?: string;
+}
+
+export interface ReferenceImportRecord {
+  recordNumber: number;
+  paper: ReferenceImportPaper;
+  provenance: ReferenceImportProvenance;
+}
+
+export interface InvalidReferenceImportRecord {
+  recordNumber: number;
+  errors: string[];
+  raw?: Record<string, unknown> | string;
+}
+
+export interface CsvImportPreview {
+  headers: string[];
+  suggestedMapping: AppliedCsvColumnMapping;
+  appliedMapping: AppliedCsvColumnMapping;
+}
+
+export interface ReferenceImportPreview {
+  format: ReferenceImportFormat | "unknown";
+  sizeBytes: number;
+  totalRecords: number;
+  records: ReferenceImportRecord[];
+  invalidRecords: InvalidReferenceImportRecord[];
+  fileErrors: string[];
+  warnings: string[];
+  csv?: CsvImportPreview;
+  canCommit: boolean;
+}
+
+export interface ReferenceImportPreviewInput {
+  content: string | Uint8Array;
+  format?: ReferenceImportFormat;
+  /** Used only to infer a format; paths are never returned from this service. */
+  fileName?: string;
+  csvMapping?: CsvColumnMapping;
+}
+
+interface RawReferenceCandidate {
+  recordNumber: number;
+  title?: string;
+  abstract?: string;
+  authors?: string[];
+  year?: string;
+  doi?: string;
+  url?: string;
+  pdfUrl?: string;
+  venue?: string;
+  sourcePaperId?: string;
+  sourceAuthority?: string;
+  citationCount?: string;
+  raw: Record<string, unknown>;
+}
+
+interface ParsedImport {
+  candidates: RawReferenceCandidate[];
+  invalidRecords: InvalidReferenceImportRecord[];
+  totalRecords: number;
+  fileErrors: string[];
+  warnings: string[];
+  csv?: CsvImportPreview;
+}
+
+interface CsvRow {
+  line: number;
+  cells: string[];
+}
+
+const DEFAULT_LIMITS: ReferenceImportLimits = {
+  maxBytes: REFERENCE_IMPORT_MAX_BYTES,
+  maxRecords: REFERENCE_IMPORT_MAX_RECORDS
+};
+
+export class ReferenceImportService {
+  private readonly limits: ReferenceImportLimits;
+
+  constructor(limits: Partial<ReferenceImportLimits> = {}) {
+    this.limits = { ...DEFAULT_LIMITS, ...limits };
+    if (!Number.isSafeInteger(this.limits.maxBytes) || this.limits.maxBytes <= 0) {
+      throw new Error("Reference import maxBytes must be a positive integer.");
+    }
+    if (!Number.isSafeInteger(this.limits.maxRecords) || this.limits.maxRecords <= 0) {
+      throw new Error("Reference import maxRecords must be a positive integer.");
+    }
+  }
+
+  preview(input: ReferenceImportPreviewInput): ReferenceImportPreview {
+    const sizeBytes =
+      typeof input.content === "string" ? Buffer.byteLength(input.content, "utf8") : input.content.byteLength;
+    const format = input.format ?? detectReferenceImportFormat(input.fileName, input.content) ?? "unknown";
+    if (sizeBytes > this.limits.maxBytes) {
+      return blockedPreview(format, sizeBytes, `Reference files may not exceed ${formatBytes(this.limits.maxBytes)}.`);
+    }
+    if (format === "unknown") {
+      return blockedPreview(format, sizeBytes, "Could not detect a RIS, BibTeX, or CSV reference format.");
+    }
+
+    const content = decodeContent(input.content);
+    let parsed: ParsedImport;
+    try {
+      if (format === "ris") parsed = parseRis(content, this.limits.maxRecords);
+      else if (format === "bibtex") parsed = parseBibtex(content, this.limits.maxRecords);
+      else parsed = parseCsv(content, input.csvMapping, this.limits.maxRecords);
+    } catch (error) {
+      if (error instanceof ImportRecordLimitError) {
+        return {
+          ...blockedPreview(
+            format,
+            sizeBytes,
+            `Reference files may contain at most ${this.limits.maxRecords.toLocaleString("en-US")} records.`
+          ),
+          totalRecords: this.limits.maxRecords + 1
+        };
+      }
+      throw error;
+    }
+
+    const records: ReferenceImportRecord[] = [];
+    const invalidRecords = [...parsed.invalidRecords];
+    for (const candidate of parsed.candidates) {
+      const validated = validateCandidate(candidate, format);
+      if ("errors" in validated) invalidRecords.push(validated);
+      else records.push(validated);
+    }
+
+    const fileErrors = [...parsed.fileErrors];
+    if (parsed.totalRecords === 0) fileErrors.push("No reference records were found.");
+    return {
+      format,
+      sizeBytes,
+      totalRecords: parsed.totalRecords,
+      records,
+      invalidRecords: invalidRecords.sort((left, right) => left.recordNumber - right.recordNumber),
+      fileErrors,
+      warnings: parsed.warnings,
+      csv: parsed.csv,
+      canCommit: fileErrors.length === 0 && records.length > 0
+    };
+  }
+}
+
+export function previewReferenceImport(
+  input: ReferenceImportPreviewInput,
+  limits: Partial<ReferenceImportLimits> = {}
+): ReferenceImportPreview {
+  return new ReferenceImportService(limits).preview(input);
+}
+
+export function detectReferenceImportFormat(
+  fileName: string | undefined,
+  content?: string | Uint8Array
+): ReferenceImportFormat | undefined {
+  const safeName = fileName?.split(/[\\/]/).at(-1)?.toLowerCase();
+  if (safeName?.endsWith(".ris")) return "ris";
+  if (safeName?.endsWith(".bib") || safeName?.endsWith(".bibtex")) return "bibtex";
+  if (safeName?.endsWith(".csv")) return "csv";
+
+  if (content === undefined) return undefined;
+  const sample = decodeContent(content)
+    .slice(0, 8192)
+    .replace(/^\uFEFF/, "")
+    .trimStart();
+  if (/^TY\s{1,2}-/m.test(sample)) return "ris";
+  if (/^@(article|book|inproceedings|incollection|misc|phdthesis|mastersthesis|techreport)\s*[{(]/im.test(sample)) {
+    return "bibtex";
+  }
+  const firstLine = sample.split(/\r?\n/, 1)[0] ?? "";
+  if (firstLine.includes(",") || firstLine.includes("\t")) return "csv";
+  return undefined;
+}
+
+export function inferCsvColumnMapping(headers: readonly string[]): AppliedCsvColumnMapping {
+  const aliases: Record<ReferenceImportField, readonly string[]> = {
+    title: ["title", "paper title", "article title", "document title", "name"],
+    authors: ["authors", "author", "creators", "creator"],
+    abstract: ["abstract", "summary", "description"],
+    year: ["year", "publication year", "published year", "date", "publication date"],
+    doi: ["doi", "digital object identifier"],
+    url: ["url", "link", "record url", "landing page"],
+    pdfUrl: ["pdf url", "pdf", "full text url", "fulltext url", "document url"],
+    venue: ["venue", "journal", "publication", "container title", "booktitle"],
+    sourcePaperId: ["source id", "source identifier", "paper id", "accession number", "eprint", "id"],
+    sourceAuthority: ["source authority", "authority", "database", "source"],
+    citationCount: ["citation count", "citations", "times cited", "cited by"]
+  };
+  const normalizedHeaders = headers.map((header) => normalizeHeader(header));
+  const mapping: AppliedCsvColumnMapping = {};
+  const used = new Set<number>();
+  for (const field of referenceImportFields) {
+    const index = normalizedHeaders.findIndex(
+      (header, candidateIndex) => !used.has(candidateIndex) && aliases[field].includes(header)
+    );
+    if (index >= 0) {
+      mapping[field] = headers[index];
+      used.add(index);
+    }
+  }
+  return mapping;
+}
+
+function parseRis(content: string, maxRecords: number): ParsedImport {
+  const records: Array<{ fields: Map<string, string[]>; malformed: string[]; number: number }> = [];
+  let current: { fields: Map<string, string[]>; malformed: string[]; number: number } | undefined;
+  let lastTag: string | undefined;
+
+  const finish = (): void => {
+    if (!current) return;
+    if (records.length >= maxRecords) throw new ImportRecordLimitError();
+    records.push(current);
+    current = undefined;
+    lastTag = undefined;
+  };
+
+  for (const line of content.replace(/^\uFEFF/, "").split(/\r?\n/)) {
+    const tagged = /^([A-Z0-9]{2})\s{1,2}-\s?(.*)$/.exec(line);
+    if (tagged) {
+      const [, tag, value] = tagged;
+      if (tag === "TY") {
+        finish();
+        current = { fields: new Map(), malformed: [], number: records.length + 1 };
+      } else if (!current) {
+        current = { fields: new Map(), malformed: [], number: records.length + 1 };
+      }
+      const values = current!.fields.get(tag) ?? [];
+      values.push(value.trim());
+      current!.fields.set(tag, values);
+      lastTag = tag;
+      if (tag === "ER") finish();
+      continue;
+    }
+
+    const continuation = /^\s{2,}(.+)$/.exec(line);
+    if (continuation && current && lastTag) {
+      const values = current.fields.get(lastTag);
+      if (values?.length) values[values.length - 1] = `${values.at(-1)} ${continuation[1].trim()}`;
+    } else if (line.trim() && current) {
+      current.malformed.push(line.trim());
+    }
+  }
+  finish();
+
+  const candidates: RawReferenceCandidate[] = [];
+  const invalidRecords: InvalidReferenceImportRecord[] = [];
+  for (const record of records) {
+    if (record.malformed.length) {
+      invalidRecords.push({
+        recordNumber: record.number,
+        errors: [`Malformed RIS line${record.malformed.length === 1 ? "" : "s"}: ${record.malformed.join(" | ")}`],
+        raw: risRawObject(record.fields)
+      });
+      continue;
+    }
+    const values = (tags: readonly string[]): string[] => tags.flatMap((tag) => record.fields.get(tag) ?? []);
+    const first = (tags: readonly string[]): string | undefined => values(tags).find((value) => value.trim());
+    const urls = values(["UR"]);
+    const explicitPdf = first(["L1", "L2"]);
+    const pdfUrl = explicitPdf ?? urls.find(isLikelyPdfUrl);
+    const sourceAuthority = first(["DP", "DB"]);
+    const sourcePaperId = first(["AN", "ID"]);
+    candidates.push({
+      recordNumber: record.number,
+      title: first(["TI", "T1", "CT"]),
+      abstract: first(["AB", "N2"]),
+      authors: values(["AU", "A1"]).flatMap(splitAuthors),
+      year: first(["PY", "Y1", "DA"]),
+      doi: first(["DO"]) ?? urls.map(extractDoiFromUrl).find(Boolean),
+      url: urls.find((url) => url !== pdfUrl) ?? urls[0],
+      pdfUrl,
+      venue: first(["JO", "JF", "T2", "JA"]),
+      sourcePaperId,
+      sourceAuthority,
+      citationCount: first(["TC"]),
+      raw: risRawObject(record.fields)
+    });
+  }
+
+  return {
+    candidates,
+    invalidRecords,
+    totalRecords: records.length,
+    fileErrors: [],
+    warnings: []
+  };
+}
+
+function parseBibtex(content: string, maxRecords: number): ParsedImport {
+  const entries = extractBibtexEntries(content.replace(/^\uFEFF/, ""), maxRecords);
+  const candidates: RawReferenceCandidate[] = [];
+  const invalidRecords = [...entries.invalidRecords];
+  for (const entry of entries.entries) {
+    try {
+      const parsed = parseBibtexEntry(entry.body);
+      const fields = parsed.fields;
+      const value = (...names: string[]): string | undefined => {
+        for (const name of names) {
+          const candidate = fields.get(name);
+          if (candidate?.trim()) return cleanBibtexValue(candidate);
+        }
+        return undefined;
+      };
+      const authorValue = value("author");
+      const url = value("url", "link");
+      const explicitPdf = value("pdf", "fulltext", "full-text", "file");
+      const archivePrefix = value("archiveprefix", "database", "source");
+      const eprint = value("eprint", "sourceid", "source-id", "accessionnumber");
+      candidates.push({
+        recordNumber: entry.number,
+        title: value("title"),
+        abstract: value("abstract", "summary"),
+        authors: authorValue ? splitBibtexAuthors(authorValue) : [],
+        year: value("year", "date"),
+        doi: value("doi") ?? extractDoiFromUrl(url),
+        url,
+        pdfUrl: explicitPdf && isHttpUrl(explicitPdf) ? explicitPdf : isLikelyPdfUrl(url) ? url : undefined,
+        venue: value("journal", "booktitle", "journaltitle", "container-title", "publisher"),
+        sourcePaperId: eprint ?? value("id") ?? parsed.key,
+        sourceAuthority: archivePrefix,
+        citationCount: value("citationcount", "citation-count", "citations", "times-cited"),
+        raw: Object.fromEntries(fields)
+      });
+    } catch (error) {
+      invalidRecords.push({
+        recordNumber: entry.number,
+        errors: [error instanceof Error ? error.message : String(error)],
+        raw: truncate(entry.raw)
+      });
+    }
+  }
+  return {
+    candidates,
+    invalidRecords,
+    totalRecords: entries.totalRecords,
+    fileErrors: [],
+    warnings: []
+  };
+}
+
+function parseCsv(content: string, requestedMapping: CsvColumnMapping | undefined, maxRecords: number): ParsedImport {
+  let rows: CsvRow[];
+  try {
+    rows = parseCsvRows(content.replace(/^\uFEFF/, ""), maxRecords + 1);
+  } catch (error) {
+    if (error instanceof ImportRecordLimitError) throw error;
+    return {
+      candidates: [],
+      invalidRecords: [],
+      totalRecords: 0,
+      fileErrors: [error instanceof Error ? error.message : String(error)],
+      warnings: []
+    };
+  }
+  if (!rows.length) {
+    return { candidates: [], invalidRecords: [], totalRecords: 0, fileErrors: [], warnings: [] };
+  }
+
+  const headers = rows[0].cells.map((header, index) => (index === 0 ? header.replace(/^\uFEFF/, "") : header).trim());
+  const dataRows = rows.slice(1).filter((row) => row.cells.some((cell) => cell.trim()));
+  if (dataRows.length > maxRecords) throw new ImportRecordLimitError();
+  const fileErrors: string[] = [];
+  if (headers.every((header) => !header)) fileErrors.push("CSV must have a header row.");
+  const duplicateHeaders = findDuplicateHeaders(headers);
+  if (duplicateHeaders.length) fileErrors.push(`CSV headers must be unique: ${duplicateHeaders.join(", ")}.`);
+
+  const suggestedMapping = inferCsvColumnMapping(headers);
+  const appliedMapping = requestedMapping === undefined ? suggestedMapping : cleanRequestedMapping(requestedMapping);
+  for (const [field, header] of Object.entries(appliedMapping)) {
+    if (!headers.includes(header)) fileErrors.push(`CSV mapping for ${field} refers to an unknown column: ${header}.`);
+  }
+  if (!appliedMapping.title) fileErrors.push("CSV mapping must select a title column.");
+
+  const candidates: RawReferenceCandidate[] = [];
+  const invalidRecords: InvalidReferenceImportRecord[] = [];
+  for (let index = 0; index < dataRows.length; index += 1) {
+    const row = dataRows[index];
+    const recordNumber = index + 1;
+    const raw = Object.fromEntries(
+      headers.map((header, column) => [header || `column-${column + 1}`, row.cells[column] ?? ""])
+    );
+    if (row.cells.length > headers.length) {
+      invalidRecords.push({
+        recordNumber,
+        errors: [`CSV line ${row.line} has ${row.cells.length} columns; expected ${headers.length}.`],
+        raw
+      });
+      continue;
+    }
+    const read = (field: ReferenceImportField): string | undefined => {
+      const header = appliedMapping[field];
+      if (!header) return undefined;
+      const column = headers.indexOf(header);
+      return column >= 0 ? row.cells[column]?.trim() : undefined;
+    };
+    candidates.push({
+      recordNumber,
+      title: read("title"),
+      authors: splitAuthors(read("authors") ?? ""),
+      abstract: read("abstract"),
+      year: read("year"),
+      doi: read("doi"),
+      url: read("url"),
+      pdfUrl: read("pdfUrl"),
+      venue: read("venue"),
+      sourcePaperId: read("sourcePaperId"),
+      sourceAuthority: read("sourceAuthority"),
+      citationCount: read("citationCount"),
+      raw
+    });
+  }
+
+  return {
+    candidates,
+    invalidRecords,
+    totalRecords: dataRows.length,
+    fileErrors,
+    warnings: [],
+    csv: { headers, suggestedMapping, appliedMapping }
+  };
+}
+
+function validateCandidate(
+  candidate: RawReferenceCandidate,
+  format: ReferenceImportFormat
+): ReferenceImportRecord | InvalidReferenceImportRecord {
+  const errors: string[] = [];
+  const title = cleanText(candidate.title);
+  if (!title) errors.push("Title is required.");
+  const year = parseYear(candidate.year);
+  if (candidate.year?.trim() && year === undefined) {
+    errors.push(`Year must contain a value from 1500 through 3000: ${candidate.year}.`);
+  }
+  const citationCount = parseNonnegativeInteger(candidate.citationCount);
+  if (candidate.citationCount?.trim() && citationCount === undefined) {
+    errors.push(`Citation count must be a nonnegative integer: ${candidate.citationCount}.`);
+  }
+  const url = validateHttpUrl(candidate.url, "URL", errors);
+  const pdfUrl = validateHttpUrl(candidate.pdfUrl, "PDF URL", errors);
+  if (errors.length || !title) {
+    return { recordNumber: candidate.recordNumber, errors, raw: candidate.raw };
+  }
+
+  const authors = uniqueStrings(
+    candidate.authors?.map(cleanText).filter((value): value is string => Boolean(value)) ?? []
+  );
+  const sourcePaperId = cleanText(candidate.sourcePaperId);
+  const sourceAuthority = normalizeSourceAuthority(candidate.sourceAuthority);
+  const paper: ReferenceImportPaper = {
+    title,
+    authors,
+    source: "reference-import",
+    isOpenAccess: false,
+    fieldsOfStudy: [],
+    raw: candidate.raw
+  };
+  const abstract = cleanText(candidate.abstract);
+  const doi = normalizeDoi(candidate.doi);
+  const venue = cleanText(candidate.venue);
+  if (abstract) paper.abstract = abstract;
+  if (year !== undefined) paper.year = year;
+  if (doi) paper.doi = doi;
+  if (url) paper.url = url;
+  if (pdfUrl) paper.pdfUrl = pdfUrl;
+  if (venue) paper.venue = venue;
+  if (sourcePaperId) paper.sourcePaperId = sourcePaperId;
+  if (sourceAuthority) paper.sourceAuthority = sourceAuthority;
+  if (citationCount !== undefined) paper.citationCount = citationCount;
+
+  return {
+    recordNumber: candidate.recordNumber,
+    paper,
+    provenance: {
+      source: "reference-import",
+      format,
+      recordNumber: candidate.recordNumber,
+      sourceIdentifier: sourcePaperId,
+      sourceAuthority
+    }
+  };
+}
+
+function extractBibtexEntries(
+  content: string,
+  maxRecords: number
+): {
+  entries: Array<{ number: number; body: string; raw: string }>;
+  invalidRecords: InvalidReferenceImportRecord[];
+  totalRecords: number;
+} {
+  const entries: Array<{ number: number; body: string; raw: string }> = [];
+  const invalidRecords: InvalidReferenceImportRecord[] = [];
+  let totalRecords = 0;
+  let index = 0;
+  while (index < content.length) {
+    const at = content.indexOf("@", index);
+    if (at < 0) break;
+    const typeMatch = /^@([a-zA-Z][\w-]*)\s*([{(])/.exec(content.slice(at));
+    if (!typeMatch) {
+      index = at + 1;
+      continue;
+    }
+    const type = typeMatch[1].toLowerCase();
+    const opener = typeMatch[2];
+    const openIndex = at + typeMatch[0].lastIndexOf(opener);
+    const closeIndex = findBalancedEnd(content, openIndex, opener, opener === "{" ? "}" : ")");
+    if (["comment", "preamble", "string"].includes(type)) {
+      index = closeIndex < 0 ? content.length : closeIndex + 1;
+      continue;
+    }
+    totalRecords += 1;
+    if (totalRecords > maxRecords) throw new ImportRecordLimitError();
+    if (closeIndex < 0) {
+      invalidRecords.push({
+        recordNumber: totalRecords,
+        errors: [`BibTeX entry @${type} has no closing ${opener === "{" ? "brace" : "parenthesis"}.`],
+        raw: truncate(content.slice(at))
+      });
+      break;
+    }
+    entries.push({
+      number: totalRecords,
+      body: content.slice(openIndex + 1, closeIndex),
+      raw: content.slice(at, closeIndex + 1)
+    });
+    index = closeIndex + 1;
+  }
+  return { entries, invalidRecords, totalRecords };
+}
+
+function parseBibtexEntry(body: string): { key: string; fields: Map<string, string> } {
+  const comma = findTopLevelComma(body);
+  if (comma < 0) throw new Error("BibTeX entry is missing its field list.");
+  const key = body.slice(0, comma).trim();
+  if (!key) throw new Error("BibTeX entry is missing its citation key.");
+  const fields = new Map<string, string>();
+  let index = comma + 1;
+  while (index < body.length) {
+    index = skipWhitespaceAndCommas(body, index);
+    if (index >= body.length) break;
+    const nameMatch = /^[a-zA-Z][\w-]*/.exec(body.slice(index));
+    if (!nameMatch) throw new Error(`Malformed BibTeX field near: ${truncate(body.slice(index), 80)}`);
+    const name = nameMatch[0].toLowerCase();
+    index += nameMatch[0].length;
+    index = skipWhitespace(body, index);
+    if (body[index] !== "=") throw new Error(`BibTeX field ${name} is missing '='.`);
+    index = skipWhitespace(body, index + 1);
+    const parts: string[] = [];
+    while (index < body.length) {
+      const token = readBibtexValue(body, index);
+      parts.push(token.value);
+      index = skipWhitespace(body, token.nextIndex);
+      if (body[index] !== "#") break;
+      index = skipWhitespace(body, index + 1);
+    }
+    fields.set(name, parts.join(""));
+    index = skipWhitespace(body, index);
+    if (index < body.length && body[index] !== ",") {
+      throw new Error(`BibTeX field ${name} is not followed by a comma.`);
+    }
+  }
+  return { key, fields };
+}
+
+function readBibtexValue(content: string, start: number): { value: string; nextIndex: number } {
+  const opener = content[start];
+  if (opener === "{") {
+    const end = findBalancedEnd(content, start, "{", "}");
+    if (end < 0) throw new Error("BibTeX field has an unclosed brace.");
+    return { value: content.slice(start + 1, end), nextIndex: end + 1 };
+  }
+  if (opener === '"') {
+    let escaped = false;
+    for (let index = start + 1; index < content.length; index += 1) {
+      const character = content[index];
+      if (character === '"' && !escaped) {
+        return { value: content.slice(start + 1, index), nextIndex: index + 1 };
+      }
+      escaped = character === "\\" && !escaped;
+      if (character !== "\\") escaped = false;
+    }
+    throw new Error("BibTeX field has an unclosed quote.");
+  }
+  let index = start;
+  while (index < content.length && !/[#,\s]/.test(content[index])) index += 1;
+  if (index === start) throw new Error("BibTeX field has no value.");
+  return { value: content.slice(start, index), nextIndex: index };
+}
+
+function findBalancedEnd(content: string, start: number, opener: string, closer: string): number {
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = start; index < content.length; index += 1) {
+    const character = content[index];
+    if (character === '"' && !escaped) quoted = !quoted;
+    if (!quoted) {
+      if (character === opener) depth += 1;
+      else if (character === closer) {
+        depth -= 1;
+        if (depth === 0) return index;
+      }
+    }
+    escaped = character === "\\" && !escaped;
+    if (character !== "\\") escaped = false;
+  }
+  return -1;
+}
+
+function findTopLevelComma(content: string): number {
+  let braces = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index];
+    if (character === '"' && !escaped) quoted = !quoted;
+    if (!quoted) {
+      if (character === "{") braces += 1;
+      else if (character === "}") braces = Math.max(0, braces - 1);
+      else if (character === "," && braces === 0) return index;
+    }
+    escaped = character === "\\" && !escaped;
+    if (character !== "\\") escaped = false;
+  }
+  return -1;
+}
+
+function parseCsvRows(content: string, maxDataRowsPlusHeader: number): CsvRow[] {
+  const rows: CsvRow[] = [];
+  let cells: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  let line = 1;
+  let rowLine = 1;
+
+  const finishRow = (): void => {
+    cells.push(cell);
+    if (cells.some((value) => value.length > 0)) {
+      rows.push({ line: rowLine, cells });
+      if (rows.length > maxDataRowsPlusHeader) throw new ImportRecordLimitError();
+    }
+    cells = [];
+    cell = "";
+    rowLine = line + 1;
+  };
+
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index];
+    if (inQuotes) {
+      if (character === '"') {
+        if (content[index + 1] === '"') {
+          cell += '"';
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += character;
+        if (character === "\n") line += 1;
+      }
+      continue;
+    }
+
+    if (character === '"' && cell.length === 0) inQuotes = true;
+    else if (character === ",") {
+      cells.push(cell);
+      cell = "";
+    } else if (character === "\n") {
+      finishRow();
+      line += 1;
+      rowLine = line;
+    } else if (character !== "\r") cell += character;
+  }
+  if (inQuotes) throw new Error(`CSV has an unclosed quoted field beginning near line ${rowLine}.`);
+  if (cell.length || cells.length) finishRow();
+  return rows;
+}
+
+function splitAuthors(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed) && parsed.every((author) => typeof author === "string")) return parsed;
+    } catch {
+      // Continue with delimiter-based parsing.
+    }
+  }
+  const delimiter = trimmed.includes(";") ? /\s*;\s*/ : trimmed.includes("|") ? /\s*\|\s*/ : /\s+and\s+/i;
+  return trimmed
+    .split(delimiter)
+    .map(cleanText)
+    .filter((author): author is string => Boolean(author));
+}
+
+function splitBibtexAuthors(value: string): string[] {
+  const authors: string[] = [];
+  let braces = 0;
+  let start = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] === "{") braces += 1;
+    else if (value[index] === "}") braces = Math.max(0, braces - 1);
+    else if (braces === 0 && /^\s+and\s+/i.test(value.slice(index))) {
+      const match = /^\s+and\s+/i.exec(value.slice(index))!;
+      const author = cleanBibtexValue(value.slice(start, index));
+      if (author) authors.push(author);
+      index += match[0].length - 1;
+      start = index + 1;
+    }
+  }
+  const finalAuthor = cleanBibtexValue(value.slice(start));
+  if (finalAuthor) authors.push(finalAuthor);
+  return uniqueStrings(authors);
+}
+
+function cleanBibtexValue(value: string): string {
+  return value
+    .replace(/\\url\s*{([^}]*)}/gi, "$1")
+    .replace(/\\(?:textit|textbf|emph)\s*{([^}]*)}/gi, "$1")
+    .replace(/\\([#$%&_{}])/g, "$1")
+    .replace(/[{}]/g, "")
+    .replace(/~/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function parseYear(value: string | undefined): number | undefined {
+  if (!value?.trim()) return undefined;
+  const match = /(?:^|\D)(\d{4})(?:\D|$)/.exec(value);
+  if (!match) return undefined;
+  const year = Number.parseInt(match[1], 10);
+  return year >= 1500 && year <= 3000 ? year : undefined;
+}
+
+function parseNonnegativeInteger(value: string | undefined): number | undefined {
+  if (!value?.trim() || !/^\d+$/.test(value.trim())) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function validateHttpUrl(value: string | undefined, label: string, errors: string[]): string | undefined {
+  const cleaned = cleanText(value);
+  if (!cleaned) return undefined;
+  try {
+    const url = new URL(cleaned);
+    if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("unsupported protocol");
+    return url.toString();
+  } catch {
+    errors.push(`${label} must be an absolute HTTP or HTTPS URL: ${cleaned}.`);
+    return undefined;
+  }
+}
+
+function extractDoiFromUrl(value: string | undefined): string | undefined {
+  if (!value || !/doi\.org\//i.test(value)) return undefined;
+  return normalizeDoi(value);
+}
+
+function isLikelyPdfUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  return /(?:\.pdf(?:[?#]|$)|\/pdf(?:[/?#]|$))/i.test(value);
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function risRawObject(fields: ReadonlyMap<string, string[]>): Record<string, unknown> {
+  return Object.fromEntries([...fields].map(([tag, values]) => [tag, values.length === 1 ? values[0] : values]));
+}
+
+function cleanRequestedMapping(mapping: CsvColumnMapping): AppliedCsvColumnMapping {
+  const cleaned: AppliedCsvColumnMapping = {};
+  for (const field of referenceImportFields) {
+    const header = mapping[field]?.trim();
+    if (header) cleaned[field] = header;
+  }
+  return cleaned;
+}
+
+function findDuplicateHeaders(headers: readonly string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const header of headers) {
+    const normalized = normalizeHeader(header);
+    if (normalized) counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+  }
+  return headers.filter((header, index) => {
+    const normalized = normalizeHeader(header);
+    return Boolean(
+      normalized &&
+      (counts.get(normalized) ?? 0) > 1 &&
+      headers.findIndex((item) => normalizeHeader(item) === normalized) === index
+    );
+  });
+}
+
+function normalizeHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/[^a-z0-9 ]+/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function cleanText(value: string | undefined): string | undefined {
+  const cleaned = value?.replace(/\s+/g, " ").trim();
+  return cleaned || undefined;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = value.toLocaleLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function skipWhitespace(value: string, index: number): number {
+  while (index < value.length && /\s/.test(value[index])) index += 1;
+  return index;
+}
+
+function skipWhitespaceAndCommas(value: string, index: number): number {
+  while (index < value.length && /[\s,]/.test(value[index])) index += 1;
+  return index;
+}
+
+function decodeContent(content: string | Uint8Array): string {
+  if (typeof content === "string") return content;
+  return new TextDecoder("utf-8").decode(content);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes % (1024 * 1024) === 0) return `${bytes / (1024 * 1024)} MiB`;
+  return `${bytes.toLocaleString("en-US")} bytes`;
+}
+
+function blockedPreview(
+  format: ReferenceImportFormat | "unknown",
+  sizeBytes: number,
+  error: string
+): ReferenceImportPreview {
+  return {
+    format,
+    sizeBytes,
+    totalRecords: 0,
+    records: [],
+    invalidRecords: [],
+    fileErrors: [error],
+    warnings: [],
+    canCommit: false
+  };
+}
+
+function truncate(value: string, length = 2000): string {
+  return value.length <= length ? value : `${value.slice(0, length)}…`;
+}
+
+class ImportRecordLimitError extends Error {}

--- a/src/main/services/review-agent-service.ts
+++ b/src/main/services/review-agent-service.ts
@@ -1,0 +1,751 @@
+import type {
+  AppSettings,
+  ExtractionField,
+  ReviewEvidence,
+  ReviewExtractionSuggestion,
+  ReviewRun,
+  ReviewRunEvent,
+  ReviewRunItem,
+  ReviewStage,
+  StartReviewRunRequest
+} from "../../shared/schemas.js";
+import { reviewRunEventSchema } from "../../shared/schemas.js";
+import type { PaperPilotDb } from "../db.js";
+import { id, nowIso } from "../utils.js";
+import {
+  formatReviewEvidence,
+  fitReviewEvidenceBudget,
+  parseReviewAgentJson,
+  validateExtractionSuggestion,
+  validateScreeningSuggestion,
+  type ReviewAgentCriterion,
+  type ReviewAgentEvidence,
+  type ReviewAgentExtractionField
+} from "./review-agent-utils.js";
+import { collectReviewPaperEvidence } from "./review-evidence.js";
+import type { CredentialService } from "./credential-service.js";
+import { ResearchProvider, type ProviderChatInput, type ProviderChatResult } from "./research-provider.js";
+import type { SettingsService } from "./settings-service.js";
+
+type ReviewRunEmitter = (event: ReviewRunEvent) => void;
+
+export interface ReviewProvider {
+  chat(input: ProviderChatInput): Promise<ProviderChatResult>;
+}
+
+interface ActiveReviewRun {
+  runId?: string;
+  reviewId: string;
+  projectId: string;
+  controller: AbortController;
+}
+
+/**
+ * Runs advisory review work independently of research chat. The service never
+ * creates chat messages and never supplies model tools.
+ */
+export class ReviewAgentService {
+  private readonly active = new Map<string, ActiveReviewRun>();
+  private readonly provider: ReviewProvider;
+
+  constructor(
+    private readonly db: PaperPilotDb,
+    private readonly settings: SettingsService,
+    credentials: CredentialService,
+    provider?: ReviewProvider
+  ) {
+    this.provider = provider ?? new ResearchProvider(credentials);
+    this.db.markInterruptedReviewRuns();
+  }
+
+  async start(input: StartReviewRunRequest, emit: ReviewRunEmitter): Promise<ReviewRun> {
+    const review = this.db.getReviewById(input.reviewId);
+    if (!review) throw new Error(`Review not found: ${input.reviewId}`);
+    const paperIds = [...new Set(input.paperIds)];
+    if (paperIds.length !== input.paperIds.length) throw new Error("Review run paper IDs must be unique.");
+    this.assertPapersEligible(review.id, review.projectId, input.stage, paperIds);
+    if (input.stage !== "extraction" && input.fieldIds?.length) {
+      throw new Error("Extraction fields may only be selected for extraction runs.");
+    }
+    const fieldIds = input.stage === "extraction" ? this.resolveExtractionFieldIds(review.id, input.fieldIds) : [];
+    const reservation = this.reserveProject(review.id, review.projectId);
+    try {
+      const settings = await this.settings.get();
+      const timestamp = nowIso();
+      const run = this.db.saveReviewRun({
+        id: id("review_run"),
+        reviewId: review.id,
+        stage: input.stage,
+        provider: settings.ai.provider,
+        model: settings.ai.model,
+        protocolRevisionId: review.currentRevisionId,
+        status: "queued",
+        paperIds,
+        fieldIds,
+        completedCount: 0,
+        failedCount: 0,
+        cancelledCount: 0,
+        createdAt: timestamp,
+        updatedAt: timestamp
+      });
+      for (const paperId of paperIds) {
+        this.db.saveReviewRunItem(emptyRunItem(run.id, paperId, timestamp));
+      }
+      this.db.appendReviewAuditEvent({
+        reviewId: review.id,
+        kind: "run-started",
+        actor: "user",
+        entityType: "review-run",
+        entityId: run.id,
+        payload: { stage: run.stage, paperCount: run.paperIds.length, provider: run.provider, model: run.model }
+      });
+      this.launch(run, settings, fieldIds, emit, reservation);
+      return run;
+    } catch (error) {
+      this.releaseProject(reservation);
+      throw error;
+    }
+  }
+
+  cancel(runId: string): boolean {
+    const run = this.db.getReviewRun(runId);
+    if (!run) return false;
+    const review = this.db.getReviewById(run.reviewId);
+    if (!review) return false;
+    const active = this.active.get(review.projectId);
+    if (!active || active.runId !== runId) return false;
+    active.controller.abort(new DOMException("Review run cancelled by user.", "AbortError"));
+    return true;
+  }
+
+  async retry(runId: string, emit: ReviewRunEmitter): Promise<ReviewRun> {
+    const run = this.db.getReviewRun(runId);
+    if (!run) throw new Error(`Review run not found: ${runId}`);
+    if (!new Set<ReviewRun["status"]>(["failed", "partial", "cancelled"]).has(run.status)) {
+      if (run.status === "completed") return run;
+      throw new Error("Only failed, partial, or cancelled review runs can be retried.");
+    }
+    const review = this.db.getReviewById(run.reviewId);
+    if (!review) throw new Error(`Review not found: ${run.reviewId}`);
+    const retryable = this.db
+      .listReviewRunItems(run.id)
+      .filter((item) => item.status === "failed" || item.status === "cancelled");
+    if (!retryable.length) return run;
+    this.assertPapersEligible(
+      review.id,
+      review.projectId,
+      run.stage,
+      retryable.map((item) => item.paperId)
+    );
+    const reservation = this.reserveProject(review.id, review.projectId, run.id);
+    try {
+      const settings = await this.settings.get();
+      if (settings.ai.provider !== run.provider || settings.ai.model !== run.model) {
+        throw new Error(
+          `Retry requires the original ${run.provider} model ${run.model}. Restore that global provider/model or start a new review batch.`
+        );
+      }
+      const timestamp = nowIso();
+      for (const item of retryable) {
+        this.db.updateReviewRunItem(item.id, {
+          status: "queued",
+          error: undefined,
+          startedAt: undefined,
+          completedAt: undefined,
+          updatedAt: timestamp
+        });
+      }
+      const next = this.db.updateReviewRun(run.id, {
+        status: "queued",
+        failedCount: 0,
+        cancelledCount: 0,
+        error: undefined,
+        completedAt: undefined
+      });
+      this.launch(next, settings, next.fieldIds, emit, reservation);
+      return next;
+    } catch (error) {
+      this.releaseProject(reservation);
+      throw error;
+    }
+  }
+
+  isProjectActive(projectId: string): boolean {
+    return this.active.has(projectId);
+  }
+
+  private reserveProject(reviewId: string, projectId: string, runId?: string): ActiveReviewRun {
+    if (this.active.has(projectId)) throw new Error("This project already has an active review run.");
+    const reservation = { runId, reviewId, projectId, controller: new AbortController() };
+    this.active.set(projectId, reservation);
+    return reservation;
+  }
+
+  private releaseProject(reservation: ActiveReviewRun): void {
+    if (this.active.get(reservation.projectId) === reservation) this.active.delete(reservation.projectId);
+  }
+
+  private launch(
+    run: ReviewRun,
+    settings: AppSettings,
+    fieldIds: string[] | undefined,
+    emit: ReviewRunEmitter,
+    reservation: ActiveReviewRun
+  ): void {
+    const review = this.db.getReviewById(run.reviewId)!;
+    if (this.active.get(review.projectId) !== reservation || reservation.reviewId !== run.reviewId) {
+      throw new Error("The review run lost its project reservation before launch.");
+    }
+    reservation.runId = run.id;
+    queueMicrotask(() => {
+      void this.execute(run.id, settings, fieldIds, reservation.controller, emit, reservation)
+        .catch((error: unknown) => this.finalizeUnexpectedFailure(run.id, error, emit, reservation))
+        .finally(() => this.releaseProject(reservation));
+    });
+  }
+
+  private finalizeUnexpectedFailure(
+    runId: string,
+    error: unknown,
+    emit: ReviewRunEmitter,
+    reservation: ActiveReviewRun
+  ): void {
+    const message = `Review run stopped unexpectedly. ${safeError(error)}`;
+    try {
+      const current = this.db.getReviewRun(runId);
+      if (!current || !new Set<ReviewRun["status"]>(["queued", "running"]).has(current.status)) return;
+      for (const item of this.db
+        .listReviewRunItems(runId)
+        .filter((candidate) => candidate.status === "queued" || candidate.status === "running")) {
+        this.db.updateReviewRunItem(item.id, {
+          status: "failed",
+          error: message,
+          completedAt: nowIso()
+        });
+      }
+      const counted = this.refreshRunCounts(runId);
+      const status: ReviewRun["status"] = counted.completedCount > 0 ? "partial" : "failed";
+      const failed = this.db.updateReviewRun(runId, {
+        status,
+        error: message,
+        completedAt: nowIso()
+      });
+      this.db.appendReviewAuditEvent({
+        reviewId: failed.reviewId,
+        kind: "run-completed",
+        actor: "system",
+        entityType: "review-run",
+        entityId: failed.id,
+        payload: { status, unexpectedFailure: true, error: message }
+      });
+      this.releaseProject(reservation);
+      emitValidated(emit, {
+        type: "error",
+        runId: failed.id,
+        reviewId: failed.reviewId,
+        status: "failed",
+        error: message
+      });
+      emitValidated(emit, { type: "complete", runId: failed.id, reviewId: failed.reviewId, run: failed });
+    } catch {
+      try {
+        const current = this.db.getReviewRun(runId);
+        if (current) {
+          emitValidated(emit, {
+            type: "error",
+            runId: current.id,
+            reviewId: current.reviewId,
+            status: "failed",
+            error: message
+          });
+        }
+      } catch {
+        // The database itself is unavailable; the startup recovery pass will finalize the row on next launch.
+      }
+    }
+  }
+
+  private async execute(
+    runId: string,
+    settings: AppSettings,
+    fieldIds: string[] | undefined,
+    controller: AbortController,
+    emit: ReviewRunEmitter,
+    reservation: ActiveReviewRun
+  ): Promise<void> {
+    let run = this.db.updateReviewRun(runId, { status: "running", startedAt: nowIso() });
+    emitValidated(emit, { type: "status", runId: run.id, reviewId: run.reviewId, status: "running" });
+    const review = this.db.getReviewById(run.reviewId)!;
+    const revision = this.db.getReviewProtocolRevision(run.reviewId, run.protocolRevisionId);
+    if (!revision) throw new Error(`Protocol revision not found: ${run.protocolRevisionId}`);
+    const items = this.db.listReviewRunItems(run.id).filter((item) => item.status === "queued");
+
+    for (let index = 0; index < items.length; index += 1) {
+      if (controller.signal.aborted) break;
+      const item = items[index];
+      emitValidated(emit, progressEvent(run, item.paperId));
+      if (controller.signal.aborted) break;
+      try {
+        const completed = await this.processItem({
+          run,
+          item,
+          projectId: review.projectId,
+          settings,
+          fieldIds,
+          signal: controller.signal
+        });
+        emitValidated(emit, { type: "item", runId: run.id, reviewId: run.reviewId, item: completed });
+      } catch (error) {
+        const cancelled = controller.signal.aborted || isAbortError(error);
+        const recordedAttempts = this.db.getReviewRunItem(item.id)?.attemptCount ?? item.attemptCount;
+        const failed = this.db.updateReviewRunItem(item.id, {
+          status: cancelled ? "cancelled" : "failed",
+          attemptCount: recordedAttempts,
+          error: cancelled ? "Review run cancelled by user." : safeError(error),
+          completedAt: nowIso()
+        });
+        emitValidated(emit, { type: "item", runId: run.id, reviewId: run.reviewId, item: failed });
+        if (cancelled) break;
+      }
+      run = this.refreshRunCounts(run.id);
+      emitValidated(emit, progressEvent(run));
+    }
+
+    if (controller.signal.aborted) {
+      for (const item of this.db.listReviewRunItems(run.id).filter((candidate) => candidate.status === "queued")) {
+        this.db.updateReviewRunItem(item.id, {
+          status: "cancelled",
+          error: "Review run cancelled before processing began.",
+          completedAt: nowIso()
+        });
+      }
+    }
+    run = this.refreshRunCounts(run.id);
+    const total = run.paperIds.length;
+    const status: ReviewRun["status"] = controller.signal.aborted
+      ? "cancelled"
+      : run.failedCount === total
+        ? "failed"
+        : run.failedCount > 0 || run.cancelledCount > 0
+          ? "partial"
+          : "completed";
+    run = this.db.updateReviewRun(run.id, {
+      status,
+      error: status === "failed" ? "Every selected paper failed review assistance." : undefined,
+      completedAt: nowIso()
+    });
+    this.db.appendReviewAuditEvent({
+      reviewId: run.reviewId,
+      kind: status === "cancelled" ? "run-cancelled" : "run-completed",
+      actor: status === "cancelled" ? "user" : "ai",
+      entityType: "review-run",
+      entityId: run.id,
+      payload: {
+        status,
+        completedCount: run.completedCount,
+        failedCount: run.failedCount,
+        cancelledCount: run.cancelledCount
+      }
+    });
+    this.releaseProject(reservation);
+    emitValidated(emit, progressEvent(run));
+    if (status === "failed" || status === "cancelled") {
+      emitValidated(emit, {
+        type: "error",
+        runId: run.id,
+        reviewId: run.reviewId,
+        error: status === "cancelled" ? "Review run cancelled by user." : (run.error ?? "Review run failed."),
+        status
+      });
+    }
+    emitValidated(emit, { type: "complete", runId: run.id, reviewId: run.reviewId, run });
+  }
+
+  private async processItem(input: {
+    run: ReviewRun;
+    item: ReviewRunItem;
+    projectId: string;
+    settings: AppSettings;
+    fieldIds: string[] | undefined;
+    signal: AbortSignal;
+  }): Promise<ReviewRunItem> {
+    const timestamp = nowIso();
+    let item = this.db.updateReviewRunItem(input.item.id, {
+      status: "running",
+      attemptCount: input.item.attemptCount,
+      startedAt: timestamp,
+      error: undefined
+    });
+    const paper = this.db.getPaper(input.projectId, item.paperId);
+    if (!paper) throw new Error(`Paper not found: ${item.paperId}`);
+    const revision = this.db.getReviewProtocolRevision(input.run.reviewId, input.run.protocolRevisionId)!;
+    const evidence = fitReviewEvidenceBudget(
+      collectReviewPaperEvidence({
+        db: this.db,
+        projectId: input.projectId,
+        paperId: item.paperId,
+        stage: input.run.stage,
+        query: `${revision.researchQuestion}\n${revision.objectives.join("\n")}`,
+        limit: 12
+      }),
+      input.settings.ai.provider
+    );
+    const storedEvidence = evidence.map((entry) => toStoredEvidence(input.run, item.id, paper, entry, timestamp));
+
+    if (input.run.stage === "extraction") {
+      const allFields = this.db.listExtractionFields(input.run.reviewId);
+      const selected = input.fieldIds?.length
+        ? allFields.filter((field) => input.fieldIds!.includes(field.id))
+        : allFields;
+      if (!selected.length) throw new Error("No active extraction fields were selected.");
+      let providerAttempts = 0;
+      const suggestions = evidence.length
+        ? await this.extractInGroups(input, selected, evidence, () => {
+            providerAttempts += 1;
+            this.db.updateReviewRunItem(item.id, {
+              attemptCount: input.item.attemptCount + providerAttempts
+            });
+          })
+        : selected.map(notFoundSuggestion);
+      item = this.db.updateReviewRunItem(item.id, {
+        status: "completed",
+        attemptCount: input.item.attemptCount + providerAttempts,
+        extractionSuggestions: suggestions,
+        evidence: storedEvidence,
+        completedAt: nowIso()
+      });
+      for (const suggestion of suggestions) {
+        this.db.saveExtractionValue({
+          reviewId: input.run.reviewId,
+          paperId: item.paperId,
+          fieldId: suggestion.fieldId,
+          value: suggestion.value,
+          // A model can recommend that a field is not found, but only a reviewer
+          // can accept that as a completed extraction state.
+          status: suggestion.status === "not-found" ? "suggested" : suggestion.status,
+          origin: "ai",
+          evidenceIds: suggestion.evidenceIds
+            .map((evidenceId) => storedEvidence.find((entry) => entry.evidenceId === evidenceId)?.id)
+            .filter((value): value is string => Boolean(value)),
+          runItemId: item.id
+        });
+      }
+      return item;
+    }
+
+    const criteria: ReviewAgentCriterion[] = revision.criteria
+      .filter((criterion) => criterion.stage === input.run.stage)
+      .map((criterion) => ({
+        id: criterion.id,
+        kind: criterion.type,
+        text: `${criterion.label}${criterion.description ? ` — ${criterion.description}` : ""}`
+      }));
+    if (!evidence.length) {
+      return this.db.updateReviewRunItem(item.id, {
+        status: "completed",
+        suggestedDecision: "uncertain",
+        rationale:
+          input.run.stage === "title-abstract"
+            ? "No abstract or usable metadata is available."
+            : "No trusted indexed full text is available for this paper.",
+        evidence: [],
+        completedAt: nowIso()
+      });
+    }
+    let providerAttempts = 0;
+    const result = await this.requestAndValidate(
+      input.settings,
+      screeningPrompt(input.run.stage, revision.researchQuestion, revision.objectives, criteria, evidence),
+      (value) => validateScreeningSuggestion({ value, criteria, evidence, paperId: paper.id }),
+      input.signal,
+      () => {
+        providerAttempts += 1;
+        this.db.updateReviewRunItem(item.id, {
+          attemptCount: input.item.attemptCount + providerAttempts
+        });
+      }
+    );
+    const reasonCriterionId = exclusionReason(result.value.assessments, criteria);
+    return this.db.updateReviewRunItem(item.id, {
+      status: "completed",
+      attemptCount: input.item.attemptCount + result.attempts,
+      suggestedDecision: result.value.decision,
+      suggestedReasonCriterionId: result.value.decision === "exclude" ? reasonCriterionId : undefined,
+      suggestedCustomReason:
+        result.value.decision === "exclude" && !reasonCriterionId
+          ? "AI suggested exclusion; reviewer must choose a reason."
+          : undefined,
+      rationale: result.value.rationale,
+      criterionAssessments: result.value.assessments,
+      evidence: storedEvidence,
+      completedAt: nowIso()
+    });
+  }
+
+  private async extractInGroups(
+    input: {
+      run: ReviewRun;
+      item: ReviewRunItem;
+      settings: AppSettings;
+      signal: AbortSignal;
+    },
+    fields: ExtractionField[],
+    evidence: ReviewAgentEvidence[],
+    onProviderAttempt: () => void
+  ): Promise<ReviewExtractionSuggestion[]> {
+    const revision = this.db.getReviewProtocolRevision(input.run.reviewId, input.run.protocolRevisionId)!;
+    const suggestions: ReviewExtractionSuggestion[] = [];
+    for (let offset = 0; offset < fields.length; offset += 6) {
+      const group = fields.slice(offset, offset + 6);
+      const agentFields: ReviewAgentExtractionField[] = group.map((field) => ({
+        id: field.id,
+        type: field.type,
+        options: field.options
+      }));
+      const result = await this.requestAndValidate(
+        input.settings,
+        extractionPrompt(revision.researchQuestion, group, evidence),
+        (value) => validateExtractionSuggestion({ value, fields: agentFields, evidence, paperId: input.item.paperId }),
+        input.signal,
+        onProviderAttempt
+      );
+      for (const value of result.value.values) {
+        suggestions.push({
+          fieldId: value.fieldId,
+          value: value.status === "found" ? (value.value as ReviewExtractionSuggestion["value"]) : null,
+          status: value.status === "found" ? "suggested" : value.status === "unclear" ? "needs-review" : "not-found",
+          evidenceIds: value.status === "found" || value.status === "unclear" ? value.evidenceIds : [],
+          rationale: value.note
+        });
+      }
+    }
+    return suggestions;
+  }
+
+  private async requestAndValidate<T>(
+    settings: AppSettings,
+    prompt: string,
+    validate: (value: unknown) => T,
+    signal: AbortSignal,
+    onAttempt?: () => void
+  ): Promise<{ value: T; attempts: number }> {
+    let invalidOutput = "";
+    let validationError = "";
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      const messages =
+        attempt === 1
+          ? [{ role: "user" as const, content: prompt }]
+          : [
+              { role: "user" as const, content: prompt },
+              { role: "assistant" as const, content: invalidOutput },
+              {
+                role: "user" as const,
+                content: `The previous JSON was invalid: ${validationError}. Return one corrected JSON object only.`
+              }
+            ];
+      onAttempt?.();
+      const response = await this.provider.chat({
+        settings,
+        system: reviewSystemPrompt(),
+        messages,
+        signal,
+        onDelta: () => undefined
+      });
+      invalidOutput = response.content;
+      try {
+        return { value: validate(parseReviewAgentJson(response.content)), attempts: attempt };
+      } catch (error) {
+        validationError = safeError(error);
+        if (attempt === 2) {
+          throw new Error(`Review response validation failed after one repair attempt. ${validationError}`, {
+            cause: error
+          });
+        }
+      }
+    }
+    throw new Error("Review response validation failed.");
+  }
+
+  private refreshRunCounts(runId: string): ReviewRun {
+    const items = this.db.listReviewRunItems(runId);
+    return this.db.updateReviewRun(runId, {
+      completedCount: items.filter((item) => item.status === "completed").length,
+      failedCount: items.filter((item) => item.status === "failed").length,
+      cancelledCount: items.filter((item) => item.status === "cancelled").length
+    });
+  }
+
+  private assertPapersEligible(reviewId: string, projectId: string, stage: ReviewStage, paperIds: string[]): void {
+    for (const paperId of paperIds) {
+      if (!this.db.getPaper(projectId, paperId)) throw new Error(`Paper not found in review project: ${paperId}`);
+      if (
+        (stage === "full-text" || stage === "extraction") &&
+        this.db.getCurrentScreeningDecision(reviewId, paperId, "title-abstract")?.decision !== "include"
+      ) {
+        throw new Error(
+          `${stage === "extraction" ? "Extraction" : "Full-text"} assistance is limited to papers currently included during title/abstract screening.`
+        );
+      }
+      if (
+        stage === "extraction" &&
+        this.db.getCurrentScreeningDecision(reviewId, paperId, "full-text")?.decision !== "include"
+      ) {
+        throw new Error("Extraction assistance is limited to papers included during full-text screening.");
+      }
+    }
+  }
+
+  private resolveExtractionFieldIds(reviewId: string, requested: string[] | undefined): string[] {
+    const activeIds = this.db.listExtractionFields(reviewId).map((field) => field.id);
+    const selected = requested?.length ? [...new Set(requested)] : activeIds;
+    if (!selected.length) throw new Error("At least one active extraction field is required.");
+    if (requested && selected.length !== requested.length) throw new Error("Extraction field IDs must be unique.");
+    const active = new Set(activeIds);
+    const unknown = selected.find((fieldId) => !active.has(fieldId));
+    if (unknown) throw new Error(`Active extraction field not found: ${unknown}`);
+    return selected;
+  }
+}
+
+function emptyRunItem(runId: string, paperId: string, timestamp: string): ReviewRunItem {
+  return {
+    id: id("review_item"),
+    runId,
+    paperId,
+    status: "queued",
+    attemptCount: 0,
+    criterionAssessments: [],
+    extractionSuggestions: [],
+    evidence: [],
+    stale: false,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+}
+
+function toStoredEvidence(
+  run: ReviewRun,
+  runItemId: string,
+  paper: { id: string; title: string; doi?: string; url?: string },
+  evidence: ReviewAgentEvidence,
+  createdAt: string
+): ReviewEvidence {
+  return {
+    id: id("review_evidence"),
+    reviewId: run.reviewId,
+    evidenceId: evidence.evidenceId,
+    runId: run.id,
+    runItemId,
+    paperId: evidence.paperId,
+    artifactId: evidence.artifactId,
+    chunkId: evidence.chunkId,
+    sourceType:
+      evidence.sourceType === "artifact"
+        ? "artifact-chunk"
+        : evidence.locator === "Abstract"
+          ? "paper-abstract"
+          : "paper-metadata",
+    title: evidence.title || paper.title,
+    excerpt: evidence.excerpt,
+    locator: evidence.locator,
+    page: evidence.page,
+    doi: paper.doi,
+    url: paper.url,
+    createdAt
+  };
+}
+
+function reviewSystemPrompt(): string {
+  return [
+    "You are an advisory evidence-review assistant.",
+    "Use only the supplied evidence for this paper and return exactly one JSON object.",
+    "Never make a human screening decision, invent evidence, or reveal hidden reasoning.",
+    "When evidence is insufficient, use uncertain or not-found as instructed."
+  ].join("\n");
+}
+
+function screeningPrompt(
+  stage: Exclude<ReviewStage, "extraction">,
+  question: string,
+  objectives: string[],
+  criteria: ReviewAgentCriterion[],
+  evidence: ReviewAgentEvidence[]
+): string {
+  return [
+    `Stage: ${stage}`,
+    `Research question: ${question || "Not specified"}`,
+    `Objectives: ${objectives.length ? objectives.join("; ") : "Not specified"}`,
+    "Criteria:",
+    ...criteria.map((criterion) => `- ${criterion.id} (${criterion.kind}): ${criterion.text}`),
+    "Evidence:",
+    formatReviewEvidence(evidence),
+    "Return JSON with decision (include|exclude|uncertain), rationale, and assessments.",
+    "Each assessment must contain criterionId, assessment (met|not-met|unclear), explanation, and evidenceIds.",
+    "Assess every criterion exactly once. Non-unclear assessments require evidence IDs."
+  ].join("\n\n");
+}
+
+function extractionPrompt(question: string, fields: ExtractionField[], evidence: ReviewAgentEvidence[]): string {
+  return [
+    `Research question: ${question || "Not specified"}`,
+    "Extraction fields:",
+    ...fields.map(
+      (field) =>
+        `- ${field.id}: ${field.name} (${field.type})${field.options.length ? `; options: ${field.options.join(", ")}` : ""}${field.description ? ` — ${field.description}` : ""}`
+    ),
+    "Evidence:",
+    formatReviewEvidence(evidence),
+    "Return JSON with a values array. Include every field exactly once.",
+    "Each item must contain fieldId, status (found|not-found|unclear), value when found, evidenceIds, and optional note.",
+    "Found values require current-paper evidence. Never infer a value that is not stated in the evidence."
+  ].join("\n\n");
+}
+
+function exclusionReason(
+  assessments: Array<{ criterionId: string; assessment: "met" | "not-met" | "unclear" }>,
+  criteria: ReviewAgentCriterion[]
+): string | undefined {
+  const byId = new Map(criteria.map((criterion) => [criterion.id, criterion]));
+  return assessments.find((assessment) => {
+    const criterion = byId.get(assessment.criterionId);
+    return criterion?.kind === "exclusion" ? assessment.assessment === "met" : assessment.assessment === "not-met";
+  })?.criterionId;
+}
+
+function notFoundSuggestion(field: ExtractionField): ReviewExtractionSuggestion {
+  return {
+    fieldId: field.id,
+    value: null,
+    status: "not-found",
+    evidenceIds: [],
+    rationale: "No trusted indexed full text is available for this paper."
+  };
+}
+
+function progressEvent(run: ReviewRun, currentPaperId?: string): ReviewRunEvent {
+  return {
+    type: "progress",
+    runId: run.id,
+    reviewId: run.reviewId,
+    completed: run.completedCount,
+    failed: run.failedCount,
+    cancelled: run.cancelledCount,
+    total: run.paperIds.length,
+    currentPaperId
+  };
+}
+
+function emitValidated(emit: ReviewRunEmitter, event: ReviewRunEvent): void {
+  emit(reviewRunEventSchema.parse(event));
+}
+
+function safeError(error: unknown): string {
+  if (error instanceof Error) return error.message.slice(0, 4_000);
+  return String(error).slice(0, 4_000);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}

--- a/src/main/services/review-agent-utils.ts
+++ b/src/main/services/review-agent-utils.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+
+export interface ReviewAgentEvidence {
+  evidenceId: string;
+  paperId: string;
+  sourceType: "paper" | "artifact";
+  title: string;
+  excerpt: string;
+  artifactId?: string;
+  chunkId?: string;
+  page?: number;
+  locator?: string;
+}
+
+export interface ReviewAgentCriterion {
+  id: string;
+  kind: "inclusion" | "exclusion";
+  text: string;
+}
+
+export interface ReviewAgentExtractionField {
+  id: string;
+  type: "short-text" | "long-text" | "number" | "boolean" | "single-select" | "multi-select";
+  options?: string[];
+}
+
+const criterionAssessmentSchema = z.object({
+  criterionId: z.string(),
+  assessment: z.enum(["met", "not-met", "unclear"]),
+  explanation: z.string().trim().min(1).max(2_000),
+  evidenceIds: z.array(z.string()).max(12).default([])
+});
+
+const screeningSuggestionSchema = z.object({
+  decision: z.enum(["include", "exclude", "uncertain"]),
+  rationale: z.string().trim().min(1).max(4_000),
+  assessments: z.array(criterionAssessmentSchema)
+});
+
+export type ReviewAgentScreeningSuggestion = z.infer<typeof screeningSuggestionSchema>;
+
+const extractionSuggestionSchema = z.object({
+  values: z.array(
+    z.object({
+      fieldId: z.string(),
+      status: z.enum(["found", "not-found", "unclear"]),
+      value: z.unknown().optional(),
+      note: z.string().trim().max(2_000).optional(),
+      evidenceIds: z.array(z.string()).max(12).default([])
+    })
+  )
+});
+
+export type ReviewAgentExtractionSuggestion = z.infer<typeof extractionSuggestionSchema>;
+
+export function parseReviewAgentJson(content: string): unknown {
+  const trimmed = content.trim();
+  if (!trimmed) throw new Error("The AI provider returned an empty review response.");
+  const unfenced = trimmed
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+  try {
+    return JSON.parse(unfenced) as unknown;
+  } catch {
+    const object = firstBalancedJsonObject(unfenced);
+    if (!object) throw new Error("The AI provider did not return valid JSON.");
+    try {
+      return JSON.parse(object) as unknown;
+    } catch {
+      throw new Error("The AI provider did not return valid JSON.");
+    }
+  }
+}
+
+export function validateScreeningSuggestion(input: {
+  value: unknown;
+  criteria: ReviewAgentCriterion[];
+  evidence: ReviewAgentEvidence[];
+  paperId: string;
+}): ReviewAgentScreeningSuggestion {
+  const parsed = screeningSuggestionSchema.parse(input.value);
+  const criteria = new Map(input.criteria.map((criterion) => [criterion.id, criterion]));
+  const evidence = new Map(input.evidence.map((entry) => [entry.evidenceId, entry]));
+  const seen = new Set<string>();
+
+  for (const assessment of parsed.assessments) {
+    if (!criteria.has(assessment.criterionId)) {
+      throw new Error(`Unknown review criterion: ${assessment.criterionId}.`);
+    }
+    if (seen.has(assessment.criterionId)) {
+      throw new Error(`Duplicate review criterion assessment: ${assessment.criterionId}.`);
+    }
+    seen.add(assessment.criterionId);
+    validateEvidenceIds(assessment.evidenceIds, evidence, input.paperId);
+    if (assessment.assessment !== "unclear" && assessment.evidenceIds.length === 0) {
+      throw new Error(`Criterion ${assessment.criterionId} is missing supporting evidence.`);
+    }
+  }
+  for (const criterion of input.criteria) {
+    if (!seen.has(criterion.id)) throw new Error(`Missing review criterion assessment: ${criterion.id}.`);
+  }
+
+  const byId = new Map(parsed.assessments.map((assessment) => [assessment.criterionId, assessment]));
+  const includeIsSupported =
+    input.criteria.length > 0 &&
+    input.criteria.every((criterion) => {
+      const assessment = byId.get(criterion.id)!;
+      return criterion.kind === "inclusion" ? assessment.assessment === "met" : assessment.assessment === "not-met";
+    });
+  const excludeIsSupported = input.criteria.some((criterion) => {
+    const assessment = byId.get(criterion.id)!;
+    return criterion.kind === "inclusion" ? assessment.assessment === "not-met" : assessment.assessment === "met";
+  });
+  if (parsed.decision === "include" && !includeIsSupported) {
+    throw new Error("The include recommendation is inconsistent with its criterion assessments.");
+  }
+  if (parsed.decision === "exclude" && !excludeIsSupported) {
+    throw new Error("The exclude recommendation is inconsistent with its criterion assessments.");
+  }
+  if (parsed.decision === "uncertain" && (includeIsSupported || excludeIsSupported)) {
+    throw new Error("The uncertain recommendation is inconsistent with its criterion assessments.");
+  }
+  return parsed;
+}
+
+export function validateExtractionSuggestion(input: {
+  value: unknown;
+  fields: ReviewAgentExtractionField[];
+  evidence: ReviewAgentEvidence[];
+  paperId: string;
+}): ReviewAgentExtractionSuggestion {
+  const parsed = extractionSuggestionSchema.parse(input.value);
+  const fields = new Map(input.fields.map((field) => [field.id, field]));
+  const evidence = new Map(input.evidence.map((entry) => [entry.evidenceId, entry]));
+  const seen = new Set<string>();
+  for (const item of parsed.values) {
+    const field = fields.get(item.fieldId);
+    if (!field) throw new Error(`Unknown extraction field: ${item.fieldId}.`);
+    if (seen.has(item.fieldId)) throw new Error(`Duplicate extraction field value: ${item.fieldId}.`);
+    seen.add(item.fieldId);
+    validateEvidenceIds(item.evidenceIds, evidence, input.paperId);
+    if (item.status === "found") {
+      if (item.value === undefined || item.value === null || item.value === "") {
+        throw new Error(`Extraction field ${item.fieldId} is marked found without a value.`);
+      }
+      if (item.evidenceIds.length === 0) {
+        throw new Error(`Extraction field ${item.fieldId} is missing supporting evidence.`);
+      }
+      validateExtractionValue(field, item.value);
+    } else if (item.value !== undefined && item.value !== null && item.value !== "") {
+      throw new Error(`Extraction field ${item.fieldId} has a value but is marked ${item.status}.`);
+    }
+  }
+  for (const field of input.fields) {
+    if (!seen.has(field.id)) throw new Error(`Missing extraction field value: ${field.id}.`);
+  }
+  return parsed;
+}
+
+export function formatReviewEvidence(evidence: ReviewAgentEvidence[]): string {
+  return evidence
+    .map((entry) => {
+      const locator = entry.page ? `page ${entry.page}` : entry.locator;
+      return `[${entry.evidenceId}] ${entry.title}${locator ? ` — ${locator}` : ""}\n${entry.excerpt}`;
+    })
+    .join("\n\n");
+}
+
+export function fitReviewEvidenceBudget(
+  evidence: ReviewAgentEvidence[],
+  provider: "ollama" | "vercel" | "openai-compatible"
+): ReviewAgentEvidence[] {
+  if (!evidence.length) return [];
+  // Approximate four characters per token and retain room for the protocol,
+  // structured instructions, and the provider's response.
+  const totalCharacterBudget = provider === "ollama" ? 16_000 : 40_000;
+  const perEntryBudget = Math.max(400, Math.floor(totalCharacterBudget / evidence.length));
+  return evidence.map((entry) => ({
+    ...entry,
+    excerpt: entry.excerpt.slice(0, perEntryBudget)
+  }));
+}
+
+function validateEvidenceIds(ids: string[], evidence: Map<string, ReviewAgentEvidence>, paperId: string): void {
+  for (const evidenceId of ids) {
+    const entry = evidence.get(evidenceId);
+    if (!entry) throw new Error(`Unknown review evidence reference: ${evidenceId}.`);
+    if (entry.paperId !== paperId) throw new Error(`Review evidence ${evidenceId} belongs to a different paper.`);
+  }
+}
+
+function validateExtractionValue(field: ReviewAgentExtractionField, value: unknown): void {
+  switch (field.type) {
+    case "short-text":
+    case "long-text":
+      z.string().parse(value);
+      return;
+    case "number":
+      z.number().finite().parse(value);
+      return;
+    case "boolean":
+      z.boolean().parse(value);
+      return;
+    case "single-select": {
+      const selected = z.string().parse(value);
+      if (!field.options?.includes(selected)) throw new Error(`Invalid option for extraction field ${field.id}.`);
+      return;
+    }
+    case "multi-select": {
+      const selected = z.array(z.string()).parse(value);
+      if (selected.some((option) => !field.options?.includes(option))) {
+        throw new Error(`Invalid option for extraction field ${field.id}.`);
+      }
+    }
+  }
+}
+
+function firstBalancedJsonObject(value: string): string | undefined {
+  const start = value.indexOf("{");
+  if (start < 0) return undefined;
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = start; index < value.length; index += 1) {
+    const character = value[index];
+    if (quoted) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') quoted = false;
+      continue;
+    }
+    if (character === '"') quoted = true;
+    else if (character === "{") depth += 1;
+    else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return value.slice(start, index + 1);
+    }
+  }
+  return undefined;
+}

--- a/src/main/services/review-evidence.ts
+++ b/src/main/services/review-evidence.ts
@@ -1,0 +1,138 @@
+import type { ReviewStage } from "../../shared/schemas.js";
+import type { PaperPilotDb } from "../db.js";
+import type { ReviewAgentEvidence } from "./review-agent-utils.js";
+
+const trustedFullTextTypes = new Set(["paper-pdf", "markdown", "table"]);
+
+export function collectReviewPaperEvidence(input: {
+  db: PaperPilotDb;
+  projectId: string;
+  paperId: string;
+  stage: ReviewStage;
+  query: string;
+  limit?: number;
+}): ReviewAgentEvidence[] {
+  const paper = input.db.getPaper(input.projectId, input.paperId);
+  if (!paper) throw new Error(`Paper not found: ${input.paperId}`);
+  const limit = Math.max(1, Math.min(input.limit ?? 12, 24));
+  if (input.stage === "title-abstract") {
+    const metadata = [
+      `Title: ${paper.title}`,
+      paper.authors.length ? `Authors: ${paper.authors.join("; ")}` : undefined,
+      paper.year ? `Year: ${paper.year}` : undefined,
+      paper.venue ? `Venue: ${paper.venue}` : undefined,
+      paper.doi ? `DOI: ${paper.doi}` : undefined,
+      paper.url ? `URL: ${paper.url}` : undefined
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n");
+    const entries: ReviewAgentEvidence[] = [
+      {
+        evidenceId: "S1",
+        paperId: paper.id,
+        sourceType: "paper",
+        title: paper.title,
+        excerpt: metadata,
+        locator: "Paper metadata"
+      }
+    ];
+    const abstract = paper.abstract?.trim();
+    if (abstract && limit > 1) {
+      entries.push({
+        evidenceId: "S2",
+        paperId: paper.id,
+        sourceType: "paper",
+        title: paper.title,
+        excerpt: abstract.slice(0, 8_000),
+        locator: "Abstract"
+      });
+    }
+    return entries;
+  }
+
+  const linkedArtifacts = input.db
+    .listArtifacts(input.projectId)
+    .filter(
+      (artifact) =>
+        trustedFullTextTypes.has(artifact.type) &&
+        artifact.type !== "chat-answer" &&
+        artifact.source !== "research-chat" &&
+        metadataString(artifact.metadata.paperId) === paper.id
+    );
+  const entries: Omit<ReviewAgentEvidence, "evidenceId">[] = [];
+  const seen = new Set<string>();
+  const add = (entry: Omit<ReviewAgentEvidence, "evidenceId">): void => {
+    const key = `${entry.artifactId}:${entry.chunkId ?? entry.excerpt.slice(0, 120)}`;
+    if (seen.has(key) || entries.length >= limit) return;
+    seen.add(key);
+    entries.push(entry);
+  };
+
+  for (const artifact of linkedArtifacts) {
+    for (const row of input.db.searchIndexedChunks({
+      projectId: input.projectId,
+      artifactId: artifact.id,
+      query: input.query,
+      limit
+    })) {
+      const metadata = safeJson(row.metadataJson);
+      add({
+        paperId: paper.id,
+        sourceType: "artifact",
+        artifactId: artifact.id,
+        chunkId: row.chunkId,
+        title: paper.title,
+        excerpt: row.text.slice(0, 4_000),
+        page: positiveInteger(metadata.page),
+        locator: locatorFromMetadata(metadata)
+      });
+    }
+  }
+  for (const artifact of linkedArtifacts) {
+    if (entries.length >= limit) break;
+    for (const row of input.db.listArtifactChunks(input.projectId, artifact.id, limit)) {
+      const metadata = safeJson(row.metadataJson);
+      add({
+        paperId: paper.id,
+        sourceType: "artifact",
+        artifactId: artifact.id,
+        chunkId: row.chunkId,
+        title: paper.title,
+        excerpt: row.text.slice(0, 4_000),
+        page: positiveInteger(metadata.page),
+        locator: locatorFromMetadata(metadata)
+      });
+    }
+  }
+  return entries.map((entry, index) => ({ ...entry, evidenceId: `S${index + 1}` }));
+}
+
+export function hasIndexedReviewFullText(db: PaperPilotDb, projectId: string, paperId: string): boolean {
+  return db.listArtifacts(projectId).some((artifact) => {
+    if (!trustedFullTextTypes.has(artifact.type) || metadataString(artifact.metadata.paperId) !== paperId) return false;
+    return db.listArtifactChunks(projectId, artifact.id, 1).length > 0;
+  });
+}
+
+function safeJson(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function metadataString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : undefined;
+}
+
+function locatorFromMetadata(metadata: Record<string, unknown>): string | undefined {
+  if (positiveInteger(metadata.page)) return `Page ${positiveInteger(metadata.page)}`;
+  return metadataString(metadata.locator) ?? metadataString(metadata.heading) ?? metadataString(metadata.section);
+}

--- a/src/main/services/review-export-service.ts
+++ b/src/main/services/review-export-service.ts
@@ -639,11 +639,11 @@ function risText(value: string): string {
 }
 
 function markdownInline(value: string): string {
-  return value.replace(/\r?\n/g, " ").replace(/`/g, "\\`");
+  return value.replace(/\\/g, "\\\\").replace(/\r?\n/g, " ").replace(/`/g, "\\`");
 }
 
 function markdownTable(value: string): string {
-  return value.replace(/\r?\n/g, " ").replace(/\|/g, "\\|").trim();
+  return value.replace(/\\/g, "\\\\").replace(/\r?\n/g, " ").replace(/\|/g, "\\|").trim();
 }
 
 function escapeXml(value: string): string {

--- a/src/main/services/review-export-service.ts
+++ b/src/main/services/review-export-service.ts
@@ -1,0 +1,800 @@
+import {
+  paperSchema,
+  type DiscoveryBatch,
+  type ExtractionField,
+  type ExtractionPrimitiveValue,
+  type ExtractionValue,
+  type Paper,
+  type ReviewAuditEvent,
+  type ReviewEvidence,
+  type ReviewFlowSummary,
+  type ReviewProtocol,
+  type ReviewProtocolRevision,
+  type ReviewRun,
+  type ScreeningDecision
+} from "../../shared/schemas.js";
+import type {
+  ExtractionFieldHistoryEntry,
+  ExtractionValueHistoryEntry,
+  PortableExtractionValue,
+  PortableReviewEvidence,
+  PortableReviewRunItem,
+  PortableScreeningDecision,
+  ReviewCandidateOrigin
+} from "../db.js";
+
+export interface ReviewExportInput {
+  protocol: ReviewProtocol;
+  revision: ReviewProtocolRevision;
+  revisions: readonly ReviewProtocolRevision[];
+  batches: readonly DiscoveryBatch[];
+  candidateOrigins: readonly ReviewCandidateOrigin[];
+  screeningDecisions: readonly PortableScreeningDecision[];
+  includedPapers: readonly Paper[];
+  includedPaperIds: readonly string[];
+  extractionFields: readonly ExtractionField[];
+  extractionFieldHistory: readonly ExtractionFieldHistoryEntry[];
+  extractionValues: readonly PortableExtractionValue[];
+  extractionValueHistory: readonly ExtractionValueHistoryEntry[];
+  evidence: readonly PortableReviewEvidence[];
+  runs: readonly ReviewRun[];
+  runItems: readonly PortableReviewRunItem[];
+  auditEvents: readonly ReviewAuditEvent[];
+  flowSummary: ReviewFlowSummary;
+}
+
+export const REVIEW_EXPORT_FILE_NAMES = [
+  "evidence-matrix.csv",
+  "evidence-locators.csv",
+  "screening-decisions.csv",
+  "included-references.ris",
+  "included-references.bib",
+  "review-summary.md",
+  "review-flow.svg",
+  "review-audit.json"
+] as const;
+
+export type ReviewExportFileName = (typeof REVIEW_EXPORT_FILE_NAMES)[number];
+export type ReviewExportPackage = Map<ReviewExportFileName, string>;
+
+/**
+ * Render an auditable review export without touching the filesystem.
+ * The same logical input always produces byte-for-byte identical files.
+ */
+export function renderReviewExportPackage(input: ReviewExportInput): ReviewExportPackage {
+  const paperById = collectPaperSnapshots(input);
+  const papers = sortPapers(
+    input.includedPaperIds.flatMap((paperId) => {
+      const paper = paperById.get(paperId);
+      return paper ? [paper] : [];
+    })
+  );
+  const fields = sortFields(input.extractionFields.filter((field) => field.active));
+  const values = currentConfirmedValues(input.extractionValues, fields, new Set(papers.map((paper) => paper.id)));
+  const files: ReviewExportPackage = new Map();
+
+  files.set("evidence-matrix.csv", renderEvidenceMatrix(papers, fields, values));
+  files.set(
+    "evidence-locators.csv",
+    renderEvidenceLocators(paperById, input.extractionFields, input.extractionValues, input.evidence)
+  );
+  files.set("screening-decisions.csv", renderScreeningDecisions(input.screeningDecisions, paperById, input.revisions));
+  files.set("included-references.ris", renderRis(papers));
+  files.set("included-references.bib", renderBibtex(papers));
+  files.set("review-summary.md", renderSummary(input, papers, fields, values, paperById));
+  files.set("review-flow.svg", renderFlowSvg(input.flowSummary));
+  files.set("review-audit.json", renderAuditJson(input, papers, paperById));
+
+  return files;
+}
+
+function renderEvidenceMatrix(
+  papers: readonly Paper[],
+  fields: readonly ExtractionField[],
+  values: ReadonlyMap<string, ExtractionValue>
+): string {
+  const fieldHeaders = uniqueFieldHeaders(fields);
+  const headers = ["paper_id", "title", "authors", "year", "doi", ...fieldHeaders];
+  const rows = papers.map((paper) => [
+    paper.id,
+    paper.title,
+    paper.authors.join("; "),
+    paper.year,
+    paper.doi,
+    ...fields.map((field) => {
+      const value = values.get(valueKey(paper.id, field.id));
+      return value ? renderExtractionValue(value.value) : "";
+    })
+  ]);
+  return renderCsv(headers, rows);
+}
+
+function renderEvidenceLocators(
+  paperById: ReadonlyMap<string, Paper>,
+  fields: readonly ExtractionField[],
+  values: readonly ExtractionValue[],
+  evidence: readonly ReviewEvidence[]
+): string {
+  const fieldById = new Map(fields.map((field) => [field.id, field]));
+  const valuesByEvidenceId = new Map<string, ExtractionValue[]>();
+  for (const value of [...values].sort(compareExtractionValues)) {
+    for (const evidenceId of value.evidenceIds) {
+      valuesByEvidenceId.set(evidenceId, [...(valuesByEvidenceId.get(evidenceId) ?? []), value]);
+    }
+  }
+  const rows: CsvCell[][] = [];
+  for (const entry of [...evidence].sort(compareEvidence)) {
+    const linkedValues = valuesByEvidenceId.get(entry.id) ?? [undefined];
+    for (const value of linkedValues) {
+      const paperId = entry.paperId ?? value?.paperId;
+      const paper = paperId ? paperById.get(paperId) : undefined;
+      const field = value ? fieldById.get(value.fieldId) : undefined;
+      rows.push([
+        entry.id,
+        entry.evidenceId,
+        entry.sourceType,
+        paperId,
+        paper?.title,
+        paper ? "retained" : paperId ? "snapshot unavailable" : "not linked",
+        entry.artifactId,
+        entry.chunkId,
+        entry.title,
+        entry.excerpt,
+        entry.page,
+        entry.locator,
+        entry.doi,
+        entry.url,
+        entry.retrievalScore,
+        entry.runId,
+        entry.runItemId,
+        value?.id,
+        value?.fieldId,
+        field?.name,
+        value?.status,
+        value?.origin
+      ]);
+    }
+  }
+
+  return renderCsv(
+    [
+      "evidence_record_id",
+      "evidence_id",
+      "source_type",
+      "paper_id",
+      "paper_title",
+      "paper_record_state",
+      "artifact_id",
+      "chunk_id",
+      "evidence_title",
+      "excerpt",
+      "page",
+      "locator",
+      "doi",
+      "url",
+      "retrieval_score",
+      "run_id",
+      "run_item_id",
+      "value_id",
+      "field_id",
+      "field_name",
+      "value_status",
+      "value_origin"
+    ],
+    rows
+  );
+}
+
+function renderScreeningDecisions(
+  decisions: readonly PortableScreeningDecision[],
+  paperById: ReadonlyMap<string, Paper>,
+  revisions: readonly ReviewProtocolRevision[]
+): string {
+  const criterionByRevisionAndId = new Map(
+    revisions.flatMap((revision) =>
+      revision.criteria.map((criterion) => [`${revision.id}\u0000${criterion.id}`, criterion] as const)
+    )
+  );
+  const rows = [...decisions].sort(compareDecisions).map((decision) => {
+    const criterion = decision.reasonCriterionId
+      ? criterionByRevisionAndId.get(`${decision.protocolRevisionId}\u0000${decision.reasonCriterionId}`)
+      : undefined;
+    const paper = paperById.get(decision.paperId);
+    return [
+      decision.id,
+      decision.paperId,
+      paper?.title,
+      paper ? "retained or snapshotted" : "snapshot unavailable",
+      decision.stage,
+      decision.decision,
+      decision.reasonCriterionId,
+      criterion?.label,
+      decision.customReason,
+      decision.protocolRevisionId,
+      decision.previousDecisionId,
+      decision.runItemId,
+      decision.createdAt
+    ];
+  });
+  return renderCsv(
+    [
+      "decision_id",
+      "paper_id",
+      "paper_title",
+      "paper_record_state",
+      "stage",
+      "decision",
+      "reason_criterion_id",
+      "reason_criterion",
+      "custom_reason",
+      "protocol_revision_id",
+      "previous_decision_id",
+      "run_item_id",
+      "created_at"
+    ],
+    rows
+  );
+}
+
+function renderRis(papers: readonly Paper[]): string {
+  const lines: string[] = [];
+  for (const paper of papers) {
+    lines.push("TY  - JOUR", `TI  - ${risText(paper.title)}`);
+    for (const author of paper.authors) lines.push(`AU  - ${risText(author)}`);
+    if (paper.abstract) lines.push(`AB  - ${risText(paper.abstract)}`);
+    if (paper.year) lines.push(`PY  - ${paper.year}`);
+    if (paper.doi) lines.push(`DO  - ${risText(paper.doi)}`);
+    if (paper.url) lines.push(`UR  - ${risText(paper.url)}`);
+    if (paper.pdfUrl) lines.push(`L1  - ${risText(paper.pdfUrl)}`);
+    if (paper.venue) lines.push(`JO  - ${risText(paper.venue)}`);
+    if (paper.sourcePaperId) lines.push(`AN  - ${risText(paper.sourcePaperId)}`);
+    lines.push(`DP  - ${risText(paper.source)}`);
+    if (paper.citationCount !== undefined) lines.push(`TC  - ${paper.citationCount}`);
+    lines.push("ER  -", "");
+  }
+  return ensureFinalNewline(lines.join("\n"));
+}
+
+function renderBibtex(papers: readonly Paper[]): string {
+  const keyCounts = new Map<string, number>();
+  const entries = papers.map((paper) => {
+    const baseKey = bibtexBaseKey(paper);
+    const count = (keyCounts.get(baseKey) ?? 0) + 1;
+    keyCounts.set(baseKey, count);
+    const key = count === 1 ? baseKey : `${baseKey}${count}`;
+    const fields: Array<[string, string | number | undefined]> = [
+      ["title", paper.title],
+      ["author", paper.authors.length ? paper.authors.join(" and ") : undefined],
+      ["year", paper.year],
+      ["abstract", paper.abstract],
+      ["journal", paper.venue],
+      ["doi", paper.doi],
+      ["url", paper.url],
+      ["pdf", paper.pdfUrl],
+      ["source", paper.source],
+      ["sourceid", paper.sourcePaperId],
+      ["citationcount", paper.citationCount]
+    ];
+    const renderedFields = fields
+      .filter((field): field is [string, string | number] => field[1] !== undefined)
+      .map(([name, value]) => `  ${name} = {${escapeBibtex(String(value))}}`)
+      .join(",\n");
+    return `@article{${key},\n${renderedFields}\n}`;
+  });
+  return ensureFinalNewline(entries.join("\n\n"));
+}
+
+function renderSummary(
+  input: ReviewExportInput,
+  papers: readonly Paper[],
+  fields: readonly ExtractionField[],
+  values: ReadonlyMap<string, ExtractionValue>,
+  paperById: ReadonlyMap<string, Paper>
+): string {
+  const { protocol, revision, flowSummary } = input;
+  const lines: string[] = [
+    "# Evidence Review Summary",
+    "",
+    "> This is an auditable Paper Pilot review-flow summary. It is not a PRISMA 2020-compliant report, diagram, or certification.",
+    "",
+    "This file reports the supplied protocol and recorded workflow state. It does not contain AI-generated conclusions.",
+    "",
+    "## Protocol",
+    "",
+    `- Review ID: ${markdownInline(protocol.id)}`,
+    `- Project ID: ${markdownInline(protocol.projectId)}`,
+    `- Template: ${markdownInline(protocol.template)}`,
+    `- Current revision: ${revision.version}`,
+    `- Protocol revisions retained: ${input.revisions.length}`,
+    `- Activated: ${markdownInline(protocol.activatedAt)}`,
+    `- Review state as of: ${markdownInline(flowSummary.generatedAt)}`,
+    "",
+    "### Research question",
+    "",
+    revision.researchQuestion || "_Not specified._",
+    "",
+    "### Objectives",
+    ""
+  ];
+  if (revision.objectives.length) lines.push(...revision.objectives.map((objective) => `- ${objective}`));
+  else lines.push("_None specified._");
+
+  lines.push("", "### Eligibility criteria", "");
+  const criteria = [...revision.criteria].sort(
+    (left, right) =>
+      screeningStageOrder(left.stage) - screeningStageOrder(right.stage) ||
+      left.order - right.order ||
+      compareText(left.id, right.id)
+  );
+  if (criteria.length) {
+    lines.push("| Stage | Type | Criterion | Description |", "| --- | --- | --- | --- |");
+    for (const criterion of criteria) {
+      lines.push(
+        `| ${markdownTable(criterion.stage)} | ${markdownTable(criterion.type)} | ${markdownTable(criterion.label)} | ${markdownTable(criterion.description ?? "")} |`
+      );
+    }
+  } else lines.push("_No criteria configured._");
+
+  lines.push(
+    "",
+    "## Recorded review flow",
+    "",
+    "| Measure | Count |",
+    "| --- | ---: |",
+    `| Identified records | ${flowSummary.identifiedRecords} |`,
+    `| Filtered records | ${flowSummary.filteredRecords} |`,
+    `| Invalid records | ${flowSummary.invalidRecords} |`,
+    `| Duplicate records | ${flowSummary.duplicateRecords} |`,
+    `| Merged records | ${flowSummary.mergedRecords} |`,
+    `| New records | ${flowSummary.newRecords} |`,
+    `| Unique records screened | ${flowSummary.uniqueRecordsScreened} |`,
+    `| Title/abstract exclusions | ${flowSummary.titleAbstractExclusions} |`,
+    `| Full texts sought | ${flowSummary.fullTextsSought} |`,
+    `| Full texts unavailable | ${flowSummary.fullTextsUnavailable} |`,
+    `| Included papers | ${flowSummary.includedPapers} |`,
+    ""
+  );
+  if (!flowSummary.historicalCountsAvailable) {
+    lines.push(
+      "Historical discovery and duplicate counts were unavailable for papers that predated review activation.",
+      ""
+    );
+  }
+
+  lines.push("### Full-text exclusions by reason", "");
+  const exclusionReasons = Object.entries(flowSummary.fullTextExclusionsByReason).sort(([left], [right]) =>
+    compareText(left, right)
+  );
+  if (exclusionReasons.length) {
+    lines.push("| Reason | Count |", "| --- | ---: |");
+    for (const [reason, count] of exclusionReasons) {
+      lines.push(`| ${markdownTable(reason)} | ${count} |`);
+    }
+  } else lines.push("_No full-text exclusions recorded._");
+
+  lines.push(
+    "",
+    "## Extraction status",
+    "",
+    "| Measure | Count |",
+    "| --- | ---: |",
+    `| Configured active fields | ${fields.length} |`,
+    `| Included papers supplied | ${papers.length} |`,
+    `| Total cells | ${flowSummary.extraction.totalCells} |`,
+    `| Confirmed cells | ${flowSummary.extraction.confirmedCells} |`,
+    `| Not found cells | ${flowSummary.extraction.notFoundCells} |`,
+    `| Needs review cells | ${flowSummary.extraction.needsReviewCells} |`,
+    `| Completion | ${formatNumber(flowSummary.extraction.completionPercent)}% |`,
+    `| Confirmed values exported | ${values.size} |`,
+    `| Included paper records recovered from live data or snapshots | ${papers.length} |`,
+    "",
+    "## Discovery batches",
+    ""
+  );
+  const batches = [...input.batches].sort(compareBatches);
+  if (batches.length) {
+    lines.push(
+      "| Label | Kind | Status | Identified | Filtered | Invalid | Duplicates | Merged | New | Historical counts |",
+      "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+    );
+    for (const batch of batches) {
+      lines.push(
+        `| ${markdownTable(batch.label)} | ${markdownTable(batch.kind)} | ${markdownTable(batch.status)} | ${batch.counts.identified} | ${batch.counts.filtered} | ${batch.counts.invalid} | ${batch.counts.duplicates} | ${batch.counts.merged} | ${batch.counts.newRecords} | ${batch.historicalCountsAvailable ? "available" : "unavailable"} |`
+      );
+    }
+  } else lines.push("_No discovery batches recorded._");
+
+  lines.push(
+    "",
+    "The audit JSON retains every discovery candidate occurrence and its immutable record/paper snapshots.",
+    "",
+    `- Candidate origins retained: ${input.candidateOrigins.length}`,
+    `- Distinct paper records represented by live data or snapshots: ${paperById.size}`
+  );
+
+  lines.push("", "## AI assistance runs", "");
+  const runs = [...input.runs].sort(compareRuns);
+  if (runs.length) {
+    lines.push(
+      "AI assistance was advisory; its outputs required human confirmation before inclusion in the evidence matrix.",
+      "",
+      "| Stage | Provider | Model | Status | Papers | Completed | Failed | Cancelled |",
+      "| --- | --- | --- | --- | ---: | ---: | ---: | ---: |"
+    );
+    for (const run of runs) {
+      lines.push(
+        `| ${markdownTable(run.stage)} | ${markdownTable(run.provider)} | ${markdownTable(run.model)} | ${markdownTable(run.status)} | ${run.paperIds.length} | ${run.completedCount} | ${run.failedCount} | ${run.cancelledCount} |`
+      );
+    }
+  } else lines.push("_No AI assistance runs recorded._");
+
+  lines.push("", `Run items retained in the audit JSON: ${input.runItems.length}.`);
+
+  if (flowSummary.warnings.length) {
+    lines.push("", "## Warnings", "", ...[...flowSummary.warnings].sort(compareText).map((warning) => `- ${warning}`));
+  }
+  return ensureFinalNewline(lines.join("\n"));
+}
+
+function renderFlowSvg(summary: ReviewFlowSummary): string {
+  const fullTextExclusions = Object.values(summary.fullTextExclusionsByReason).reduce((sum, count) => sum + count, 0);
+  const historicalNote = summary.historicalCountsAvailable
+    ? "Historical discovery counts are available."
+    : "Historical discovery and duplicate counts are incomplete for pre-existing papers.";
+  const boxes = [
+    { x: 320, y: 90, label: "Records identified", count: summary.identifiedRecords },
+    { x: 320, y: 210, label: "Unique records screened", count: summary.uniqueRecordsScreened },
+    { x: 320, y: 330, label: "Full texts sought", count: summary.fullTextsSought },
+    { x: 320, y: 450, label: "Included papers", count: summary.includedPapers },
+    {
+      x: 30,
+      y: 90,
+      label: "Filtered / invalid / duplicate",
+      count: summary.filteredRecords + summary.invalidRecords + summary.duplicateRecords
+    },
+    { x: 650, y: 210, label: "Title/abstract exclusions", count: summary.titleAbstractExclusions },
+    { x: 30, y: 330, label: "Full texts unavailable", count: summary.fullTextsUnavailable },
+    { x: 650, y: 330, label: "Full-text exclusions", count: fullTextExclusions }
+  ];
+  const boxMarkup = boxes
+    .map(
+      (box) => `  <g transform="translate(${box.x} ${box.y})">
+    <rect width="280" height="76" rx="10" fill="#ffffff" stroke="#334155" stroke-width="2" />
+    <text x="140" y="30" text-anchor="middle" font-size="15" fill="#0f172a">${escapeXml(box.label)}</text>
+    <text x="140" y="57" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">${box.count}</text>
+  </g>`
+    )
+    .join("\n");
+
+  return ensureFinalNewline(`<svg xmlns="http://www.w3.org/2000/svg" width="960" height="610" viewBox="0 0 960 610" role="img" aria-labelledby="review-flow-title review-flow-desc">
+  <title id="review-flow-title">Review flow</title>
+  <desc id="review-flow-desc">An auditable review-flow diagram, not a PRISMA 2020 diagram. ${escapeXml(historicalNote)} ${summary.identifiedRecords} records identified, ${summary.uniqueRecordsScreened} screened, and ${summary.includedPapers} included.</desc>
+  <rect width="960" height="610" fill="#f8fafc" />
+  <text x="480" y="35" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#0f172a">Review flow</text>
+  <text x="480" y="60" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#475569">Not a PRISMA 2020-compliant diagram or certification</text>
+  <g stroke="#64748b" stroke-width="2" fill="none" aria-hidden="true">
+    <path d="M460 166 V210" />
+    <path d="M460 286 V330" />
+    <path d="M460 406 V450" />
+    <path d="M320 128 H310" />
+    <path d="M600 248 H650" />
+    <path d="M320 368 H310" />
+    <path d="M600 368 H650" />
+  </g>
+  <g font-family="system-ui, sans-serif">
+${boxMarkup}
+  </g>
+  <text x="480" y="565" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#334155">Extraction completion: ${formatNumber(summary.extraction.completionPercent)}% (${summary.extraction.confirmedCells} confirmed of ${summary.extraction.totalCells} cells)</text>
+  <text x="480" y="590" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" fill="#64748b">Review state as of ${escapeXml(summary.generatedAt)}</text>
+</svg>`);
+}
+
+function renderAuditJson(
+  input: ReviewExportInput,
+  includedPapers: readonly Paper[],
+  paperById: ReadonlyMap<string, Paper>
+): string {
+  const audit = {
+    schemaVersion: 2,
+    exportKind: "paper-pilot-review-audit",
+    notice: "Audit data and recorded workflow state; this renderer does not generate an AI-authored conclusion.",
+    stateAsOf: input.flowSummary.generatedAt,
+    protocol: input.protocol,
+    currentRevision: sortedRevision(input.revision),
+    protocolHistory: [...input.revisions]
+      .sort((left, right) => left.version - right.version || compareText(left.id, right.id))
+      .map(sortedRevision),
+    batches: [...input.batches].sort(compareBatches),
+    candidateOrigins: [...input.candidateOrigins].sort(compareCandidateOrigins),
+    screeningDecisions: [...input.screeningDecisions].sort(compareDecisions),
+    includedPaperIds: [...input.includedPaperIds].sort(compareText),
+    includedPapers: sortPapers(includedPapers),
+    paperSnapshots: sortPapers([...paperById.values()]),
+    extractionFields: sortFields(input.extractionFields),
+    extractionFieldHistory: [...input.extractionFieldHistory].sort(compareExtractionFieldHistory),
+    extractionValues: [...input.extractionValues].sort(compareExtractionValues),
+    extractionValueHistory: [...input.extractionValueHistory].sort(compareExtractionValueHistory),
+    evidence: [...input.evidence].sort(compareEvidence),
+    runs: [...input.runs].sort(compareRuns),
+    runItems: [...input.runItems].sort(compareRunItems),
+    auditEvents: [...input.auditEvents].sort(compareAuditEvents),
+    flowSummary: input.flowSummary
+  };
+  return `${stableJsonStringify(audit, 2)}\n`;
+}
+
+function sortedRevision(revision: ReviewProtocolRevision): ReviewProtocolRevision {
+  return {
+    ...revision,
+    criteria: [...revision.criteria].sort(
+      (left, right) =>
+        screeningStageOrder(left.stage) - screeningStageOrder(right.stage) ||
+        left.order - right.order ||
+        compareText(left.id, right.id)
+    )
+  };
+}
+
+type CsvCell = string | number | boolean | null | undefined;
+
+function renderCsv(headers: readonly string[], rows: readonly (readonly CsvCell[])[]): string {
+  const allRows = [headers, ...rows];
+  return ensureFinalNewline(
+    allRows
+      .map((row) =>
+        row
+          .map((cell) => {
+            if (cell === null || cell === undefined) return "";
+            return escapeCsv(typeof cell === "string" ? neutralizeSpreadsheetFormula(cell) : String(cell));
+          })
+          .join(",")
+      )
+      .join("\n")
+  );
+}
+
+function escapeCsv(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+function neutralizeSpreadsheetFormula(value: string): string {
+  return /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
+}
+
+function collectPaperSnapshots(input: ReviewExportInput): Map<string, Paper> {
+  const papers = new Map<string, Paper>();
+  const add = (value: unknown): void => {
+    const parsed = paperSchema.safeParse(value);
+    if (parsed.success && !papers.has(parsed.data.id)) papers.set(parsed.data.id, parsed.data);
+  };
+
+  // Prefer current records, then fall back to immutable review snapshots for deleted records.
+  input.includedPapers.forEach(add);
+  input.screeningDecisions.forEach((decision) => add(decision.paperSnapshot));
+  input.candidateOrigins.forEach((origin) => {
+    add(origin.paperSnapshot);
+    add(origin.recordSnapshot);
+  });
+  input.extractionValues.forEach((value) => add(value.paperSnapshot));
+  input.extractionValueHistory.forEach((value) => add(value.paperSnapshot));
+  input.evidence.forEach((evidence) => add(evidence.paperSnapshot));
+  input.runItems.forEach((item) => add(item.paperSnapshot));
+  return papers;
+}
+
+function currentConfirmedValues(
+  values: readonly ExtractionValue[],
+  fields: readonly ExtractionField[],
+  includedPaperIds: ReadonlySet<string>
+): Map<string, ExtractionValue> {
+  const fieldRevision = new Map(fields.map((field) => [field.id, field.revision]));
+  const result = new Map<string, ExtractionValue>();
+  for (const value of [...values].sort(compareExtractionValues)) {
+    if (
+      !includedPaperIds.has(value.paperId) ||
+      value.status !== "confirmed" ||
+      fieldRevision.get(value.fieldId) !== value.fieldRevision
+    ) {
+      continue;
+    }
+    const key = valueKey(value.paperId, value.fieldId);
+    const previous = result.get(key);
+    if (!previous || compareCurrentValue(previous, value) < 0) result.set(key, value);
+  }
+  return result;
+}
+
+function renderExtractionValue(value: ExtractionPrimitiveValue): CsvCell {
+  if (value === null) return "";
+  if (Array.isArray(value)) return value.join("; ");
+  return value;
+}
+
+function uniqueFieldHeaders(fields: readonly ExtractionField[]): string[] {
+  const counts = new Map<string, number>();
+  for (const field of fields) counts.set(field.name, (counts.get(field.name) ?? 0) + 1);
+  return fields.map((field) => ((counts.get(field.name) ?? 0) > 1 ? `${field.name} [${field.id}]` : field.name));
+}
+
+function bibtexBaseKey(paper: Paper): string {
+  const author = paper.authors[0] ?? "paper";
+  const family = author.includes(",") ? author.split(",", 1)[0] : (author.trim().split(/\s+/).at(-1) ?? "paper");
+  const familySlug = asciiSlug(family) || "paper";
+  const titleWord = paper.title
+    .split(/\s+/)
+    .map(asciiSlug)
+    .find((word) => word && !["a", "an", "the"].includes(word));
+  return `${familySlug}${paper.year ?? "nd"}${titleWord || "study"}`;
+}
+
+function escapeBibtex(value: string): string {
+  return value
+    .replace(/[\\{}%&_#$]/g, (character) => (character === "\\" ? "\\textbackslash{}" : `\\${character}`))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function risText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function markdownInline(value: string): string {
+  return value.replace(/\r?\n/g, " ").replace(/`/g, "\\`");
+}
+
+function markdownTable(value: string): string {
+  return value.replace(/\r?\n/g, " ").replace(/\|/g, "\\|").trim();
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function asciiSlug(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function sortPapers(papers: readonly Paper[]): Paper[] {
+  return [...papers].sort(
+    (left, right) =>
+      compareText(left.title.toLowerCase(), right.title.toLowerCase()) ||
+      compareOptionalNumber(left.year, right.year) ||
+      compareText(left.id, right.id)
+  );
+}
+
+function sortFields(fields: readonly ExtractionField[]): ExtractionField[] {
+  return [...fields].sort(
+    (left, right) => left.order - right.order || compareText(left.name, right.name) || compareText(left.id, right.id)
+  );
+}
+
+function compareDecisions(left: ScreeningDecision, right: ScreeningDecision): number {
+  return (
+    compareText(left.paperId, right.paperId) ||
+    screeningStageOrder(left.stage) - screeningStageOrder(right.stage) ||
+    compareText(left.createdAt, right.createdAt) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function compareBatches(left: DiscoveryBatch, right: DiscoveryBatch): number {
+  return compareText(left.createdAt, right.createdAt) || compareText(left.id, right.id);
+}
+
+function compareCandidateOrigins(left: ReviewCandidateOrigin, right: ReviewCandidateOrigin): number {
+  return (
+    compareText(left.createdAt, right.createdAt) ||
+    compareText(left.batchId, right.batchId) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function compareExtractionValues(left: ExtractionValue, right: ExtractionValue): number {
+  return (
+    compareText(left.paperId, right.paperId) ||
+    compareText(left.fieldId, right.fieldId) ||
+    left.fieldRevision - right.fieldRevision ||
+    compareText(left.updatedAt, right.updatedAt) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function compareExtractionFieldHistory(left: ExtractionFieldHistoryEntry, right: ExtractionFieldHistoryEntry): number {
+  return (
+    compareText(left.id, right.id) || left.revision - right.revision || compareText(left.recordedAt, right.recordedAt)
+  );
+}
+
+function compareExtractionValueHistory(left: ExtractionValueHistoryEntry, right: ExtractionValueHistoryEntry): number {
+  return (
+    compareText(left.id, right.id) ||
+    left.changeRevision - right.changeRevision ||
+    compareText(left.recordedAt, right.recordedAt)
+  );
+}
+
+function compareCurrentValue(left: ExtractionValue, right: ExtractionValue): number {
+  return (
+    left.fieldRevision - right.fieldRevision ||
+    compareText(left.updatedAt, right.updatedAt) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function compareEvidence(left: ReviewEvidence, right: ReviewEvidence): number {
+  return (
+    compareText(left.paperId ?? "", right.paperId ?? "") ||
+    compareText(left.evidenceId, right.evidenceId) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function compareRuns(left: ReviewRun, right: ReviewRun): number {
+  return compareText(left.createdAt, right.createdAt) || compareText(left.id, right.id);
+}
+
+function compareRunItems(left: PortableReviewRunItem, right: PortableReviewRunItem): number {
+  return (
+    compareText(left.createdAt, right.createdAt) ||
+    compareText(left.runId, right.runId) ||
+    compareText(left.paperId, right.paperId) ||
+    compareText(left.id, right.id)
+  );
+}
+
+function compareAuditEvents(left: ReviewAuditEvent, right: ReviewAuditEvent): number {
+  return compareText(left.createdAt, right.createdAt) || compareText(left.id, right.id);
+}
+
+function screeningStageOrder(stage: ScreeningDecision["stage"]): number {
+  return stage === "title-abstract" ? 0 : 1;
+}
+
+function valueKey(paperId: string, fieldId: string): string {
+  return `${paperId}\u0000${fieldId}`;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareOptionalNumber(left: number | undefined, right: number | undefined): number {
+  if (left === right) return 0;
+  if (left === undefined) return 1;
+  if (right === undefined) return -1;
+  return left - right;
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(2)));
+}
+
+function ensureFinalNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+function stableJsonStringify(value: unknown, space: number): string {
+  return JSON.stringify(sortJsonValue(value), null, space);
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => compareText(left, right))
+        .map(([key, nested]) => [key, sortJsonValue(nested)])
+    );
+  }
+  return value;
+}

--- a/src/main/services/review-import-manager.ts
+++ b/src/main/services/review-import-manager.ts
@@ -1,0 +1,483 @@
+import { basename } from "node:path";
+import { readFile, stat } from "node:fs/promises";
+import {
+  MAX_REFERENCE_IMPORT_BYTES,
+  MAX_REFERENCE_IMPORT_RECORDS,
+  type DiscoveryBatchCounts,
+  type Paper,
+  type ReferenceImportCommitRequest,
+  type ReferenceImportCommitResponse,
+  type ReferenceImportFormat,
+  type ReferenceImportMapping,
+  type ReferenceImportMatch,
+  type ReferenceImportPreview,
+  type ReferenceImportPreviewItem
+} from "../../shared/schemas.js";
+import type { PaperPilotDb, ReviewCandidateOriginInput } from "../db.js";
+import { id, sha256 } from "../utils.js";
+import { mergeAuthoritativeSourceIdentifiers, PaperIdentityResolver, resolvePaperIdentity } from "./paper-identity.js";
+import {
+  ReferenceImportService,
+  type AppliedCsvColumnMapping,
+  type ReferenceImportPaper,
+  type ReferenceImportRecord
+} from "./reference-import-service.js";
+
+interface ImportSession {
+  id: string;
+  projectId: string;
+  reviewId: string;
+  filePath: string;
+  fileName: string;
+  content: Buffer;
+  hash: string;
+  format: ReferenceImportFormat;
+  createdAt: number;
+}
+
+const IMPORT_WRITE_BATCH_SIZE = 500;
+
+export class ReviewImportManager {
+  private readonly sessions = new Map<string, ImportSession>();
+
+  constructor(
+    private readonly db: PaperPilotDb,
+    private readonly parser = new ReferenceImportService(),
+    private readonly sessionLifetimeMs = 30 * 60 * 1000
+  ) {}
+
+  async preview(input: {
+    projectId: string;
+    reviewId: string;
+    filePath: string;
+    format?: ReferenceImportFormat;
+    mapping?: ReferenceImportMapping;
+  }): Promise<ReferenceImportPreview> {
+    this.assertReview(input.projectId, input.reviewId);
+    const info = await stat(input.filePath);
+    if (!info.isFile()) throw new Error("The selected reference import is not a file.");
+    if (info.size > MAX_REFERENCE_IMPORT_BYTES) throw new Error("Reference files may not exceed 50 MiB.");
+    const content = await readFile(input.filePath);
+    const parsed = this.parser.preview({
+      content,
+      fileName: basename(input.filePath),
+      format: input.format,
+      csvMapping: toParserMapping(input.mapping)
+    });
+    if (parsed.format === "unknown") throw new Error(parsed.fileErrors[0] ?? "Unsupported reference import format.");
+    if (parsed.totalRecords > MAX_REFERENCE_IMPORT_RECORDS) {
+      throw new Error(parsed.fileErrors[0] ?? "Reference files may contain at most 50,000 records.");
+    }
+    const previewId = id("import_preview");
+    const session: ImportSession = {
+      id: previewId,
+      projectId: input.projectId,
+      reviewId: input.reviewId,
+      filePath: input.filePath,
+      fileName: basename(input.filePath),
+      content,
+      hash: sha256(content),
+      format: parsed.format,
+      createdAt: Date.now()
+    };
+    this.pruneSessions();
+    this.sessions.set(previewId, session);
+    return this.toSharedPreview(session, parsed);
+  }
+
+  async remap(previewId: string, mapping: ReferenceImportMapping): Promise<ReferenceImportPreview> {
+    const session = this.requireSession(previewId);
+    const parsed = this.parser.preview({
+      content: session.content,
+      fileName: session.fileName,
+      format: session.format,
+      csvMapping: toParserMapping(mapping)
+    });
+    if (parsed.totalRecords > MAX_REFERENCE_IMPORT_RECORDS) {
+      throw new Error(parsed.fileErrors[0] ?? "Reference files may contain at most 50,000 records.");
+    }
+    return this.toSharedPreview(session, parsed);
+  }
+
+  async commit(input: ReferenceImportCommitRequest): Promise<ReferenceImportCommitResponse> {
+    const session = this.requireSession(input.previewId);
+    if (session.projectId !== input.projectId || session.reviewId !== input.reviewId) {
+      throw new Error("The reference import preview belongs to a different project or review.");
+    }
+    this.assertReview(input.projectId, input.reviewId);
+    const currentContent = await readFile(session.filePath);
+    if (sha256(currentContent) !== session.hash) {
+      throw new Error("The reference file changed after preview. Preview it again before importing.");
+    }
+    const parsed = this.parser.preview({
+      content: currentContent,
+      fileName: session.fileName,
+      format: session.format,
+      csvMapping: toParserMapping(input.mapping)
+    });
+    if (!parsed.canCommit) throw new Error(parsed.fileErrors[0] ?? "The reference import cannot be committed.");
+
+    const result = this.db.transaction(() => {
+      const counts: DiscoveryBatchCounts = {
+        identified: parsed.totalRecords,
+        filtered: 0,
+        invalid: parsed.invalidRecords.length,
+        duplicates: 0,
+        merged: 0,
+        newRecords: 0
+      };
+      let batch = this.db.saveDiscoveryBatch({
+        reviewId: input.reviewId,
+        kind: "reference-import",
+        label: `Reference import — ${session.fileName}`,
+        fileName: session.fileName,
+        importFormat: session.format,
+        status: "running",
+        counts,
+        historicalCountsAvailable: true,
+        config: { mapping: input.mapping ?? null }
+      });
+      const resolutions = new Map(input.resolutions.map((resolution) => [resolution.recordIndex, resolution]));
+      const existing = this.db.listPapers(input.projectId);
+      const resolver = new PaperIdentityResolver(existing);
+      const previewTargets = new Map<string, string>();
+      let pendingOrigins: ReviewCandidateOriginInput[] = [];
+      const flushOrigins = (): void => {
+        if (!pendingOrigins.length) return;
+        this.db.recordReviewCandidateOriginsBulk(pendingOrigins);
+        pendingOrigins = [];
+      };
+      const queueOrigin = (origin: ReviewCandidateOriginInput): void => {
+        pendingOrigins.push(origin);
+        if (pendingOrigins.length >= IMPORT_WRITE_BATCH_SIZE) flushOrigins();
+      };
+
+      for (const invalid of parsed.invalidRecords) {
+        queueOrigin({
+          reviewId: input.reviewId,
+          batchId: batch.id,
+          sourceRecordId: String(invalid.recordNumber),
+          resolution: "invalid",
+          recordSnapshot: { raw: invalid.raw, errors: invalid.errors }
+        });
+      }
+
+      for (const record of parsed.records) {
+        const recordIndex = record.recordNumber - 1;
+        const match = resolver.resolve(record.paper);
+        const requested = resolutions.get(recordIndex);
+        if (match.kind === "ambiguous" && !requested) {
+          throw new Error(`Imported record ${record.recordNumber} requires an explicit ambiguous-match resolution.`);
+        }
+        if (requested?.action === "skip") {
+          counts.filtered += 1;
+          queueOrigin({
+            reviewId: input.reviewId,
+            batchId: batch.id,
+            sourceRecordId: record.provenance.sourceIdentifier ?? String(record.recordNumber),
+            resolution: "skipped",
+            recordSnapshot: record
+          });
+          continue;
+        }
+
+        if (requested?.action === "merge") {
+          const targetId = requested.paperId ? (previewTargets.get(requested.paperId) ?? requested.paperId) : undefined;
+          const target = targetId ? resolver.list().find((candidate) => candidate.id === targetId) : undefined;
+          const targetMatches =
+            target &&
+            (match.kind === "exact"
+              ? match.candidate.id === target.id
+              : match.kind === "ambiguous" && match.candidates.some((candidate) => candidate.id === target.id));
+          if (!targetMatches) {
+            throw new Error(`Invalid merge target for imported record ${record.recordNumber}.`);
+          }
+          const merged = this.mergeIntoPaper(input.projectId, target, record.paper);
+          resolver.replace(target, merged);
+          counts.merged += 1;
+          queueOrigin({
+            reviewId: input.reviewId,
+            batchId: batch.id,
+            paperId: merged.id,
+            matchedPaperId: target.id,
+            sourceRecordId: record.provenance.sourceIdentifier ?? String(record.recordNumber),
+            resolution: "merged",
+            paperSnapshot: merged,
+            recordSnapshot: record
+          });
+          previewTargets.set(previewPaperId(record.recordNumber), merged.id);
+          continue;
+        }
+
+        if (match.kind === "exact") {
+          const enriched = wouldEnrich(match.candidate, record.paper);
+          const paper = enriched
+            ? this.mergeIntoPaper(input.projectId, match.candidate, record.paper)
+            : match.candidate;
+          if (enriched) resolver.replace(match.candidate, paper);
+          if (enriched) counts.merged += 1;
+          else counts.duplicates += 1;
+          queueOrigin({
+            reviewId: input.reviewId,
+            batchId: batch.id,
+            paperId: paper.id,
+            matchedPaperId: match.candidate.id,
+            sourceRecordId: record.provenance.sourceIdentifier ?? String(record.recordNumber),
+            resolution: enriched ? "merged" : "duplicate",
+            paperSnapshot: paper,
+            recordSnapshot: record
+          });
+          previewTargets.set(previewPaperId(record.recordNumber), paper.id);
+          continue;
+        }
+
+        const created = this.createPaper(input.projectId, record, match.kind === "ambiguous");
+        resolver.add(created);
+        counts.newRecords += 1;
+        queueOrigin({
+          reviewId: input.reviewId,
+          batchId: batch.id,
+          paperId: created.id,
+          matchedPaperId: match.kind === "ambiguous" ? match.candidates[0]?.id : undefined,
+          sourceRecordId: record.provenance.sourceIdentifier ?? String(record.recordNumber),
+          resolution: match.kind === "ambiguous" ? "kept-separate" : "created",
+          paperSnapshot: created,
+          recordSnapshot: record
+        });
+        previewTargets.set(previewPaperId(record.recordNumber), created.id);
+      }
+      flushOrigins();
+
+      batch = this.db.saveDiscoveryBatch({
+        ...batch,
+        kind: "reference-import",
+        status: "completed",
+        counts,
+        completedAt: new Date().toISOString()
+      });
+      this.db.appendReviewAuditEvent({
+        reviewId: input.reviewId,
+        kind: "import-committed",
+        actor: "user",
+        entityType: "discovery-batch",
+        entityId: batch.id,
+        payload: { fileName: session.fileName, format: session.format, counts }
+      });
+      return { batch, counts };
+    });
+    this.sessions.delete(session.id);
+    return result;
+  }
+
+  private toSharedPreview(
+    session: ImportSession,
+    parsed: ReturnType<ReferenceImportService["preview"]>
+  ): ReferenceImportPreview {
+    const existing = this.db.listPapers(session.projectId);
+    const resolver = new PaperIdentityResolver(existing);
+    const validItems: ReferenceImportPreviewItem[] = parsed.records.map((record) => {
+      const match = resolver.resolve(record.paper);
+      if (match.kind === "none") {
+        resolver.add({
+          ...record.paper,
+          id: previewPaperId(record.recordNumber)
+        });
+      } else if (match.kind === "exact" && wouldEnrich(match.candidate, record.paper)) {
+        resolver.replace(match.candidate, {
+          ...match.candidate,
+          ...mergePaperMetadata(match.candidate, record.paper)
+        });
+      }
+      return {
+        recordIndex: record.recordNumber - 1,
+        record: toSharedRecord(record.paper),
+        rawTitle: record.paper.title,
+        valid: true,
+        errors: [],
+        match: toSharedMatch(match)
+      };
+    });
+    const invalidItems: ReferenceImportPreviewItem[] = parsed.invalidRecords.map((record) => ({
+      recordIndex: Math.max(0, record.recordNumber - 1),
+      rawTitle: rawTitle(record.raw),
+      valid: false,
+      errors: record.errors,
+      match: { kind: "none", candidatePaperIds: [] }
+    }));
+    return {
+      previewId: session.id,
+      projectId: session.projectId,
+      reviewId: session.reviewId,
+      fileName: session.fileName,
+      format: session.format,
+      sizeBytes: parsed.sizeBytes,
+      totalRecords: parsed.totalRecords,
+      validRecords: parsed.records.length,
+      invalidRecords: parsed.invalidRecords.length,
+      columns: parsed.csv?.headers ?? [],
+      suggestedMapping: fromParserMapping(parsed.csv?.suggestedMapping),
+      items: [...validItems, ...invalidItems].sort((left, right) => left.recordIndex - right.recordIndex),
+      warnings: [...parsed.warnings, ...parsed.fileErrors]
+    };
+  }
+
+  private createPaper(projectId: string, record: ReferenceImportRecord, keptSeparate: boolean): Paper {
+    const paperId = id("paper");
+    return this.db.savePaper(projectId, {
+      ...record.paper,
+      id: paperId,
+      raw: {
+        ...(record.paper.raw ?? {}),
+        referenceImport: record.provenance,
+        sourceAuthority: record.paper.sourceAuthority,
+        forceSeparateIdentity: keptSeparate ? paperId : undefined
+      }
+    });
+  }
+
+  private mergeIntoPaper(projectId: string, current: Paper, incoming: ReferenceImportPaper): Paper {
+    return this.db.updatePaper(projectId, current.id, mergePaperMetadata(current, incoming));
+  }
+
+  private assertReview(projectId: string, reviewId: string): void {
+    const review = this.db.getReviewById(reviewId);
+    if (!review || review.projectId !== projectId) throw new Error("Review not found in the selected project.");
+  }
+
+  private requireSession(previewId: string): ImportSession {
+    this.pruneSessions();
+    const session = this.sessions.get(previewId);
+    if (!session) throw new Error("The reference import preview expired. Preview the file again.");
+    return session;
+  }
+
+  private pruneSessions(): void {
+    const cutoff = Date.now() - this.sessionLifetimeMs;
+    for (const [sessionId, session] of this.sessions) {
+      if (session.createdAt < cutoff) this.sessions.delete(sessionId);
+    }
+  }
+}
+
+function toSharedRecord(paper: ReferenceImportPaper) {
+  return {
+    title: paper.title,
+    authors: paper.authors,
+    abstract: paper.abstract,
+    year: paper.year,
+    doi: paper.doi,
+    url: paper.url,
+    pdfUrl: paper.pdfUrl,
+    venue: paper.venue,
+    sourceId: paper.sourcePaperId,
+    sourceAuthority: paper.sourceAuthority,
+    citationCount: paper.citationCount
+  };
+}
+
+function toSharedMatch(match: ReturnType<typeof resolvePaperIdentity>): ReferenceImportMatch {
+  if (match.kind === "none") return { kind: "none", candidatePaperIds: [] };
+  if (match.kind === "exact") {
+    return {
+      kind: "exact",
+      matchedBy:
+        match.strategy === "source-identifier"
+          ? "source-id"
+          : match.strategy === "bibliographic-fingerprint"
+            ? "fingerprint"
+            : "doi",
+      paperId: match.candidate.id,
+      candidatePaperIds: []
+    };
+  }
+  return {
+    kind: "ambiguous",
+    matchedBy:
+      match.strategy === "source-identifier"
+        ? "source-id"
+        : match.strategy === "bibliographic-fingerprint"
+          ? "fingerprint"
+          : match.strategy === "doi"
+            ? "doi"
+            : undefined,
+    candidatePaperIds: match.candidates.flatMap((candidate) => (candidate.id ? [candidate.id] : []))
+  };
+}
+
+function previewPaperId(recordNumber: number): string {
+  return `preview-paper:${recordNumber}`;
+}
+
+function mergePaperMetadata(current: Paper, incoming: ReferenceImportPaper): Partial<Paper> {
+  const identity = mergeAuthoritativeSourceIdentifiers(current, incoming);
+  return {
+    abstract: current.abstract || incoming.abstract,
+    authors: current.authors.length ? current.authors : incoming.authors,
+    year: current.year ?? incoming.year,
+    publishedAt: current.publishedAt,
+    doi: current.doi ?? incoming.doi,
+    url: current.url ?? incoming.url,
+    pdfUrl: current.pdfUrl ?? incoming.pdfUrl,
+    venue: current.venue ?? incoming.venue,
+    citationCount: Math.max(current.citationCount ?? 0, incoming.citationCount ?? 0) || undefined,
+    isOpenAccess: current.isOpenAccess || incoming.isOpenAccess,
+    sourcePaperId: identity.sourcePaperId,
+    raw: identity.raw
+  };
+}
+
+function wouldEnrich(current: Paper, incoming: ReferenceImportPaper): boolean {
+  const patch = mergePaperMetadata(current, incoming);
+  return (
+    (!current.abstract && Boolean(patch.abstract)) ||
+    (!current.authors.length && Boolean(patch.authors?.length)) ||
+    (current.year === undefined && patch.year !== undefined) ||
+    (!current.doi && Boolean(patch.doi)) ||
+    (!current.url && Boolean(patch.url)) ||
+    (!current.pdfUrl && Boolean(patch.pdfUrl)) ||
+    (!current.venue && Boolean(patch.venue)) ||
+    (patch.citationCount ?? 0) > (current.citationCount ?? 0) ||
+    patch.sourcePaperId !== current.sourcePaperId ||
+    JSON.stringify(patch.raw ?? {}) !== JSON.stringify(current.raw ?? {})
+  );
+}
+
+function toParserMapping(mapping: ReferenceImportMapping | undefined): AppliedCsvColumnMapping | undefined {
+  if (!mapping) return undefined;
+  return {
+    title: mapping.title,
+    authors: mapping.authors,
+    abstract: mapping.abstract,
+    year: mapping.year,
+    doi: mapping.doi,
+    url: mapping.url,
+    pdfUrl: mapping.pdfUrl,
+    venue: mapping.venue,
+    sourcePaperId: mapping.sourceId,
+    sourceAuthority: mapping.sourceAuthority,
+    citationCount: mapping.citationCount
+  };
+}
+
+function fromParserMapping(mapping: AppliedCsvColumnMapping | undefined): Partial<ReferenceImportMapping> | undefined {
+  if (!mapping) return undefined;
+  return {
+    title: mapping.title,
+    authors: mapping.authors,
+    abstract: mapping.abstract,
+    year: mapping.year,
+    doi: mapping.doi,
+    url: mapping.url,
+    pdfUrl: mapping.pdfUrl,
+    venue: mapping.venue,
+    sourceId: mapping.sourcePaperId,
+    sourceAuthority: mapping.sourceAuthority,
+    citationCount: mapping.citationCount
+  };
+}
+
+function rawTitle(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const candidate = (raw as Record<string, unknown>).title;
+  return typeof candidate === "string" ? candidate : undefined;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,7 +5,10 @@ import type {
   AiModelListRequest,
   AiProviderCheckRequest,
   AiProviderHealth,
+  ActivateReviewRequest,
   Artifact,
+  AttachReviewPaperPdfRequest,
+  CancelReviewRunRequest,
   ChatMode,
   ChatRun,
   ChatRunEvent,
@@ -13,22 +16,51 @@ import type {
   Conversation,
   CredentialUpsert,
   CrawlConfig,
+  DiscoveryBatch,
+  ExportReviewRequest,
+  ExtractionField,
+  ExtractionValue,
+  FetchReviewPaperFullTextRequest,
   Job,
+  MarkReviewPapersForReviewRequest,
   Message,
   Paper,
   PaperUpdate,
   Project,
   ProjectPolicy,
   ProjectUpdate,
+  ReferenceImportCommitRequest,
+  ReferenceImportCommitResponse,
+  ReferenceImportMapping,
+  ReferenceImportPreview,
+  ReferenceImportPreviewRequest,
   ReindexRequest,
   ReindexResponse,
+  ReorderExtractionFieldsRequest,
+  RetryReviewRunRequest,
+  ReviewFlowSummary,
+  ReviewEvidence,
+  ReviewPaperPage,
+  ReviewPaperQuery,
+  ReviewProtocol,
+  ReviewProtocolRevision,
+  ReviewRun,
+  ReviewRunEvent,
+  ReviewRunItem,
+  ReviseReviewProtocolRequest,
+  SaveExtractionValueRequest,
+  SaveScreeningDecisionRequest,
   SearchRequest,
   SearchResponse,
   SourceDefinition,
   StartChatRunRequest,
   StartChatRunResponse,
+  StartReviewRunRequest,
+  ScreeningDecision,
+  UpsertExtractionFieldRequest,
   UpdateStatus
 } from "../shared/schemas.js";
+import { reviewRunEventSchema } from "../shared/schemas.js";
 
 const { contextBridge, ipcRenderer } = electron;
 
@@ -53,6 +85,23 @@ export interface WindowState {
   isMaximized: boolean;
   isFocused: boolean;
   isFullScreen?: boolean;
+}
+
+export interface ReviewState {
+  protocol: ReviewProtocol;
+  revision: ReviewProtocolRevision;
+}
+
+export interface ReviewFileActionResult {
+  ok: boolean;
+  artifactId?: string;
+  warning?: string;
+}
+
+export interface ReviewExportResult {
+  ok: boolean;
+  path?: string;
+  fileCount?: number;
 }
 
 export interface PaperPilotApi {
@@ -161,6 +210,33 @@ export interface PaperPilotApi {
   retryJob(jobId: string): Promise<Job>;
   clearTerminalJobs(projectId?: string): Promise<{ cleared: number }>;
   onJobChanged(listener: (job: Job) => void): () => void;
+  getReview(projectId: string): Promise<ReviewState | undefined>;
+  activateReview(input: ActivateReviewRequest): Promise<ReviewState>;
+  listReviewProtocolRevisions(reviewId: string): Promise<ReviewProtocolRevision[]>;
+  reviseReviewProtocol(input: ReviseReviewProtocolRequest): Promise<ReviewProtocolRevision>;
+  listReviewPapers(input: ReviewPaperQuery): Promise<ReviewPaperPage>;
+  listDiscoveryBatches(reviewId: string): Promise<DiscoveryBatch[]>;
+  previewReferenceImport(input: ReferenceImportPreviewRequest): Promise<ReferenceImportPreview | undefined>;
+  remapReferenceImport(input: { previewId: string; mapping: ReferenceImportMapping }): Promise<ReferenceImportPreview>;
+  commitReferenceImport(input: ReferenceImportCommitRequest): Promise<ReferenceImportCommitResponse>;
+  saveScreeningDecision(input: SaveScreeningDecisionRequest): Promise<ScreeningDecision>;
+  markReviewPapersForReview(input: MarkReviewPapersForReviewRequest): Promise<{ ok: true; marked: number }>;
+  listExtractionFields(reviewId: string): Promise<ExtractionField[]>;
+  upsertExtractionField(input: UpsertExtractionFieldRequest): Promise<ExtractionField>;
+  reorderExtractionFields(input: ReorderExtractionFieldsRequest): Promise<ExtractionField[]>;
+  listExtractionValues(input: { reviewId: string; paperIds?: string[] }): Promise<ExtractionValue[]>;
+  listReviewEvidence(input: { reviewId: string; evidenceIds?: string[] }): Promise<ReviewEvidence[]>;
+  saveExtractionValue(input: SaveExtractionValueRequest): Promise<ExtractionValue>;
+  startReviewRun(input: StartReviewRunRequest): Promise<ReviewRun>;
+  cancelReviewRun(input: CancelReviewRunRequest): Promise<{ cancelled: boolean }>;
+  retryReviewRun(input: RetryReviewRunRequest): Promise<ReviewRun>;
+  listReviewRuns(reviewId: string): Promise<ReviewRun[]>;
+  listReviewRunItems(runId: string): Promise<ReviewRunItem[]>;
+  onReviewRunEvent(listener: (event: ReviewRunEvent) => void): () => void;
+  getReviewSummary(reviewId: string): Promise<ReviewFlowSummary>;
+  fetchReviewPaperFullText(input: FetchReviewPaperFullTextRequest): Promise<ReviewFileActionResult>;
+  attachReviewPaperPdf(input: AttachReviewPaperPdfRequest): Promise<ReviewFileActionResult>;
+  exportReview(input: ExportReviewRequest): Promise<ReviewExportResult>;
 }
 
 const api: PaperPilotApi = {
@@ -251,7 +327,39 @@ const api: PaperPilotApi = {
     const handler = (_event: Electron.IpcRendererEvent, job: Job) => listener(job);
     ipcRenderer.on("jobs:changed", handler);
     return () => ipcRenderer.off("jobs:changed", handler);
-  }
+  },
+  getReview: (projectId) => ipcRenderer.invoke("review:get", projectId),
+  activateReview: (input) => ipcRenderer.invoke("review:activate", input),
+  listReviewProtocolRevisions: (reviewId) => ipcRenderer.invoke("review:listProtocolRevisions", reviewId),
+  reviseReviewProtocol: (input) => ipcRenderer.invoke("review:reviseProtocol", input),
+  listReviewPapers: (input) => ipcRenderer.invoke("review:listPapers", input),
+  listDiscoveryBatches: (reviewId) => ipcRenderer.invoke("review:listDiscoveryBatches", reviewId),
+  previewReferenceImport: (input) => ipcRenderer.invoke("review:previewImport", input),
+  remapReferenceImport: (input) => ipcRenderer.invoke("review:remapImport", input),
+  commitReferenceImport: (input) => ipcRenderer.invoke("review:commitImport", input),
+  saveScreeningDecision: (input) => ipcRenderer.invoke("review:saveDecision", input),
+  markReviewPapersForReview: (input) => ipcRenderer.invoke("review:markForReview", input),
+  listExtractionFields: (reviewId) => ipcRenderer.invoke("review:listExtractionFields", reviewId),
+  upsertExtractionField: (input) => ipcRenderer.invoke("review:upsertExtractionField", input),
+  reorderExtractionFields: (input) => ipcRenderer.invoke("review:reorderExtractionFields", input),
+  listExtractionValues: (input) => ipcRenderer.invoke("review:listExtractionValues", input),
+  listReviewEvidence: (input) => ipcRenderer.invoke("review:listEvidence", input),
+  saveExtractionValue: (input) => ipcRenderer.invoke("review:saveExtractionValue", input),
+  startReviewRun: (input) => ipcRenderer.invoke("review:startRun", input),
+  cancelReviewRun: (input) => ipcRenderer.invoke("review:cancelRun", input),
+  retryReviewRun: (input) => ipcRenderer.invoke("review:retryRun", input),
+  listReviewRuns: (reviewId) => ipcRenderer.invoke("review:listRuns", reviewId),
+  listReviewRunItems: (runId) => ipcRenderer.invoke("review:listRunItems", runId),
+  onReviewRunEvent: (listener) => {
+    const handler = (_event: Electron.IpcRendererEvent, runEvent: unknown) =>
+      listener(reviewRunEventSchema.parse(runEvent));
+    ipcRenderer.on("review:run-event", handler);
+    return () => ipcRenderer.off("review:run-event", handler);
+  },
+  getReviewSummary: (reviewId) => ipcRenderer.invoke("review:getSummary", { reviewId }),
+  fetchReviewPaperFullText: (input) => ipcRenderer.invoke("review:fetchFullText", input),
+  attachReviewPaperPdf: (input) => ipcRenderer.invoke("review:attachPdf", input),
+  exportReview: (input) => ipcRenderer.invoke("review:export", input)
 };
 
 contextBridge.exposeInMainWorld("paperPilot", api);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,8 +7,10 @@ import { ArtifactPanel, ArtifactViewerModal } from "./components/artifacts";
 import { ChatWorkspace } from "./components/chat-workspace";
 import { JobDrawer } from "./components/job-drawer";
 import { ProjectRail } from "./components/project-rail";
+import { ReviewWorkspace } from "./components/review-workspace";
 import { SearchPanel } from "./components/search-panel";
 import { SettingsPanel } from "./components/settings-panel";
+import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { WindowTitleBar } from "./components/window-title-bar";
@@ -36,6 +38,7 @@ export function App(): JSX.Element {
   const [viewerArtifactId, setViewerArtifactId] = useState<string | undefined>(undefined);
   const [viewerHighlightQuery, setViewerHighlightQuery] = useState("");
   const [viewerSearchPage, setViewerSearchPage] = useState<number | undefined>(undefined);
+  const [workspaceMode, setWorkspaceMode] = useState<"chat" | "review">("chat");
   const queryClient = useQueryClient();
 
   const projectsQuery = useQuery({
@@ -204,28 +207,62 @@ export function App(): JSX.Element {
           onImport={() => importProject.mutateAsync()}
         />
         <section className="relative flex min-h-0 min-w-0 flex-col border-l border-border bg-card">
-          <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_minmax(300px,340px)] overflow-hidden">
-            <ChatWorkspace
-              bundle={activeBundle}
-              activeProjectId={activeProjectId}
-              currentArtifactId={viewerArtifactId}
+          <div className="flex h-11 shrink-0 items-center justify-center border-b border-border bg-background/80 px-4">
+            <div className="flex rounded-lg bg-muted p-0.5" role="tablist" aria-label="Project workspace">
+              <Button
+                role="tab"
+                aria-selected={workspaceMode === "chat"}
+                variant={workspaceMode === "chat" ? "secondary" : "ghost"}
+                size="sm"
+                onClick={() => setWorkspaceMode("chat")}
+              >
+                Chat
+              </Button>
+              <Button
+                role="tab"
+                aria-selected={workspaceMode === "review"}
+                variant={workspaceMode === "review" ? "secondary" : "ghost"}
+                size="sm"
+                onClick={() => setWorkspaceMode("review")}
+              >
+                Review
+              </Button>
+            </div>
+          </div>
+          {workspaceMode === "chat" ? (
+            <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_minmax(300px,340px)] overflow-hidden">
+              <ChatWorkspace
+                bundle={activeBundle}
+                activeProjectId={activeProjectId}
+                currentArtifactId={viewerArtifactId}
+                onOpenArtifact={(artifactId, page) => {
+                  setViewerHighlightQuery("");
+                  setViewerSearchPage(page);
+                  setViewerArtifactId(artifactId);
+                }}
+              />
+              <ArtifactPanel
+                projectId={activeProjectId}
+                artifacts={artifacts}
+                papers={activeBundle?.papers ?? []}
+                onOpenArtifact={(artifactId) => {
+                  setViewerHighlightQuery("");
+                  setViewerSearchPage(undefined);
+                  setViewerArtifactId(artifactId);
+                }}
+              />
+            </div>
+          ) : (
+            <ReviewWorkspace
+              projectId={activeProjectId}
+              projectTitle={activeBundle?.project.title}
               onOpenArtifact={(artifactId, page) => {
                 setViewerHighlightQuery("");
                 setViewerSearchPage(page);
                 setViewerArtifactId(artifactId);
               }}
             />
-            <ArtifactPanel
-              projectId={activeProjectId}
-              artifacts={artifacts}
-              papers={activeBundle?.papers ?? []}
-              onOpenArtifact={(artifactId) => {
-                setViewerHighlightQuery("");
-                setViewerSearchPage(undefined);
-                setViewerArtifactId(artifactId);
-              }}
-            />
-          </div>
+          )}
           <JobDrawer projectId={activeProjectId} initialJobs={activeBundle?.jobs ?? []} />
         </section>
       </div>

--- a/src/renderer/components/review-workspace.tsx
+++ b/src/renderer/components/review-workspace.tsx
@@ -1,0 +1,2664 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { JSX, KeyboardEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  ActivateReviewRequest,
+  AttachReviewPaperPdfRequest,
+  CancelReviewRunRequest,
+  DiscoveryBatch,
+  ExportReviewRequest,
+  ExtractionField,
+  ExtractionFieldType,
+  ExtractionPrimitiveValue,
+  ExtractionValue,
+  FetchReviewPaperFullTextRequest,
+  MarkReviewPapersForReviewRequest,
+  Paper,
+  ReferenceImportCommitRequest,
+  ReferenceImportCommitResponse,
+  ReferenceImportMapping,
+  ReferenceImportPreview,
+  ReferenceImportPreviewRequest,
+  ReorderExtractionFieldsRequest,
+  RetryReviewRunRequest,
+  ReviewCriterion,
+  ReviewEvidence,
+  ReviewFlowSummary,
+  ReviewPaperPage,
+  ReviewPaperQuery,
+  ReviewPaperSummary,
+  ReviewProtocol,
+  ReviewProtocolRevision,
+  ReviewRun,
+  ReviewRunEvent,
+  ReviewRunItem,
+  ReviewStage,
+  ReviewTemplate,
+  ReviseReviewProtocolRequest,
+  SaveExtractionValueRequest,
+  SaveScreeningDecisionRequest,
+  ScreeningDecision,
+  ScreeningDecisionValue,
+  StartReviewRunRequest,
+  UpsertExtractionFieldRequest
+} from "../../shared/schemas";
+import { isBlankExtractionValue, MAX_EXTRACTION_FIELDS, MAX_REVIEW_BATCH_PAPERS } from "../../shared/schemas";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+type ReviewView = "protocol" | "discover" | "abstract" | "full-text" | "extract" | "summary";
+
+export interface ReviewState {
+  protocol: ReviewProtocol;
+  revision: ReviewProtocolRevision;
+}
+
+interface ReviewApi {
+  getProjectBundle?(projectId: string): Promise<{ papers: Paper[] }>;
+  getReview(projectId: string): Promise<ReviewState | undefined>;
+  activateReview(input: ActivateReviewRequest): Promise<ReviewState>;
+  listReviewProtocolRevisions(reviewId: string): Promise<ReviewProtocolRevision[]>;
+  reviseReviewProtocol(input: ReviseReviewProtocolRequest): Promise<ReviewProtocolRevision>;
+  listReviewPapers(input: ReviewPaperQuery): Promise<ReviewPaperPage>;
+  listDiscoveryBatches(reviewId: string): Promise<DiscoveryBatch[]>;
+  previewReferenceImport(input: ReferenceImportPreviewRequest): Promise<ReferenceImportPreview | undefined>;
+  remapReferenceImport(input: { previewId: string; mapping: ReferenceImportMapping }): Promise<ReferenceImportPreview>;
+  commitReferenceImport(input: ReferenceImportCommitRequest): Promise<ReferenceImportCommitResponse>;
+  saveScreeningDecision(input: SaveScreeningDecisionRequest): Promise<ScreeningDecision>;
+  markReviewPapersForReview(input: MarkReviewPapersForReviewRequest): Promise<{ ok: boolean }>;
+  listExtractionFields(reviewId: string): Promise<ExtractionField[]>;
+  upsertExtractionField(input: UpsertExtractionFieldRequest): Promise<ExtractionField>;
+  reorderExtractionFields(input: ReorderExtractionFieldsRequest): Promise<ExtractionField[]>;
+  listExtractionValues(input: { reviewId: string; paperIds?: string[] }): Promise<ExtractionValue[]>;
+  listReviewEvidence(input: { reviewId: string; evidenceIds?: string[] }): Promise<ReviewEvidence[]>;
+  saveExtractionValue(input: SaveExtractionValueRequest): Promise<ExtractionValue>;
+  startReviewRun(input: StartReviewRunRequest): Promise<ReviewRun>;
+  cancelReviewRun(input: CancelReviewRunRequest): Promise<ReviewRun | { cancelled: boolean }>;
+  retryReviewRun(input: RetryReviewRunRequest): Promise<ReviewRun>;
+  listReviewRuns(reviewId: string): Promise<ReviewRun[]>;
+  listReviewRunItems(runId: string): Promise<ReviewRunItem[]>;
+  onReviewRunEvent?(listener: (event: ReviewRunEvent) => void): () => void;
+  getReviewSummary(reviewId: string): Promise<ReviewFlowSummary>;
+  fetchReviewPaperFullText(input: FetchReviewPaperFullTextRequest): Promise<ReviewFileActionResult>;
+  attachReviewPaperPdf(input: AttachReviewPaperPdfRequest): Promise<ReviewFileActionResult>;
+  exportReview(input: ExportReviewRequest): Promise<{ ok: boolean; path?: string }>;
+}
+
+interface ReviewFileActionResult {
+  ok: boolean;
+  artifactId?: string;
+  warning?: string;
+}
+
+const reviewViews: Array<{ id: ReviewView; label: string }> = [
+  { id: "protocol", label: "Protocol" },
+  { id: "discover", label: "Discover" },
+  { id: "abstract", label: "Abstract" },
+  { id: "full-text", label: "Full text" },
+  { id: "extract", label: "Extract" },
+  { id: "summary", label: "Summary" }
+];
+
+const AMBIGUOUS_IMPORT_PAGE_SIZE = 50;
+
+const paperSourceFilters: Array<{ value: ReviewPaperSummary["source"]; label: string }> = [
+  { value: "reference-import", label: "Reference import" },
+  { value: "openalex", label: "OpenAlex" },
+  { value: "crossref", label: "Crossref" },
+  { value: "semantic-scholar", label: "Semantic Scholar" },
+  { value: "pubmed", label: "PubMed" },
+  { value: "arxiv", label: "arXiv" },
+  { value: "europe-pmc", label: "Europe PMC" },
+  { value: "core", label: "CORE" },
+  { value: "unpaywall", label: "Unpaywall" },
+  { value: "google-scholar", label: "Google Scholar" }
+];
+
+function api(): ReviewApi {
+  return window.paperPilot as unknown as ReviewApi;
+}
+
+interface SuggestionSelection {
+  run: ReviewRun;
+  item: ReviewRunItem;
+  runOrder: number;
+  itemOrder: number;
+}
+
+function suggestionKey(stage: ReviewStage, paperId: string): string {
+  return `${stage}\u0000${paperId}`;
+}
+
+function isActionableSuggestion(run: ReviewRun, item: ReviewRunItem): boolean {
+  if (item.status !== "completed") return false;
+  return run.stage === "extraction" ? item.extractionSuggestions.length > 0 : item.suggestedDecision !== undefined;
+}
+
+function suggestionTime(selection: SuggestionSelection): number {
+  for (const value of [selection.item.completedAt, selection.item.updatedAt, selection.run.updatedAt]) {
+    const timestamp = value ? Date.parse(value) : Number.NaN;
+    if (Number.isFinite(timestamp)) return timestamp;
+  }
+  return 0;
+}
+
+function preferredSuggestion(
+  current: SuggestionSelection | undefined,
+  candidate: SuggestionSelection,
+  currentRevisionId: string
+): SuggestionSelection {
+  if (!current) return candidate;
+  const currentProtocol = current.run.protocolRevisionId === currentRevisionId;
+  const candidateProtocol = candidate.run.protocolRevisionId === currentRevisionId;
+  if (currentProtocol !== candidateProtocol) return candidateProtocol ? candidate : current;
+  const currentFresh = !current.item.stale;
+  const candidateFresh = !candidate.item.stale;
+  if (currentFresh !== candidateFresh) return candidateFresh ? candidate : current;
+  const timeDifference = suggestionTime(candidate) - suggestionTime(current);
+  if (timeDifference !== 0) return timeDifference > 0 ? candidate : current;
+  const runUpdateDifference = Date.parse(candidate.run.updatedAt) - Date.parse(current.run.updatedAt);
+  if (Number.isFinite(runUpdateDifference) && runUpdateDifference !== 0) {
+    return runUpdateDifference > 0 ? candidate : current;
+  }
+  const runCreationDifference = Date.parse(candidate.run.createdAt) - Date.parse(current.run.createdAt);
+  if (Number.isFinite(runCreationDifference) && runCreationDifference !== 0) {
+    return runCreationDifference > 0 ? candidate : current;
+  }
+  // listReviewRuns is newest-first; use its authoritative order for timestamp ties.
+  if (candidate.runOrder !== current.runOrder) return candidate.runOrder < current.runOrder ? candidate : current;
+  if (candidate.itemOrder !== current.itemOrder) return candidate.itemOrder > current.itemOrder ? candidate : current;
+  return current;
+}
+
+function latestRun(runs: ReviewRun[]): ReviewRun | undefined {
+  let selected: { run: ReviewRun; order: number } | undefined;
+  runs.forEach((run, order) => {
+    if (!selected) {
+      selected = { run, order };
+      return;
+    }
+    const difference = Date.parse(run.updatedAt) - Date.parse(selected.run.updatedAt);
+    if (difference > 0 || (difference === 0 && order < selected.order)) selected = { run, order };
+  });
+  return selected?.run;
+}
+
+export function ReviewWorkspace(props: {
+  projectId?: string;
+  projectTitle?: string;
+  onOpenArtifact?(artifactId: string, page?: number): void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const [view, setView] = useState<ReviewView>("protocol");
+  const [activeRun, setActiveRun] = useState<ReviewRun>();
+  const [runProgress, setRunProgress] = useState({ completed: 0, failed: 0, cancelled: 0, total: 0 });
+  const [suggestions, setSuggestions] = useState<Record<string, SuggestionSelection>>({});
+
+  useEffect(() => {
+    setView("protocol");
+    setActiveRun(undefined);
+    setRunProgress({ completed: 0, failed: 0, cancelled: 0, total: 0 });
+    setSuggestions({});
+  }, [props.projectId]);
+
+  const reviewQuery = useQuery({
+    queryKey: ["review", props.projectId],
+    queryFn: () => api().getReview(props.projectId!),
+    enabled: Boolean(props.projectId),
+    retry: false
+  });
+  const review = reviewQuery.data;
+  const protocolHistoryQuery = useQuery({
+    queryKey: ["review-protocol-history", review?.protocol.id],
+    queryFn: () => api().listReviewProtocolRevisions(review!.protocol.id),
+    enabled: Boolean(review)
+  });
+  const runsQuery = useQuery({
+    queryKey: ["review-runs", review?.protocol.id],
+    queryFn: () => api().listReviewRuns(review!.protocol.id),
+    enabled: Boolean(review)
+  });
+  const knownRuns = useMemo(() => runsQuery.data ?? [], [runsQuery.data]);
+  const persistedRun =
+    latestRun(knownRuns.filter((run) => run.status === "queued" || run.status === "running")) ?? latestRun(knownRuns);
+  const runItemsQuery = useQuery({
+    queryKey: ["review-run-items", review?.protocol.id, knownRuns.map((run) => run.id)],
+    queryFn: async () =>
+      Promise.all(
+        knownRuns.map(async (run, runOrder) => ({ run, runOrder, items: await api().listReviewRunItems(run.id) }))
+      ),
+    enabled: knownRuns.length > 0
+  });
+
+  useEffect(() => {
+    if (!persistedRun) return;
+    setActiveRun((current) =>
+      current?.id === persistedRun.id && current.updatedAt >= persistedRun.updatedAt ? current : persistedRun
+    );
+    setRunProgress({
+      completed: persistedRun.completedCount,
+      failed: persistedRun.failedCount,
+      cancelled: persistedRun.cancelledCount,
+      total: persistedRun.paperIds.length
+    });
+  }, [persistedRun]);
+
+  useEffect(() => {
+    if (!runItemsQuery.data) return;
+    const latestByStageAndPaper: Record<string, SuggestionSelection> = {};
+    for (const { run, runOrder, items } of runItemsQuery.data) {
+      items.forEach((item, itemOrder) => {
+        if (!isActionableSuggestion(run, item)) return;
+        const key = suggestionKey(run.stage, item.paperId);
+        latestByStageAndPaper[key] = preferredSuggestion(
+          latestByStageAndPaper[key],
+          { run, item, runOrder, itemOrder },
+          review!.revision.id
+        );
+      });
+    }
+    setSuggestions(latestByStageAndPaper);
+  }, [review, runItemsQuery.data]);
+
+  useEffect(() => {
+    const subscribe = api().onReviewRunEvent;
+    if (!subscribe || !review) return;
+    return subscribe((event) => {
+      if (event.reviewId !== review.protocol.id) return;
+      if (event.type === "status") {
+        setActiveRun((current) => (current?.id === event.runId ? { ...current, status: event.status } : current));
+      } else if (event.type === "progress") {
+        setRunProgress({
+          completed: event.completed,
+          failed: event.failed,
+          cancelled: event.cancelled,
+          total: event.total
+        });
+      } else if (event.type === "item") {
+        const eventRun =
+          knownRuns.find((run) => run.id === event.runId) ?? (activeRun?.id === event.runId ? activeRun : undefined);
+        if (eventRun && isActionableSuggestion(eventRun, event.item)) {
+          const key = suggestionKey(eventRun.stage, event.item.paperId);
+          const candidate = { run: eventRun, item: event.item, runOrder: -1, itemOrder: 0 };
+          setSuggestions((current) => ({
+            ...current,
+            [key]: preferredSuggestion(current[key], candidate, review.revision.id)
+          }));
+        }
+      } else if (event.type === "complete") {
+        setActiveRun(event.run);
+        void invalidateReviewData(queryClient, event.reviewId);
+      } else if (event.type === "error") {
+        setActiveRun((current) =>
+          current?.id === event.runId ? { ...current, status: event.status, error: event.error } : current
+        );
+      }
+    });
+  }, [activeRun, knownRuns, queryClient, review]);
+
+  const activate = useMutation({
+    mutationFn: (input: ActivateReviewRequest) => api().activateReview(input),
+    onSuccess: (state) => {
+      queryClient.setQueryData(["review", props.projectId], state);
+      setView("protocol");
+    }
+  });
+
+  const revise = useMutation({
+    mutationFn: (input: ReviseReviewProtocolRequest) => api().reviseReviewProtocol(input),
+    onSuccess: (revision) => {
+      queryClient.setQueryData<ReviewState>(["review", props.projectId], (current) =>
+        current
+          ? {
+              protocol: {
+                ...current.protocol,
+                currentRevisionId: revision.id,
+                currentRevisionNumber: revision.version,
+                updatedAt: revision.createdAt
+              },
+              revision
+            }
+          : current
+      );
+      void queryClient.invalidateQueries({ queryKey: ["review-protocol-history", revision.reviewId] });
+      void invalidateReviewData(queryClient, revision.reviewId);
+    }
+  });
+
+  const startRun = useMutation({
+    mutationFn: (input: StartReviewRunRequest) => api().startReviewRun(input),
+    onSuccess: (run) => {
+      setActiveRun(run);
+      setRunProgress({ completed: 0, failed: 0, cancelled: 0, total: run.paperIds.length });
+      void queryClient.invalidateQueries({ queryKey: ["review-runs", run.reviewId] });
+    }
+  });
+
+  const cancelRun = useMutation({
+    mutationFn: (input: CancelReviewRunRequest) => api().cancelReviewRun(input),
+    onSuccess: () => {
+      setActiveRun((current) => (current ? { ...current, status: "cancelled" } : current));
+    }
+  });
+
+  const retryRun = useMutation({
+    mutationFn: (input: RetryReviewRunRequest) => api().retryReviewRun(input),
+    onSuccess: (run) => {
+      setActiveRun(run);
+      setRunProgress({ completed: 0, failed: 0, cancelled: 0, total: run.paperIds.length });
+      void queryClient.invalidateQueries({ queryKey: ["review-runs", run.reviewId] });
+    }
+  });
+
+  if (!props.projectId) return <EmptyReview message="Select a project to begin an evidence review." />;
+  if (reviewQuery.isPending) return <EmptyReview message="Loading evidence review…" />;
+  if (reviewQuery.isError) {
+    return (
+      <EmptyReview
+        message={`The evidence review could not be loaded: ${errorMessage(reviewQuery.error)}`}
+        action={<Button onClick={() => void reviewQuery.refetch()}>Retry</Button>}
+      />
+    );
+  }
+  if (!review) {
+    return (
+      <ReviewActivation
+        projectId={props.projectId}
+        projectTitle={props.projectTitle}
+        busy={activate.isPending}
+        error={activate.error}
+        onActivate={(input) => activate.mutate(input)}
+      />
+    );
+  }
+
+  const running = activeRun?.status === "queued" || activeRun?.status === "running";
+  const runControls = (
+    <RunStatus
+      run={activeRun}
+      progress={runProgress}
+      onCancel={() => activeRun && cancelRun.mutate({ runId: activeRun.id })}
+      onRetry={() => activeRun && retryRun.mutate({ runId: activeRun.id })}
+    />
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-background" data-testid="review-workspace">
+      <header className="border-b border-border bg-card px-5 pt-4">
+        <div className="flex items-start justify-between gap-4 pb-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-lg font-semibold">Evidence review</h1>
+              <Badge variant="secondary">Protocol v{review.revision.version}</Badge>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Human-confirmed screening and extraction with an append-only audit trail.
+            </p>
+          </div>
+          {runControls}
+        </div>
+        {startRun.error || cancelRun.error || retryRun.error || runsQuery.error || runItemsQuery.error ? (
+          <div className="pb-3">
+            <InlineError
+              error={startRun.error ?? cancelRun.error ?? retryRun.error ?? runsQuery.error ?? runItemsQuery.error}
+            />
+          </div>
+        ) : null}
+        <nav aria-label="Review stages" className="flex gap-1 overflow-x-auto">
+          {reviewViews.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              aria-current={view === item.id ? "page" : undefined}
+              onClick={() => setView(item.id)}
+              className={cn(
+                "border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+                view === item.id
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-5">
+        {view === "protocol" ? (
+          <ProtocolEditor
+            protocol={review.protocol}
+            revision={review.revision}
+            history={protocolHistoryQuery.data ?? [review.revision]}
+            busy={revise.isPending}
+            error={revise.error ?? protocolHistoryQuery.error}
+            onSave={(input) => revise.mutate(input)}
+          />
+        ) : null}
+        {view === "discover" ? <DiscoverStage reviewId={review.protocol.id} projectId={props.projectId} /> : null}
+        {view === "abstract" || view === "full-text" ? (
+          <ScreeningStage
+            reviewId={review.protocol.id}
+            projectId={props.projectId}
+            protocolRevisionId={review.revision.id}
+            criteria={review.revision.criteria}
+            stage={view === "abstract" ? "title-abstract" : "full-text"}
+            suggestions={suggestions}
+            runBusy={running || startRun.isPending}
+            onOpenArtifact={props.onOpenArtifact}
+            onStartRun={(input) => startRun.mutate(input)}
+          />
+        ) : null}
+        {view === "extract" ? (
+          <ExtractionStage
+            reviewId={review.protocol.id}
+            suggestions={suggestions}
+            runBusy={running || startRun.isPending}
+            onOpenArtifact={props.onOpenArtifact}
+            onStartRun={(input) => startRun.mutate(input)}
+          />
+        ) : null}
+        {view === "summary" ? <SummaryStage reviewId={review.protocol.id} /> : null}
+      </div>
+    </div>
+  );
+}
+
+function EmptyReview(props: { message: string; action?: JSX.Element }): JSX.Element {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-8">
+      <div className="max-w-md text-center">
+        <p className="text-sm text-muted-foreground">{props.message}</p>
+        {props.action ? <div className="mt-4">{props.action}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+const templateContent: Record<
+  ReviewTemplate,
+  { name: string; description: string; question: string; objectives: string[]; criteria: ReviewCriterion[] }
+> = {
+  blank: {
+    name: "Blank review",
+    description: "Start with an empty protocol and define your own review structure.",
+    question: "",
+    objectives: [],
+    criteria: []
+  },
+  "general-empirical": {
+    name: "Empirical studies",
+    description: "A discipline-neutral starting point for empirical evidence.",
+    question: "What does the available empirical evidence show about the research topic?",
+    objectives: ["Identify relevant empirical studies", "Compare reported methods and outcomes"],
+    criteria: [
+      criterion("general-ta-include", "title-abstract", "inclusion", "Addresses the research question", 0),
+      criterion("general-ft-exclude", "full-text", "exclusion", "No empirical results", 0)
+    ]
+  },
+  pico: {
+    name: "PICO-style review",
+    description: "Frame evidence around population, intervention, comparator, and outcome.",
+    question: "In [population], how does [intervention] compared with [comparator] affect [outcome]?",
+    objectives: ["Assess eligible populations and interventions", "Extract comparator and outcome data"],
+    criteria: [
+      criterion("pico-ta-population", "title-abstract", "inclusion", "Eligible population", 0),
+      criterion("pico-ta-intervention", "title-abstract", "inclusion", "Relevant intervention", 1),
+      criterion("pico-ft-outcome", "full-text", "exclusion", "Does not report an eligible outcome", 0)
+    ]
+  }
+};
+
+function ReviewActivation(props: {
+  projectId: string;
+  projectTitle?: string;
+  busy: boolean;
+  error: unknown;
+  onActivate(input: ActivateReviewRequest): void;
+}): JSX.Element {
+  const [template, setTemplate] = useState<ReviewTemplate>("blank");
+  const selected = templateContent[template];
+  const [question, setQuestion] = useState(selected.question);
+  const [objectives, setObjectives] = useState(selected.objectives.join("\n"));
+
+  const chooseTemplate = (next: ReviewTemplate): void => {
+    setTemplate(next);
+    setQuestion(templateContent[next].question);
+    setObjectives(templateContent[next].objectives.join("\n"));
+  };
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-6" data-testid="review-activation">
+      <div className="mx-auto max-w-4xl">
+        <Badge variant="secondary">Solo evidence review</Badge>
+        <h1 className="mt-3 text-2xl font-semibold">Set up an auditable review</h1>
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+          Add a versioned protocol to {props.projectTitle ?? "this project"}. Existing papers will enter a pending
+          screening queue without changing their reading status.
+        </p>
+
+        <fieldset className="mt-6 grid gap-3 md:grid-cols-3">
+          <legend className="sr-only">Review template</legend>
+          {(Object.entries(templateContent) as Array<[ReviewTemplate, (typeof templateContent)[ReviewTemplate]]>).map(
+            ([id, item]) => (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={template === id}
+                onClick={() => chooseTemplate(id)}
+                className={cn(
+                  "rounded-xl border p-4 text-left transition-colors",
+                  template === id ? "border-primary bg-primary/5" : "border-border bg-card hover:bg-muted/50"
+                )}
+              >
+                <span className="block font-medium">{item.name}</span>
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{item.description}</span>
+              </button>
+            )
+          )}
+        </fieldset>
+
+        <Card className="mt-5 gap-4 p-5">
+          <label className="grid gap-1.5 text-sm font-medium">
+            Research question
+            <Textarea
+              value={question}
+              onChange={(event) => setQuestion(event.target.value)}
+              placeholder="What question will this review answer?"
+            />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Objectives <span className="font-normal text-muted-foreground">One per line</span>
+            <Textarea
+              value={objectives}
+              onChange={(event) => setObjectives(event.target.value)}
+              placeholder="Identify relevant studies"
+            />
+          </label>
+          <div className="rounded-lg bg-muted/60 p-3 text-xs text-muted-foreground">
+            Activation records {templateContent[template].criteria.length} starter criteria and creates a “Pre-existing
+            project papers” discovery batch. If papers already exist, historical duplicate counts will be marked
+            unavailable.
+          </div>
+          {props.error ? <InlineError error={props.error} /> : null}
+          <div className="flex justify-end">
+            <Button
+              disabled={props.busy}
+              onClick={() =>
+                props.onActivate({
+                  projectId: props.projectId,
+                  template,
+                  researchQuestion: question,
+                  objectives: lines(objectives),
+                  criteria: templateContent[template].criteria
+                })
+              }
+            >
+              {props.busy ? "Activating…" : "Activate review"}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function ProtocolEditor(props: {
+  protocol: ReviewProtocol;
+  revision: ReviewProtocolRevision;
+  history: ReviewProtocolRevision[];
+  busy: boolean;
+  error: unknown;
+  onSave(input: ReviseReviewProtocolRequest): void;
+}): JSX.Element {
+  const [question, setQuestion] = useState(props.revision.researchQuestion);
+  const [objectives, setObjectives] = useState(props.revision.objectives.join("\n"));
+  const [criteria, setCriteria] = useState(() => criterionDraft(props.revision.criteria));
+  const [changeNote, setChangeNote] = useState("");
+
+  useEffect(() => {
+    setQuestion(props.revision.researchQuestion);
+    setObjectives(props.revision.objectives.join("\n"));
+    setCriteria(criterionDraft(props.revision.criteria));
+    setChangeNote("");
+  }, [props.revision]);
+
+  const nextCriteria = (): ReviewCriterion[] => {
+    const groups: Array<{
+      value: string;
+      stage: ReviewCriterion["stage"];
+      type: ReviewCriterion["type"];
+      prefix: string;
+    }> = [
+      { value: criteria.abstractInclusion, stage: "title-abstract", type: "inclusion", prefix: "ta-i" },
+      { value: criteria.abstractExclusion, stage: "title-abstract", type: "exclusion", prefix: "ta-e" },
+      { value: criteria.fullTextInclusion, stage: "full-text", type: "inclusion", prefix: "ft-i" },
+      { value: criteria.fullTextExclusion, stage: "full-text", type: "exclusion", prefix: "ft-e" }
+    ];
+    return groups.flatMap((group) =>
+      lines(group.value).map((label, order) =>
+        criterion(`${group.prefix}-${slug(label)}-${order}`, group.stage, group.type, label, order)
+      )
+    );
+  };
+
+  return (
+    <section aria-labelledby="protocol-heading" className="mx-auto max-w-5xl">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="protocol-heading" className="text-xl font-semibold">
+            Review protocol
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Revisions preserve decisions but mark prior AI suggestions stale. Template: {props.protocol.template}.
+          </p>
+        </div>
+        <Badge variant={props.protocol.historicalCountsAvailable ? "secondary" : "outline"}>
+          {props.protocol.historicalCountsAvailable ? "Complete provenance counts" : "Historical counts unavailable"}
+        </Badge>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        <Card className="gap-4 p-5 lg:col-span-2">
+          <label className="grid gap-1.5 text-sm font-medium">
+            Research question
+            <Textarea value={question} onChange={(event) => setQuestion(event.target.value)} />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Objectives <span className="font-normal text-muted-foreground">One per line</span>
+            <Textarea value={objectives} onChange={(event) => setObjectives(event.target.value)} />
+          </label>
+        </Card>
+        <CriteriaCard
+          title="Title and abstract criteria"
+          inclusion={criteria.abstractInclusion}
+          exclusion={criteria.abstractExclusion}
+          onInclusion={(value) => setCriteria((current) => ({ ...current, abstractInclusion: value }))}
+          onExclusion={(value) => setCriteria((current) => ({ ...current, abstractExclusion: value }))}
+        />
+        <CriteriaCard
+          title="Full-text criteria"
+          inclusion={criteria.fullTextInclusion}
+          exclusion={criteria.fullTextExclusion}
+          onInclusion={(value) => setCriteria((current) => ({ ...current, fullTextInclusion: value }))}
+          onExclusion={(value) => setCriteria((current) => ({ ...current, fullTextExclusion: value }))}
+        />
+        <Card className="gap-3 p-5 lg:col-span-2">
+          <label className="grid gap-1.5 text-sm font-medium">
+            Revision note
+            <Input
+              value={changeNote}
+              onChange={(event) => setChangeNote(event.target.value)}
+              placeholder="Why is the protocol changing?"
+            />
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Saving creates protocol version {props.revision.version + 1}; previous versions remain auditable.
+          </p>
+          {props.error ? <InlineError error={props.error} /> : null}
+          <div className="flex justify-end">
+            <Button
+              disabled={props.busy}
+              onClick={() =>
+                props.onSave({
+                  reviewId: props.protocol.id,
+                  expectedVersion: props.revision.version,
+                  researchQuestion: question,
+                  objectives: lines(objectives),
+                  criteria: nextCriteria(),
+                  changeNote: changeNote.trim() || undefined
+                })
+              }
+            >
+              {props.busy ? "Saving revision…" : "Save new protocol version"}
+            </Button>
+          </div>
+        </Card>
+        <Card className="gap-3 p-5 lg:col-span-2">
+          <h3 className="font-medium">Protocol history</h3>
+          <ol className="grid gap-2">
+            {[...props.history]
+              .sort((left, right) => right.version - left.version)
+              .map((item) => (
+                <li key={item.id} className="rounded-lg border p-3 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <strong>Version {item.version}</strong>
+                    <span className="text-xs text-muted-foreground">{new Date(item.createdAt).toLocaleString()}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {item.changeNote ?? (item.version === 1 ? "Initial protocol" : "No revision note")}
+                  </p>
+                  <p className="mt-2 line-clamp-2">{item.researchQuestion || "No research question specified."}</p>
+                </li>
+              ))}
+          </ol>
+        </Card>
+      </div>
+    </section>
+  );
+}
+
+function CriteriaCard(props: {
+  title: string;
+  inclusion: string;
+  exclusion: string;
+  onInclusion(value: string): void;
+  onExclusion(value: string): void;
+}): JSX.Element {
+  return (
+    <Card className="gap-4 p-5">
+      <h3 className="font-medium">{props.title}</h3>
+      <label className="grid gap-1.5 text-sm">
+        Inclusion criteria <span className="text-xs text-muted-foreground">One per line</span>
+        <Textarea value={props.inclusion} onChange={(event) => props.onInclusion(event.target.value)} />
+      </label>
+      <label className="grid gap-1.5 text-sm">
+        Exclusion criteria <span className="text-xs text-muted-foreground">One per line</span>
+        <Textarea value={props.exclusion} onChange={(event) => props.onExclusion(event.target.value)} />
+      </label>
+    </Card>
+  );
+}
+
+function DiscoverStage(props: { reviewId: string; projectId: string }): JSX.Element {
+  const queryClient = useQueryClient();
+  const [preview, setPreview] = useState<ReferenceImportPreview>();
+  const [mapping, setMapping] = useState<Partial<ReferenceImportMapping>>({});
+  const [resolutions, setResolutions] = useState<Record<number, "keep-separate" | "merge" | "skip">>({});
+  const [mergeTargets, setMergeTargets] = useState<Record<number, string>>({});
+  const [importNotice, setImportNotice] = useState<string>();
+  const [mappingApplied, setMappingApplied] = useState(true);
+  const [ambiguousPage, setAmbiguousPage] = useState(1);
+  const [previewPage, setPreviewPage] = useState(1);
+  const [previewFilter, setPreviewFilter] = useState<"all" | "invalid">("all");
+
+  const applyPreview = (result: ReferenceImportPreview, useSuggestedMapping: boolean): void => {
+    setPreview(result);
+    if (useSuggestedMapping) setMapping(result.suggestedMapping ?? {});
+    setResolutions({});
+    setMergeTargets(
+      Object.fromEntries(
+        result.items
+          .filter((item) => item.match.kind === "ambiguous" && item.match.candidatePaperIds.length)
+          .map((item) => [item.recordIndex, item.match.candidatePaperIds[0]])
+      )
+    );
+    setMappingApplied(true);
+    setAmbiguousPage(1);
+    setPreviewPage(1);
+    setPreviewFilter("all");
+  };
+
+  const batchesQuery = useQuery({
+    queryKey: ["review-discovery", props.reviewId],
+    queryFn: () => api().listDiscoveryBatches(props.reviewId)
+  });
+  const previewImport = useMutation({
+    mutationFn: () => api().previewReferenceImport({ projectId: props.projectId, reviewId: props.reviewId }),
+    onSuccess: (result) => {
+      if (!result) {
+        setImportNotice("No reference file was selected.");
+        return;
+      }
+      setImportNotice(undefined);
+      applyPreview(result, true);
+    }
+  });
+  const remapImport = useMutation({
+    mutationFn: () =>
+      api().remapReferenceImport({
+        previewId: preview!.previewId,
+        mapping: mapping as ReferenceImportMapping
+      }),
+    onSuccess: (result) => {
+      applyPreview(result, false);
+      setImportNotice("CSV mapping applied. The preview and match resolutions have been refreshed.");
+    }
+  });
+  const commitImport = useMutation({
+    mutationFn: (input: ReferenceImportCommitRequest) => api().commitReferenceImport(input),
+    onMutate: () => setImportNotice(undefined),
+    onSuccess: (result) => {
+      setPreview(undefined);
+      setImportNotice(
+        `Import complete: ${result.counts.newRecords.toLocaleString()} new, ${result.counts.duplicates.toLocaleString()} duplicate, ${result.counts.merged.toLocaleString()} merged, and ${result.counts.invalid.toLocaleString()} invalid records.`
+      );
+      void queryClient.invalidateQueries({ queryKey: ["review-discovery", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-summary", props.reviewId] });
+    }
+  });
+
+  const ambiguous = preview?.items.filter((item) => item.match.kind === "ambiguous") ?? [];
+  const unresolvedAmbiguous = ambiguous.filter((item) => resolutions[item.recordIndex] === undefined);
+  const ambiguousTotalPages = Math.max(1, Math.ceil(ambiguous.length / AMBIGUOUS_IMPORT_PAGE_SIZE));
+  const visibleAmbiguous = ambiguous.slice(
+    (ambiguousPage - 1) * AMBIGUOUS_IMPORT_PAGE_SIZE,
+    ambiguousPage * AMBIGUOUS_IMPORT_PAGE_SIZE
+  );
+  const filteredPreviewItems = preview?.items.filter((item) => previewFilter === "all" || !item.valid) ?? [];
+  const previewTotalPages = Math.max(1, Math.ceil(filteredPreviewItems.length / AMBIGUOUS_IMPORT_PAGE_SIZE));
+  const visiblePreviewItems = filteredPreviewItems.slice(
+    (previewPage - 1) * AMBIGUOUS_IMPORT_PAGE_SIZE,
+    previewPage * AMBIGUOUS_IMPORT_PAGE_SIZE
+  );
+  const csvMappingReady = preview?.format !== "csv" || (Boolean(mapping.title) && mappingApplied);
+
+  return (
+    <section aria-labelledby="discover-heading" className="mx-auto max-w-6xl">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="discover-heading" className="text-xl font-semibold">
+            Discover and import
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            RIS, BibTeX, and CSV files are previewed before any project data changes.
+          </p>
+        </div>
+        <Button disabled={previewImport.isPending} onClick={() => previewImport.mutate()}>
+          {previewImport.isPending ? "Reading file…" : "Import references"}
+        </Button>
+      </div>
+      {previewImport.error ? (
+        <div className="mt-3">
+          <InlineError error={previewImport.error} />
+        </div>
+      ) : null}
+      {importNotice ? (
+        <p role="status" className="mt-3 rounded-lg bg-primary/10 px-3 py-2 text-sm text-foreground">
+          {importNotice}
+        </p>
+      ) : null}
+
+      {preview ? (
+        <Card className="mt-5 gap-4 p-5" data-testid="reference-import-preview">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="font-medium">Preview: {preview.fileName}</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {preview.totalRecords.toLocaleString()} records · {preview.validRecords.toLocaleString()} valid ·{" "}
+                {preview.invalidRecords.toLocaleString()} invalid
+              </p>
+            </div>
+            <Badge variant="outline">{preview.format.toUpperCase()}</Badge>
+          </div>
+
+          {preview.format === "csv" ? (
+            <div>
+              <h4 className="text-sm font-medium">CSV column mapping</h4>
+              <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {(
+                  [
+                    "title",
+                    "authors",
+                    "abstract",
+                    "year",
+                    "doi",
+                    "url",
+                    "pdfUrl",
+                    "venue",
+                    "sourceId",
+                    "sourceAuthority",
+                    "citationCount"
+                  ] as const
+                ).map((field) => (
+                  <label key={field} className="grid gap-1 text-xs capitalize">
+                    {field === "title" ? "Title (required)" : field.replace(/([A-Z])/g, " $1")}
+                    <select
+                      className="h-8 rounded-lg border border-input bg-background px-2 text-sm"
+                      value={mapping[field] ?? ""}
+                      onChange={(event) => {
+                        setMapping((current) => ({ ...current, [field]: event.target.value || undefined }));
+                        setMappingApplied(false);
+                      }}
+                    >
+                      <option value="">Not mapped</option>
+                      {preview.columns.map((column) => (
+                        <option key={column} value={column}>
+                          {column}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
+              <div className="mt-3 flex items-center gap-3">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!mapping.title || mappingApplied || remapImport.isPending}
+                  onClick={() => remapImport.mutate()}
+                >
+                  {remapImport.isPending ? "Refreshing preview…" : "Apply mapping and refresh preview"}
+                </Button>
+                {!mappingApplied ? (
+                  <span className="text-xs text-amber-700 dark:text-amber-300">
+                    Refresh the preview before committing this mapping.
+                  </span>
+                ) : null}
+              </div>
+              {remapImport.error ? (
+                <div className="mt-3">
+                  <InlineError error={remapImport.error} />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {ambiguous.length ? (
+            <div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h4 className="text-sm font-medium">Resolve ambiguous matches</h4>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {ambiguous.length - unresolvedAmbiguous.length} of {ambiguous.length} explicitly resolved. Every
+                    ambiguous record must be reviewed before import.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      setResolutions((current) => ({
+                        ...current,
+                        ...Object.fromEntries(
+                          unresolvedAmbiguous.map((item) => [item.recordIndex, "keep-separate" as const])
+                        )
+                      }))
+                    }
+                  >
+                    Keep all unresolved separate
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      setResolutions((current) => ({
+                        ...current,
+                        ...Object.fromEntries(unresolvedAmbiguous.map((item) => [item.recordIndex, "skip" as const]))
+                      }))
+                    }
+                  >
+                    Skip all unresolved
+                  </Button>
+                </div>
+              </div>
+              <div className="mt-2 grid gap-2">
+                {visibleAmbiguous.map((item) => (
+                  <div key={item.recordIndex} className="grid gap-2 rounded-lg border p-3 sm:grid-cols-[1fr_auto]">
+                    <span className="min-w-0 truncate text-sm">
+                      {item.record?.title ?? item.rawTitle ?? `Record ${item.recordIndex + 1}`}
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                      <select
+                        aria-label={`Resolution for ${item.record?.title ?? `record ${item.recordIndex + 1}`}`}
+                        className="h-8 rounded-lg border border-input bg-background px-2 text-sm"
+                        value={resolutions[item.recordIndex] ?? ""}
+                        onChange={(event) =>
+                          setResolutions((current) => ({
+                            ...current,
+                            [item.recordIndex]: event.target.value as "keep-separate" | "merge" | "skip"
+                          }))
+                        }
+                      >
+                        <option value="" disabled>
+                          Choose resolution…
+                        </option>
+                        <option value="skip">Skip</option>
+                        <option value="keep-separate">Keep separate</option>
+                        <option value="merge">Merge with match</option>
+                      </select>
+                      {resolutions[item.recordIndex] === "merge" ? (
+                        <select
+                          aria-label={`Merge target for ${item.record?.title ?? `record ${item.recordIndex + 1}`}`}
+                          className="h-8 max-w-56 rounded-lg border border-input bg-background px-2 font-mono text-xs"
+                          value={mergeTargets[item.recordIndex] ?? item.match.candidatePaperIds[0] ?? ""}
+                          onChange={(event) =>
+                            setMergeTargets((current) => ({ ...current, [item.recordIndex]: event.target.value }))
+                          }
+                        >
+                          {item.match.candidatePaperIds.map((paperId) => (
+                            <option key={paperId} value={paperId}>
+                              {paperId}
+                            </option>
+                          ))}
+                        </select>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              {ambiguousTotalPages > 1 ? (
+                <Pagination
+                  label="Ambiguous matches"
+                  page={ambiguousPage}
+                  totalPages={ambiguousTotalPages}
+                  onPage={setAmbiguousPage}
+                />
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-sm font-medium">Parsed records</h4>
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              Preview records
+              <select
+                aria-label="Preview records"
+                className="h-8 rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+                value={previewFilter}
+                onChange={(event) => {
+                  setPreviewFilter(event.target.value as "all" | "invalid");
+                  setPreviewPage(1);
+                }}
+              >
+                <option value="all">All ({preview.items.length})</option>
+                <option value="invalid">Invalid only ({preview.invalidRecords})</option>
+              </select>
+            </label>
+          </div>
+          <div className="max-h-64 overflow-auto rounded-lg border">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-muted text-xs text-muted-foreground">
+                <tr>
+                  <th className="p-2">Record</th>
+                  <th className="p-2">Status</th>
+                  <th className="p-2">Match</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visiblePreviewItems.map((item) => (
+                  <tr key={item.recordIndex} className="border-t">
+                    <td className="p-2">{item.record?.title ?? item.rawTitle ?? `Record ${item.recordIndex + 1}`}</td>
+                    <td className="p-2">{item.valid ? "Valid" : item.errors.join("; ")}</td>
+                    <td className="p-2 capitalize">{item.match.kind}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {!visiblePreviewItems.length ? (
+            <p className="text-xs text-muted-foreground">No records match this preview filter.</p>
+          ) : null}
+          <Pagination
+            label="Reference preview"
+            page={previewPage}
+            totalPages={previewTotalPages}
+            onPage={setPreviewPage}
+          />
+          {preview.warnings.map((warning) => (
+            <p key={warning} className="text-xs text-amber-700 dark:text-amber-300">
+              {warning}
+            </p>
+          ))}
+          {commitImport.error ? <InlineError error={commitImport.error} /> : null}
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setPreview(undefined)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={commitImport.isPending || !csvMappingReady || unresolvedAmbiguous.length > 0}
+              onClick={() =>
+                commitImport.mutate({
+                  projectId: props.projectId,
+                  reviewId: props.reviewId,
+                  previewId: preview.previewId,
+                  mapping: preview.format === "csv" ? (mapping as ReferenceImportMapping) : undefined,
+                  resolutions: ambiguous.map((item) => ({
+                    recordIndex: item.recordIndex,
+                    action: resolutions[item.recordIndex]!,
+                    paperId:
+                      resolutions[item.recordIndex] === "merge"
+                        ? (mergeTargets[item.recordIndex] ?? item.match.paperId ?? item.match.candidatePaperIds[0])
+                        : undefined
+                  }))
+                })
+              }
+            >
+              {commitImport.isPending ? "Importing…" : "Commit import"}
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
+      <div className="mt-6">
+        <h3 className="font-medium">Discovery provenance</h3>
+        {batchesQuery.isPending ? (
+          <p className="mt-3 text-sm text-muted-foreground">Loading discovery batches…</p>
+        ) : null}
+        {batchesQuery.error ? (
+          <div className="mt-3">
+            <InlineError error={batchesQuery.error} />
+          </div>
+        ) : null}
+        <div className="mt-3 grid gap-3">
+          {(batchesQuery.data ?? []).map((batch) => (
+            <Card key={batch.id} className="gap-3 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h4 className="font-medium">{batch.label}</h4>
+                  <p className="text-xs text-muted-foreground">
+                    {batch.kind} · {batch.status}
+                  </p>
+                </div>
+                {!batch.historicalCountsAvailable ? (
+                  <Badge variant="outline">Historical duplicates unavailable</Badge>
+                ) : null}
+              </div>
+              <dl className="grid grid-cols-3 gap-2 text-center text-xs sm:grid-cols-6">
+                <Count label="Identified" value={batch.counts.identified} />
+                <Count label="Filtered" value={batch.counts.filtered} />
+                <Count label="Invalid" value={batch.counts.invalid} />
+                <Count label="Duplicates" value={batch.counts.duplicates} />
+                <Count label="Merged" value={batch.counts.merged} />
+                <Count label="New" value={batch.counts.newRecords} />
+              </dl>
+            </Card>
+          ))}
+          {!batchesQuery.isPending && !(batchesQuery.data ?? []).length ? (
+            <p className="rounded-lg border border-dashed p-5 text-sm text-muted-foreground">
+              No discovery batches yet.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ScreeningStage(props: {
+  reviewId: string;
+  projectId: string;
+  protocolRevisionId: string;
+  criteria: ReviewCriterion[];
+  stage: "title-abstract" | "full-text";
+  suggestions: Record<string, SuggestionSelection>;
+  runBusy: boolean;
+  onOpenArtifact?(artifactId: string, page?: number): void;
+  onStartRun(input: StartReviewRunRequest): void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [source, setSource] = useState<"all" | ReviewPaperSummary["source"]>("all");
+  const [yearFrom, setYearFrom] = useState("");
+  const [yearTo, setYearTo] = useState("");
+  const [decisionFilter, setDecisionFilter] = useState<"all" | "pending" | ScreeningDecisionValue>("all");
+  const [fullText, setFullText] = useState<"any" | "available" | "missing">("any");
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [exclusionCriterionId, setExclusionCriterionId] = useState("");
+  const [exclusionReason, setExclusionReason] = useState("");
+  const [decisionError, setDecisionError] = useState<string>();
+  const [decisionNotice, setDecisionNotice] = useState<string>();
+  const [fullTextFeedback, setFullTextFeedback] = useState<
+    Record<string, { kind: "success" | "error"; message: string }>
+  >({});
+
+  useEffect(() => {
+    setPage(1);
+    setSelected(new Set());
+    setExclusionCriterionId("");
+    setExclusionReason("");
+    setDecisionError(undefined);
+    setDecisionNotice(undefined);
+    setFullTextFeedback({});
+  }, [props.stage]);
+
+  const query = useMemo<ReviewPaperQuery>(
+    () => ({
+      reviewId: props.reviewId,
+      stage: props.stage,
+      search: search.trim() || undefined,
+      sources: source === "all" ? [] : [source],
+      yearFrom: reviewYear(yearFrom),
+      yearTo: reviewYear(yearTo),
+      decisions: decisionFilter === "all" ? [] : [decisionFilter],
+      fullText,
+      sort: "created",
+      direction: "asc",
+      page,
+      pageSize: 25
+    }),
+    [decisionFilter, fullText, page, props.reviewId, props.stage, search, source, yearFrom, yearTo]
+  );
+  const papersQuery = useQuery({
+    queryKey: ["review-papers", props.reviewId, query],
+    queryFn: () => api().listReviewPapers(query)
+  });
+  const projectPapersQuery = useQuery({
+    queryKey: ["project-paper-details", props.projectId],
+    queryFn: () => api().getProjectBundle!(props.projectId),
+    enabled: typeof api().getProjectBundle === "function"
+  });
+  const provenanceQuery = useQuery({
+    queryKey: ["review-discovery", props.reviewId],
+    queryFn: () => api().listDiscoveryBatches(props.reviewId)
+  });
+  const fullTextExclusionCriteria = useMemo(
+    () =>
+      props.criteria
+        .filter((criterion) => criterion.stage === "full-text" && criterion.type === "exclusion")
+        .sort((left, right) => left.order - right.order),
+    [props.criteria]
+  );
+  const paperDetails = useMemo(
+    () => new Map((projectPapersQuery.data?.papers ?? []).map((paper) => [paper.id, paper])),
+    [projectPapersQuery.data]
+  );
+  const batchLabels = useMemo(
+    () => new Map((provenanceQuery.data ?? []).map((batch) => [batch.id, batch.label])),
+    [provenanceQuery.data]
+  );
+
+  const saveDecision = useMutation({
+    mutationFn: (input: SaveScreeningDecisionRequest) => api().saveScreeningDecision(input),
+    onMutate: () => setDecisionNotice(undefined),
+    onSuccess: () => {
+      setDecisionError(undefined);
+      void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-summary", props.reviewId] });
+    }
+  });
+  const markForReview = useMutation({
+    mutationFn: (input: MarkReviewPapersForReviewRequest) => api().markReviewPapersForReview(input),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] })
+  });
+  const fullTextAction = useMutation({
+    mutationFn: (input: { paperId: string; mode: "fetch" | "attach" }) =>
+      input.mode === "fetch"
+        ? api().fetchReviewPaperFullText({
+            projectId: props.projectId,
+            reviewId: props.reviewId,
+            paperId: input.paperId
+          })
+        : api().attachReviewPaperPdf({ projectId: props.projectId, reviewId: props.reviewId, paperId: input.paperId }),
+    onMutate: (input) => {
+      setFullTextFeedback((current) => {
+        const next = { ...current };
+        delete next[input.paperId];
+        return next;
+      });
+    },
+    onSuccess: (result, input) => {
+      const action = input.mode === "fetch" ? "Full text" : "PDF";
+      const message = result.ok
+        ? `${action} ${input.mode === "fetch" ? "fetched and indexed" : "attached and indexed"}.${result.warning ? ` ${result.warning}` : ""}`
+        : input.mode === "attach"
+          ? "PDF attachment was cancelled."
+          : "Full-text retrieval did not add an indexed document.";
+      setFullTextFeedback((current) => ({
+        ...current,
+        [input.paperId]: { kind: result.ok ? "success" : "error", message }
+      }));
+      void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] });
+    },
+    onError: (error, input) => {
+      setFullTextFeedback((current) => ({
+        ...current,
+        [input.paperId]: {
+          kind: "error",
+          message: `${input.mode === "fetch" ? "Full-text retrieval" : "PDF attachment"} failed: ${errorMessage(error)}`
+        }
+      }));
+    }
+  });
+
+  const bulkDecision = useMutation({
+    mutationFn: async (input: { paperIds: string[]; decision: ScreeningDecisionValue }) => {
+      const results = await Promise.allSettled(
+        input.paperIds.map((paperId) =>
+          api().saveScreeningDecision({
+            reviewId: props.reviewId,
+            paperId,
+            stage: props.stage,
+            decision: input.decision,
+            protocolRevisionId: props.protocolRevisionId,
+            reasonCriterionId: input.decision === "exclude" && exclusionCriterionId ? exclusionCriterionId : undefined,
+            customReason: input.decision === "exclude" ? exclusionReason.trim() || undefined : undefined
+          })
+        )
+      );
+      return {
+        succeeded: input.paperIds.filter((_paperId, index) => results[index]?.status === "fulfilled"),
+        failed: input.paperIds.filter((_paperId, index) => results[index]?.status === "rejected")
+      };
+    },
+    onSuccess: ({ succeeded, failed }) => {
+      setSelected(new Set(failed));
+      setDecisionNotice(
+        failed.length
+          ? `${succeeded.length} decisions saved; ${failed.length} failed and remain selected.`
+          : `${succeeded.length} decisions saved.`
+      );
+      setDecisionError(failed.length ? `${failed.length} selected papers could not be updated.` : undefined);
+      void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-summary", props.reviewId] });
+    },
+    onError: (error) => setDecisionError(errorMessage(error))
+  });
+
+  const decide = (paper: ReviewPaperSummary, decision: ScreeningDecisionValue, suggestion?: ReviewRunItem): void => {
+    const reasonCriterionId =
+      decision === "exclude"
+        ? (suggestion?.suggestedReasonCriterionId ?? exclusionCriterionId) || undefined
+        : undefined;
+    const customReason =
+      decision === "exclude" ? (suggestion?.suggestedCustomReason ?? exclusionReason.trim()) || undefined : undefined;
+    if (props.stage === "full-text" && decision === "exclude" && !reasonCriterionId && !customReason) {
+      setDecisionError("Enter a full-text exclusion reason or select a protocol criterion before excluding a paper.");
+      return;
+    }
+    setDecisionError(undefined);
+    saveDecision.mutate({
+      reviewId: props.reviewId,
+      paperId: paper.paperId,
+      stage: props.stage,
+      decision,
+      protocolRevisionId: props.protocolRevisionId,
+      reasonCriterionId,
+      customReason,
+      runItemId: suggestion?.id
+    });
+  };
+
+  const decideSelected = (decision: ScreeningDecisionValue): void => {
+    if (!selected.size) return;
+    if (props.stage === "full-text" && decision === "exclude" && !exclusionCriterionId && !exclusionReason.trim()) {
+      setDecisionError("Enter a full-text exclusion reason or select a protocol criterion before excluding papers.");
+      return;
+    }
+    setDecisionError(undefined);
+    setDecisionNotice(undefined);
+    bulkDecision.mutate({ paperIds: [...selected], decision });
+  };
+
+  const handlePaperKey = (event: KeyboardEvent<HTMLElement>, paper: ReviewPaperSummary): void => {
+    if (event.altKey || event.ctrlKey || event.metaKey || isFormControl(event.target)) return;
+    const key = event.key.toLowerCase();
+    const decision = key === "i" ? "include" : key === "e" ? "exclude" : key === "u" ? "uncertain" : undefined;
+    if (!decision) return;
+    event.preventDefault();
+    decide(paper, decision);
+  };
+
+  const papers = papersQuery.data?.items ?? [];
+  const allSelected = papers.length > 0 && papers.every((paper) => selected.has(paper.paperId));
+
+  return (
+    <section aria-labelledby="screening-heading" className="mx-auto max-w-6xl">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="screening-heading" className="text-xl font-semibold">
+            {props.stage === "title-abstract" ? "Title and abstract screening" : "Full-text screening"}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Focus a paper row and press I, E, or U to include, exclude, or mark uncertain.
+          </p>
+        </div>
+        <Button
+          disabled={!selected.size || selected.size > MAX_REVIEW_BATCH_PAPERS || props.runBusy}
+          onClick={() => props.onStartRun({ reviewId: props.reviewId, stage: props.stage, paperIds: [...selected] })}
+        >
+          Suggest with AI ({selected.size})
+        </Button>
+      </div>
+
+      <Card className="mt-5 gap-3 p-4">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[minmax(180px,1fr)_160px_120px_120px_160px_160px]">
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Search papers
+            <Input
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value);
+                setPage(1);
+              }}
+              placeholder="Title, author, abstract…"
+            />
+          </label>
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Source
+            <select
+              className="h-8 rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+              value={source}
+              onChange={(event) => {
+                setSource(event.target.value as typeof source);
+                setPage(1);
+              }}
+            >
+              <option value="all">All sources</option>
+              {paperSourceFilters.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Year from
+            <Input
+              type="number"
+              min={1500}
+              max={3000}
+              value={yearFrom}
+              onChange={(event) => {
+                setYearFrom(event.target.value);
+                setPage(1);
+              }}
+              placeholder="Any"
+            />
+          </label>
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Year to
+            <Input
+              type="number"
+              min={1500}
+              max={3000}
+              value={yearTo}
+              onChange={(event) => {
+                setYearTo(event.target.value);
+                setPage(1);
+              }}
+              placeholder="Any"
+            />
+          </label>
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Decision
+            <select
+              className="h-8 rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+              value={decisionFilter}
+              onChange={(event) => {
+                setDecisionFilter(event.target.value as typeof decisionFilter);
+                setPage(1);
+              }}
+            >
+              <option value="all">All decisions</option>
+              <option value="pending">Pending</option>
+              <option value="include">Included</option>
+              <option value="exclude">Excluded</option>
+              <option value="uncertain">Uncertain</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Full text
+            <select
+              className="h-8 rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+              value={fullText}
+              onChange={(event) => {
+                setFullText(event.target.value as typeof fullText);
+                setPage(1);
+              }}
+            >
+              <option value="any">Any availability</option>
+              <option value="available">Available</option>
+              <option value="missing">Missing</option>
+            </select>
+          </label>
+        </div>
+        {props.stage === "full-text" ? (
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="grid gap-1 text-xs text-muted-foreground">
+              Full-text exclusion criterion
+              <select
+                className="h-8 rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+                value={exclusionCriterionId}
+                onChange={(event) => setExclusionCriterionId(event.target.value)}
+              >
+                <option value="">No protocol criterion selected</option>
+                {fullTextExclusionCriteria.map((criterion) => (
+                  <option key={criterion.id} value={criterion.id}>
+                    {criterion.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="grid gap-1 text-xs text-muted-foreground">
+              Full-text exclusion reason <span>Custom reason (optional when a criterion is selected)</span>
+              <Input
+                value={exclusionReason}
+                onChange={(event) => setExclusionReason(event.target.value)}
+                placeholder="Enter a custom reason"
+              />
+            </label>
+          </div>
+        ) : null}
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+          <label className="flex items-center gap-2">
+            <Checkbox
+              checked={allSelected}
+              onCheckedChange={(checked) =>
+                setSelected(
+                  checked ? new Set(papers.slice(0, MAX_REVIEW_BATCH_PAPERS).map((paper) => paper.paperId)) : new Set()
+                )
+              }
+            />{" "}
+            Select this page
+          </label>
+          {papersQuery.data ? (
+            <span>
+              {papersQuery.data.total.toLocaleString()} papers · {papersQuery.data.counts.pending} pending
+            </span>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2" aria-label="Bulk screening actions">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!selected.size || bulkDecision.isPending}
+            onClick={() => decideSelected("include")}
+          >
+            Include selected ({selected.size})
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!selected.size || bulkDecision.isPending}
+            onClick={() => decideSelected("exclude")}
+          >
+            Exclude selected ({selected.size})
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!selected.size || bulkDecision.isPending}
+            onClick={() => decideSelected("uncertain")}
+          >
+            Uncertain selected ({selected.size})
+          </Button>
+        </div>
+      </Card>
+
+      {decisionError ? (
+        <p role="alert" className="mt-3 text-sm text-destructive">
+          {decisionError}
+        </p>
+      ) : null}
+      {decisionNotice ? (
+        <p role="status" className="mt-3 text-sm text-foreground">
+          {decisionNotice}
+        </p>
+      ) : null}
+      {saveDecision.error ? (
+        <div className="mt-3">
+          <InlineError error={saveDecision.error} />
+        </div>
+      ) : null}
+      {papersQuery.isPending ? <p className="mt-5 text-sm text-muted-foreground">Loading screening queue…</p> : null}
+      {papersQuery.error ? (
+        <div className="mt-5">
+          <InlineError error={papersQuery.error} />
+        </div>
+      ) : null}
+
+      <div className="mt-4 grid gap-3">
+        {papers.map((paper) => {
+          const decision = props.stage === "title-abstract" ? paper.titleAbstractDecision : paper.fullTextDecision;
+          const candidateSuggestion = props.suggestions[suggestionKey(props.stage, paper.paperId)]?.item;
+          const suggestion = decision?.runItemId === candidateSuggestion?.id ? undefined : candidateSuggestion;
+          const suggestionStale = suggestion?.stale ?? paper.aiSuggestionStale;
+          const projectPaper = paperDetails.get(paper.paperId);
+          const doi = paper.doi ?? projectPaper?.doi;
+          const paperUrl = projectPaper?.url;
+          const fullAbstract = projectPaper?.abstract ?? paper.abstract;
+          const provenance = paper.discoveryBatchIds.map((batchId) => batchLabels.get(batchId) ?? batchId);
+          return (
+            <Card
+              key={paper.paperId}
+              tabIndex={0}
+              onKeyDown={(event) => handlePaperKey(event, paper)}
+              className="gap-3 p-4 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={`Screen ${paper.title}`}
+            >
+              <div className="flex items-start gap-3">
+                <Checkbox
+                  aria-label={`Select ${paper.title}`}
+                  checked={selected.has(paper.paperId)}
+                  onCheckedChange={(checked) =>
+                    setSelected((current) => toggledSet(current, paper.paperId, checked === true))
+                  }
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <h3 className="font-medium leading-5">{paper.title}</h3>
+                    <div className="flex flex-wrap gap-1">
+                      <Badge variant={decision ? "secondary" : "outline"}>{decision?.decision ?? "pending"}</Badge>
+                      <Badge variant={paper.hasFullText ? "secondary" : "outline"}>
+                        {paper.hasFullText ? "Full text" : "Metadata only"}
+                      </Badge>
+                      {paper.needsReReview ? <Badge variant="outline">Needs re-review</Badge> : null}
+                      {suggestionStale ? <Badge variant="outline">AI suggestion stale</Badge> : null}
+                    </div>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {paper.authors.slice(0, 3).join(", ") || "Unknown authors"}
+                    {paper.year ? ` · ${paper.year}` : ""}
+                    {paper.venue ? ` · ${paper.venue}` : ""}
+                  </p>
+                  {paper.abstract ? (
+                    <p className="mt-2 line-clamp-3 text-sm leading-6 text-muted-foreground">{paper.abstract}</p>
+                  ) : (
+                    <p className="mt-2 text-sm italic text-muted-foreground">No abstract available.</p>
+                  )}
+                  <details
+                    className="mt-3 rounded-lg border bg-muted/20 p-3"
+                    data-testid={`paper-details-${paper.paperId}`}
+                  >
+                    <summary className="cursor-pointer text-sm font-medium">View paper details</summary>
+                    <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                      <div>
+                        <dt className="text-xs font-medium text-muted-foreground">DOI</dt>
+                        <dd className="mt-1 break-words">
+                          {doi ? (
+                            <a
+                              className="underline underline-offset-2"
+                              href={`https://doi.org/${encodeURIComponent(doi)}`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {doi}
+                            </a>
+                          ) : (
+                            "Not available"
+                          )}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium text-muted-foreground">URL</dt>
+                        <dd className="mt-1 break-all">
+                          {paperUrl ? (
+                            <a
+                              className="underline underline-offset-2"
+                              href={paperUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {paperUrl}
+                            </a>
+                          ) : (
+                            "Not available"
+                          )}
+                        </dd>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <dt className="text-xs font-medium text-muted-foreground">Full abstract</dt>
+                        <dd className="mt-1 whitespace-pre-wrap leading-6">
+                          {fullAbstract ?? "No abstract available."}
+                        </dd>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <dt className="text-xs font-medium text-muted-foreground">Discovery provenance</dt>
+                        <dd className="mt-1">
+                          Source: {sourceLabel(paper.source)}
+                          {provenance.length ? ` · Batches: ${provenance.join(", ")}` : " · No batch recorded"}
+                        </dd>
+                      </div>
+                    </dl>
+                  </details>
+                </div>
+              </div>
+
+              {suggestion?.suggestedDecision ? (
+                <div className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span>
+                      <strong>AI suggestion:</strong> {suggestion.suggestedDecision}
+                    </span>
+                    <Badge variant="outline">Unconfirmed</Badge>
+                  </div>
+                  {suggestion.rationale ? (
+                    <p className="mt-1 text-xs text-muted-foreground">{suggestion.rationale}</p>
+                  ) : null}
+                  {suggestion.criterionAssessments?.length ? (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-xs font-medium">
+                        Criterion assessments ({suggestion.criterionAssessments.length})
+                      </summary>
+                      <ul className="mt-2 grid gap-1 text-xs text-muted-foreground">
+                        {suggestion.criterionAssessments.map((assessment) => (
+                          <li key={assessment.criterionId}>
+                            <strong>{assessment.assessment}:</strong> {assessment.explanation}
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
+                  ) : null}
+                  {suggestion.evidence.length ? (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-xs font-medium">
+                        Evidence ({suggestion.evidence.length})
+                      </summary>
+                      <div className="mt-2 grid gap-2">
+                        {suggestion.evidence.map((evidence) => (
+                          <div key={evidence.id} className="rounded-md border bg-background p-2">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <span className="text-xs font-medium">
+                                {evidence.evidenceId} · {evidence.locator ?? evidence.title}
+                              </span>
+                              {evidence.artifactId ? (
+                                <Button
+                                  size="xs"
+                                  variant="ghost"
+                                  onClick={() => props.onOpenArtifact?.(evidence.artifactId!, evidence.page)}
+                                >
+                                  Open source{evidence.page ? ` · p. ${evidence.page}` : ""}
+                                </Button>
+                              ) : null}
+                            </div>
+                            <blockquote className="mt-1 border-l-2 pl-2 text-xs text-muted-foreground">
+                              “{evidence.excerpt}”
+                            </blockquote>
+                          </div>
+                        ))}
+                      </div>
+                    </details>
+                  ) : null}
+                  <Button
+                    className="mt-2"
+                    size="sm"
+                    variant="outline"
+                    disabled={suggestion.stale}
+                    onClick={() => decide(paper, suggestion.suggestedDecision!, suggestion)}
+                  >
+                    {suggestion.stale ? "Rerun required for current protocol" : "Confirm suggestion"}
+                  </Button>
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Include ${paper.title}`}
+                  onClick={() => decide(paper, "include")}
+                >
+                  Include <kbd className="text-[10px] text-muted-foreground">I</kbd>
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Exclude ${paper.title}`}
+                  onClick={() => decide(paper, "exclude")}
+                >
+                  Exclude <kbd className="text-[10px] text-muted-foreground">E</kbd>
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Uncertain ${paper.title}`}
+                  onClick={() => decide(paper, "uncertain")}
+                >
+                  Uncertain <kbd className="text-[10px] text-muted-foreground">U</kbd>
+                </Button>
+                {decision ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={markForReview.isPending}
+                    onClick={() =>
+                      markForReview.mutate({ reviewId: props.reviewId, paperIds: [paper.paperId], stage: props.stage })
+                    }
+                  >
+                    Mark for re-review
+                  </Button>
+                ) : null}
+                {!paper.hasFullText ? (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={fullTextAction.isPending}
+                      onClick={() => fullTextAction.mutate({ paperId: paper.paperId, mode: "fetch" })}
+                    >
+                      Fetch full text
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={fullTextAction.isPending}
+                      onClick={() => fullTextAction.mutate({ paperId: paper.paperId, mode: "attach" })}
+                    >
+                      Attach PDF
+                    </Button>
+                  </>
+                ) : null}
+              </div>
+              {fullTextFeedback[paper.paperId] ? (
+                <p
+                  role={fullTextFeedback[paper.paperId]?.kind === "error" ? "alert" : "status"}
+                  className={cn(
+                    "rounded-lg px-3 py-2 text-sm",
+                    fullTextFeedback[paper.paperId]?.kind === "error"
+                      ? "bg-destructive/10 text-destructive"
+                      : "bg-primary/10 text-foreground"
+                  )}
+                >
+                  {fullTextFeedback[paper.paperId]?.message}
+                </p>
+              ) : null}
+            </Card>
+          );
+        })}
+        {!papersQuery.isPending && !papers.length ? (
+          <p className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+            No papers match this stage and filter.
+          </p>
+        ) : null}
+      </div>
+      <Pagination
+        page={papersQuery.data?.page ?? page}
+        totalPages={papersQuery.data?.totalPages ?? 0}
+        onPage={setPage}
+      />
+    </section>
+  );
+}
+
+function ExtractionStage(props: {
+  reviewId: string;
+  suggestions: Record<string, SuggestionSelection>;
+  runBusy: boolean;
+  onOpenArtifact?(artifactId: string, page?: number): void;
+  onStartRun(input: StartReviewRunRequest): void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const [fieldDraft, setFieldDraft] = useState<{
+    id?: string;
+    revision?: number;
+    name: string;
+    type: ExtractionFieldType;
+    options: string;
+  }>({ name: "", type: "short-text", options: "" });
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const fieldsQuery = useQuery({
+    queryKey: ["review-fields", props.reviewId],
+    queryFn: () => api().listExtractionFields(props.reviewId)
+  });
+  const paperQuery = useMemo<ReviewPaperQuery>(
+    () => ({
+      reviewId: props.reviewId,
+      stage: "extraction",
+      search: search.trim() || undefined,
+      sources: [],
+      decisions: [],
+      fullText: "any",
+      sort: "created",
+      direction: "asc",
+      page,
+      pageSize: 25
+    }),
+    [page, props.reviewId, search]
+  );
+  const papersQuery = useQuery({
+    queryKey: ["review-papers", props.reviewId, paperQuery],
+    queryFn: () => api().listReviewPapers(paperQuery)
+  });
+  const paperIds = (papersQuery.data?.items ?? []).map((paper) => paper.paperId);
+  const valuesQuery = useQuery({
+    queryKey: ["review-values", props.reviewId, paperIds],
+    queryFn: () => api().listExtractionValues({ reviewId: props.reviewId, paperIds }),
+    enabled: paperIds.length > 0
+  });
+  const evidenceIds = [...new Set((valuesQuery.data ?? []).flatMap((value) => value.evidenceIds))];
+  const evidenceQuery = useQuery({
+    queryKey: ["review-evidence", props.reviewId, evidenceIds],
+    queryFn: () => api().listReviewEvidence({ reviewId: props.reviewId, evidenceIds }),
+    enabled: evidenceIds.length > 0
+  });
+
+  const upsertField = useMutation({
+    mutationFn: (input: UpsertExtractionFieldRequest) => api().upsertExtractionField(input),
+    onSuccess: () => {
+      setFieldDraft({ name: "", type: "short-text", options: "" });
+      void queryClient.invalidateQueries({ queryKey: ["review-fields", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] });
+    }
+  });
+  const reorderFields = useMutation({
+    mutationFn: (input: ReorderExtractionFieldsRequest) => api().reorderExtractionFields(input),
+    onSuccess: (nextFields) => queryClient.setQueryData(["review-fields", props.reviewId], nextFields)
+  });
+  const saveValue = useMutation({
+    mutationFn: (input: SaveExtractionValueRequest) => api().saveExtractionValue(input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["review-values", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-papers", props.reviewId] });
+      void queryClient.invalidateQueries({ queryKey: ["review-summary", props.reviewId] });
+    }
+  });
+
+  const fields = fieldsQuery.data ?? [];
+  const papers = papersQuery.data?.items ?? [];
+  const values = valuesQuery.data ?? [];
+  const valuesByCell = new Map(values.map((value) => [`${value.paperId}:${value.fieldId}`, value]));
+  const evidenceById = new Map((evidenceQuery.data ?? []).map((evidence) => [evidence.id, evidence]));
+  const isSelect = fieldDraft.type === "single-select" || fieldDraft.type === "multi-select";
+
+  const submitField = (): void => {
+    upsertField.mutate({
+      reviewId: props.reviewId,
+      fieldId: fieldDraft.id,
+      expectedRevision: fieldDraft.revision,
+      name: fieldDraft.name,
+      type: fieldDraft.type,
+      options: isSelect
+        ? fieldDraft.options
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean)
+        : [],
+      order: fieldDraft.id ? (fields.find((field) => field.id === fieldDraft.id)?.order ?? 0) : fields.length
+    });
+  };
+  const moveField = (fieldId: string, offset: -1 | 1): void => {
+    const fieldIds = fields.map((field) => field.id);
+    const from = fieldIds.indexOf(fieldId);
+    const to = from + offset;
+    if (from < 0 || to < 0 || to >= fieldIds.length) return;
+    [fieldIds[from], fieldIds[to]] = [fieldIds[to], fieldIds[from]];
+    reorderFields.mutate({ reviewId: props.reviewId, fieldIds });
+  };
+
+  return (
+    <section aria-labelledby="extract-heading" className="mx-auto max-w-full">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="extract-heading" className="text-xl font-semibold">
+            Evidence extraction
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Only full-text inclusions appear here. AI suggestions require evidence before confirmation.
+          </p>
+        </div>
+        <Button
+          disabled={!selected.size || !fields.length || props.runBusy}
+          onClick={() =>
+            props.onStartRun({
+              reviewId: props.reviewId,
+              stage: "extraction",
+              paperIds: [...selected],
+              fieldIds: fields.map((field) => field.id)
+            })
+          }
+        >
+          Suggest values with AI ({selected.size})
+        </Button>
+      </div>
+
+      <Card className="mt-5 gap-3 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-medium">Extraction fields</h3>
+          <span className="text-xs text-muted-foreground">
+            {fields.length}/{MAX_EXTRACTION_FIELDS}
+          </span>
+        </div>
+        <div className="grid gap-2 md:grid-cols-[minmax(160px,1fr)_180px_minmax(180px,1fr)_auto]">
+          <Input
+            aria-label="Field name"
+            value={fieldDraft.name}
+            onChange={(event) => setFieldDraft((current) => ({ ...current, name: event.target.value }))}
+            placeholder="Field name"
+          />
+          <select
+            aria-label="Field type"
+            className="h-8 rounded-lg border border-input bg-background px-2 text-sm"
+            value={fieldDraft.type}
+            onChange={(event) =>
+              setFieldDraft((current) => ({ ...current, type: event.target.value as ExtractionFieldType }))
+            }
+          >
+            {(
+              ["short-text", "long-text", "number", "boolean", "single-select", "multi-select"] as ExtractionFieldType[]
+            ).map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+          <Input
+            aria-label="Field options"
+            disabled={!isSelect}
+            value={fieldDraft.options}
+            onChange={(event) => setFieldDraft((current) => ({ ...current, options: event.target.value }))}
+            placeholder={isSelect ? "Options separated by commas" : "No options for this type"}
+          />
+          <div className="flex gap-2">
+            <Button
+              disabled={
+                !fieldDraft.name.trim() ||
+                upsertField.isPending ||
+                (!fieldDraft.id && fields.length >= MAX_EXTRACTION_FIELDS)
+              }
+              onClick={submitField}
+            >
+              {fieldDraft.id ? "Save field" : "Add field"}
+            </Button>
+            {fieldDraft.id ? (
+              <Button variant="ghost" onClick={() => setFieldDraft({ name: "", type: "short-text", options: "" })}>
+                Cancel
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        {upsertField.error ? <InlineError error={upsertField.error} /> : null}
+        <div className="flex flex-wrap gap-2">
+          {fields.map((field, index) => (
+            <div key={field.id} className="flex items-center rounded-lg border">
+              <button
+                type="button"
+                className="px-3 py-1.5 text-left text-xs hover:bg-muted"
+                onClick={() =>
+                  setFieldDraft({
+                    id: field.id,
+                    revision: field.revision,
+                    name: field.name,
+                    type: field.type,
+                    options: field.options.join(", ")
+                  })
+                }
+              >
+                <strong>{field.name}</strong>
+                <span className="ml-1 text-muted-foreground">
+                  {field.type} · v{field.revision}
+                </span>
+              </button>
+              <Button
+                size="xs"
+                variant="ghost"
+                aria-label={`Move ${field.name} earlier`}
+                disabled={index === 0 || reorderFields.isPending}
+                onClick={() => moveField(field.id, -1)}
+              >
+                ↑
+              </Button>
+              <Button
+                size="xs"
+                variant="ghost"
+                aria-label={`Move ${field.name} later`}
+                disabled={index === fields.length - 1 || reorderFields.isPending}
+                onClick={() => moveField(field.id, 1)}
+              >
+                ↓
+              </Button>
+            </div>
+          ))}
+        </div>
+        {reorderFields.error ? <InlineError error={reorderFields.error} /> : null}
+      </Card>
+
+      <div className="mt-5 flex flex-wrap items-end justify-between gap-3">
+        <label className="grid min-w-64 gap-1 text-xs text-muted-foreground">
+          Search included papers
+          <Input
+            value={search}
+            onChange={(event) => {
+              setSearch(event.target.value);
+              setPage(1);
+            }}
+          />
+        </label>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Checkbox
+            checked={papers.length > 0 && papers.every((paper) => selected.has(paper.paperId))}
+            onCheckedChange={(checked) =>
+              setSelected(checked ? new Set(papers.map((paper) => paper.paperId)) : new Set())
+            }
+          />{" "}
+          Select page for AI
+        </label>
+      </div>
+
+      <div className="mt-3 overflow-auto rounded-xl border">
+        <table className="min-w-full border-collapse text-left text-sm">
+          <thead className="sticky top-0 z-10 bg-muted">
+            <tr>
+              <th className="min-w-64 p-3">Included paper</th>
+              {fields.map((field) => (
+                <th key={field.id} className="min-w-56 border-l p-3">
+                  {field.name}
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">v{field.revision}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {papers.map((paper) => (
+              <tr key={paper.paperId} className="border-t align-top">
+                <th className="p-3 font-normal">
+                  <label className="flex items-start gap-2">
+                    <Checkbox
+                      aria-label={`Select ${paper.title} for extraction`}
+                      checked={selected.has(paper.paperId)}
+                      onCheckedChange={(checked) =>
+                        setSelected((current) => toggledSet(current, paper.paperId, checked === true))
+                      }
+                    />
+                    <span>
+                      <strong className="block font-medium">{paper.title}</strong>
+                      <span className="mt-1 block text-xs text-muted-foreground">
+                        {paper.extractionProgress.confirmed}/{paper.extractionProgress.total} confirmed
+                      </span>
+                      {props.suggestions[suggestionKey("extraction", paper.paperId)]?.item.extractionSuggestions
+                        .length ? (
+                        <Badge className="mt-2" variant="outline">
+                          New AI suggestions
+                        </Badge>
+                      ) : null}
+                    </span>
+                  </label>
+                </th>
+                {fields.map((field) => {
+                  const value = valuesByCell.get(`${paper.paperId}:${field.id}`);
+                  return (
+                    <td key={field.id} className="border-l p-3">
+                      <ExtractionCell
+                        field={field}
+                        value={value}
+                        evidence={(value?.evidenceIds ?? []).flatMap((evidenceId) => {
+                          const evidence = evidenceById.get(evidenceId);
+                          return evidence ? [evidence] : [];
+                        })}
+                        busy={saveValue.isPending}
+                        onOpenArtifact={props.onOpenArtifact}
+                        onSave={(nextValue, status) =>
+                          saveValue.mutate({
+                            reviewId: props.reviewId,
+                            paperId: paper.paperId,
+                            fieldId: field.id,
+                            expectedFieldRevision: field.revision,
+                            value: nextValue,
+                            status,
+                            evidenceIds: value?.evidenceIds ?? []
+                          })
+                        }
+                      />
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {!fields.length ? (
+          <p className="p-8 text-center text-sm text-muted-foreground">
+            Add an extraction field to build the evidence matrix.
+          </p>
+        ) : null}
+        {fields.length > 0 && !papersQuery.isPending && !papers.length ? (
+          <p className="p-8 text-center text-sm text-muted-foreground">
+            No full-text inclusions are ready for extraction.
+          </p>
+        ) : null}
+      </div>
+      {saveValue.error ? (
+        <div className="mt-3">
+          <InlineError error={saveValue.error} />
+        </div>
+      ) : null}
+      <Pagination
+        page={papersQuery.data?.page ?? page}
+        totalPages={papersQuery.data?.totalPages ?? 0}
+        onPage={setPage}
+      />
+    </section>
+  );
+}
+
+function ExtractionCell(props: {
+  field: ExtractionField;
+  value?: ExtractionValue;
+  evidence: ReviewEvidence[];
+  busy: boolean;
+  onOpenArtifact?(artifactId: string, page?: number): void;
+  onSave(value: ExtractionPrimitiveValue, status: SaveExtractionValueRequest["status"]): void;
+}): JSX.Element {
+  const [draft, setDraft] = useState(() => extractionDraft(props.value?.value));
+  useEffect(() => setDraft(extractionDraft(props.value?.value)), [props.value?.updatedAt, props.value?.value]);
+  const parsed = parseExtractionDraft(draft, props.field.type);
+  const blank = isBlankExtractionValue(parsed);
+  const suggestedNotFound =
+    props.value?.origin === "ai" && props.value.status === "suggested" && props.value.value === null;
+  const unclearSuggestion =
+    props.value?.origin === "ai" && props.value.status === "needs-review" && props.value.value === null;
+  return (
+    <div className="grid gap-2">
+      <ExtractionInput field={props.field} draft={draft} onDraft={setDraft} />
+      <div className="flex flex-wrap items-center gap-1">
+        {props.value ? (
+          <Badge variant={props.value.status === "confirmed" ? "secondary" : "outline"}>
+            {suggestedNotFound
+              ? "Suggested: not found"
+              : unclearSuggestion
+                ? "Needs review: unclear"
+                : props.value.status}
+          </Badge>
+        ) : (
+          <Badge variant="outline">Empty</Badge>
+        )}
+        {props.value?.origin === "manual" && !props.value.evidenceIds.length ? (
+          <span className="text-[10px] text-muted-foreground">Manual—no linked evidence</span>
+        ) : null}
+        {props.value?.evidenceIds.length ? (
+          <span className="text-[10px] text-muted-foreground">{props.value.evidenceIds.length} evidence</span>
+        ) : null}
+      </div>
+      {props.evidence.length ? (
+        <details className="rounded-md border bg-muted/20 p-2">
+          <summary className="cursor-pointer text-xs font-medium">Evidence ({props.evidence.length})</summary>
+          <div className="mt-2 grid gap-2">
+            {props.evidence.map((evidence) => (
+              <div key={evidence.id} className="text-xs">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span>{evidence.locator ?? evidence.title}</span>
+                  {evidence.artifactId ? (
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      onClick={() => props.onOpenArtifact?.(evidence.artifactId!, evidence.page)}
+                    >
+                      Open source{evidence.page ? ` · p. ${evidence.page}` : ""}
+                    </Button>
+                  ) : null}
+                </div>
+                <blockquote className="mt-1 line-clamp-4 border-l-2 pl-2 text-muted-foreground">
+                  “{evidence.excerpt}”
+                </blockquote>
+              </div>
+            ))}
+          </div>
+        </details>
+      ) : null}
+      <div className="flex gap-1">
+        <Button size="xs" disabled={props.busy || blank} onClick={() => props.onSave(parsed, "confirmed")}>
+          {props.value?.status === "suggested" ? "Confirm" : "Save"}
+        </Button>
+        <Button size="xs" variant="ghost" disabled={props.busy} onClick={() => props.onSave(null, "not-found")}>
+          {suggestedNotFound || unclearSuggestion ? "Accept not found" : "Not found"}
+        </Button>
+        {props.value?.origin === "ai" &&
+        (props.value.status === "suggested" || props.value.status === "needs-review") ? (
+          <Button size="xs" variant="ghost" disabled={props.busy} onClick={() => props.onSave(parsed, "rejected")}>
+            Reject
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ExtractionInput(props: { field: ExtractionField; draft: string; onDraft(value: string): void }): JSX.Element {
+  if (props.field.type === "long-text")
+    return (
+      <Textarea
+        aria-label={props.field.name}
+        value={props.draft}
+        onChange={(event) => props.onDraft(event.target.value)}
+      />
+    );
+  if (props.field.type === "boolean")
+    return (
+      <select
+        aria-label={props.field.name}
+        className="h-8 w-full rounded-lg border border-input bg-background px-2"
+        value={props.draft}
+        onChange={(event) => props.onDraft(event.target.value)}
+      >
+        <option value="">Not set</option>
+        <option value="true">Yes</option>
+        <option value="false">No</option>
+      </select>
+    );
+  if (props.field.type === "single-select")
+    return (
+      <select
+        aria-label={props.field.name}
+        className="h-8 w-full rounded-lg border border-input bg-background px-2"
+        value={props.draft}
+        onChange={(event) => props.onDraft(event.target.value)}
+      >
+        <option value="">Not set</option>
+        {props.field.options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    );
+  return (
+    <Input
+      aria-label={props.field.name}
+      type={props.field.type === "number" ? "number" : "text"}
+      value={props.draft}
+      onChange={(event) => props.onDraft(event.target.value)}
+      placeholder={props.field.type === "multi-select" ? "Values separated by commas" : undefined}
+    />
+  );
+}
+
+function SummaryStage(props: { reviewId: string }): JSX.Element {
+  const summaryQuery = useQuery({
+    queryKey: ["review-summary", props.reviewId],
+    queryFn: () => api().getReviewSummary(props.reviewId)
+  });
+  const exportMutation = useMutation({ mutationFn: () => api().exportReview({ reviewId: props.reviewId }) });
+  const summary = summaryQuery.data;
+  return (
+    <section aria-labelledby="summary-heading" className="mx-auto max-w-5xl">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="summary-heading" className="text-xl font-semibold">
+            Review summary
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Deterministic counts and exports derived from recorded provenance and human decisions.
+          </p>
+        </div>
+        <Button disabled={!summary || exportMutation.isPending} onClick={() => exportMutation.mutate()}>
+          {exportMutation.isPending ? "Exporting…" : "Export review package"}
+        </Button>
+      </div>
+      {summaryQuery.isPending ? <p className="mt-5 text-sm text-muted-foreground">Calculating review flow…</p> : null}
+      {summaryQuery.error ? (
+        <div className="mt-5">
+          <InlineError error={summaryQuery.error} />
+        </div>
+      ) : null}
+      {exportMutation.error ? (
+        <div className="mt-5">
+          <InlineError error={exportMutation.error} />
+        </div>
+      ) : null}
+      {exportMutation.data?.path ? (
+        <p role="status" className="mt-3 text-sm">
+          Exported to {exportMutation.data.path}
+        </p>
+      ) : null}
+      {summary ? (
+        <div className="mt-5 grid gap-5 lg:grid-cols-2">
+          <Card className="gap-3 p-5">
+            <h3 className="font-medium">Review flow counts</h3>
+            <table className="w-full text-sm">
+              <tbody>
+                <SummaryRow label="Records identified" value={summary.identifiedRecords} />
+                <SummaryRow label="Filtered before screening" value={summary.filteredRecords} />
+                <SummaryRow label="Invalid records" value={summary.invalidRecords} />
+                <SummaryRow label="Duplicate records" value={summary.duplicateRecords} />
+                <SummaryRow label="Unique records screened" value={summary.uniqueRecordsScreened} />
+                <SummaryRow label="Title/abstract exclusions" value={summary.titleAbstractExclusions} />
+                <SummaryRow label="Full texts sought" value={summary.fullTextsSought} />
+                <SummaryRow label="Full texts unavailable" value={summary.fullTextsUnavailable} />
+                {Object.entries(summary.fullTextExclusionsByReason)
+                  .sort(([left], [right]) => left.localeCompare(right))
+                  .map(([reason, count]) => (
+                    <SummaryRow key={reason} label={`Full-text exclusions — ${reason}`} value={count} />
+                  ))}
+                <SummaryRow label="Included papers" value={summary.includedPapers} />
+              </tbody>
+            </table>
+            {!summary.historicalCountsAvailable ? (
+              <p className="text-xs text-amber-700 dark:text-amber-300">
+                Historical duplicate counts are unavailable for papers that predate review activation.
+              </p>
+            ) : null}
+          </Card>
+          <FlowDiagram summary={summary} />
+          <Card className="gap-3 p-5 lg:col-span-2">
+            <h3 className="font-medium">Extraction completion</h3>
+            <div className="h-2 overflow-hidden rounded-full bg-muted">
+              <div className="h-full bg-primary" style={{ width: `${summary.extraction.completionPercent}%` }} />
+            </div>
+            <p className="text-sm">
+              {summary.extraction.completionPercent}% complete · {summary.extraction.confirmedCells} confirmed ·{" "}
+              {summary.extraction.notFoundCells} not found · {summary.extraction.needsReviewCells} need review
+            </p>
+          </Card>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function FlowDiagram({ summary }: { summary: ReviewFlowSummary }): JSX.Element {
+  return (
+    <Card className="gap-3 p-5">
+      <h3 className="font-medium">Review flow</h3>
+      <svg
+        role="img"
+        aria-labelledby="review-flow-title review-flow-description"
+        viewBox="0 0 520 330"
+        className="w-full"
+      >
+        <title id="review-flow-title">Review flow</title>
+        <desc id="review-flow-description">
+          Flow from identified records through screening to included studies. This is not a formal PRISMA 2020 diagram.
+        </desc>
+        <FlowBox y={10} label="Records identified" value={summary.identifiedRecords} />
+        <FlowArrow y={75} />
+        <FlowBox y={95} label="Unique records screened" value={summary.uniqueRecordsScreened} />
+        <FlowArrow y={160} />
+        <FlowBox y={180} label="Full texts sought" value={summary.fullTextsSought} />
+        <FlowArrow y={245} />
+        <FlowBox y={265} label="Papers included" value={summary.includedPapers} />
+      </svg>
+      <p className="text-xs text-muted-foreground">Review flow — not a claim of formal PRISMA 2020 compliance.</p>
+    </Card>
+  );
+}
+
+function FlowBox(props: { y: number; label: string; value: number }): JSX.Element {
+  return (
+    <g>
+      <rect x="90" y={props.y} width="340" height="50" rx="10" className="fill-muted stroke-border" />
+      <text x="110" y={props.y + 30} className="fill-foreground text-[14px]">
+        {props.label}
+      </text>
+      <text x="405" y={props.y + 30} textAnchor="end" className="fill-foreground text-[16px] font-semibold">
+        {props.value}
+      </text>
+    </g>
+  );
+}
+function FlowArrow({ y }: { y: number }): JSX.Element {
+  return <path d={`M260 ${y}v14m-5-5 5 5 5-5`} className="fill-none stroke-muted-foreground" />;
+}
+
+function RunStatus(props: {
+  run?: ReviewRun;
+  progress: { completed: number; failed: number; cancelled: number; total: number };
+  onCancel(): void;
+  onRetry(): void;
+}): JSX.Element {
+  if (!props.run) return <Badge variant="outline">AI assistance is advisory</Badge>;
+  const active = props.run.status === "queued" || props.run.status === "running";
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2 text-xs">
+      <Badge variant={active ? "secondary" : "outline"}>
+        {props.run.stage} · {props.run.status}
+      </Badge>
+      <span className="text-muted-foreground">
+        {props.run.provider} · {props.run.model}
+      </span>
+      {props.progress.total ? (
+        <span className="text-muted-foreground">
+          {props.progress.completed}/{props.progress.total} complete
+          {props.progress.failed ? ` · ${props.progress.failed} failed` : ""}
+        </span>
+      ) : null}
+      {props.run.error ? <span className="max-w-72 text-right text-destructive">{props.run.error}</span> : null}
+      {active ? (
+        <Button size="xs" variant="outline" onClick={props.onCancel}>
+          Stop
+        </Button>
+      ) : null}
+      {props.run.status === "failed" || props.run.status === "cancelled" || props.run.status === "partial" ? (
+        <Button size="xs" variant="outline" onClick={props.onRetry}>
+          Retry unfinished
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function Pagination(props: {
+  label?: string;
+  page: number;
+  totalPages: number;
+  onPage(page: number): void;
+}): JSX.Element {
+  if (props.totalPages <= 1) return <></>;
+  return (
+    <nav aria-label={props.label ?? "Pagination"} className="mt-4 flex items-center justify-center gap-3">
+      <Button
+        size="sm"
+        variant="outline"
+        aria-label={props.label ? `${props.label}: previous` : undefined}
+        disabled={props.page <= 1}
+        onClick={() => props.onPage(props.page - 1)}
+      >
+        Previous
+      </Button>
+      <span className="text-xs text-muted-foreground">
+        Page {props.page} of {props.totalPages}
+      </span>
+      <Button
+        size="sm"
+        variant="outline"
+        aria-label={props.label ? `${props.label}: next` : undefined}
+        disabled={props.page >= props.totalPages}
+        onClick={() => props.onPage(props.page + 1)}
+      >
+        Next
+      </Button>
+    </nav>
+  );
+}
+
+function Count(props: { label: string; value: number }): JSX.Element {
+  return (
+    <div className="rounded-lg bg-muted/60 p-2">
+      <dt className="text-muted-foreground">{props.label}</dt>
+      <dd className="mt-1 text-sm font-semibold text-foreground">{props.value.toLocaleString()}</dd>
+    </div>
+  );
+}
+function SummaryRow(props: { label: string; value: number }): JSX.Element {
+  return (
+    <tr className="border-t first:border-t-0">
+      <th className="py-2 text-left font-normal text-muted-foreground">{props.label}</th>
+      <td className="py-2 text-right font-semibold">{props.value.toLocaleString()}</td>
+    </tr>
+  );
+}
+function InlineError({ error }: { error: unknown }): JSX.Element {
+  return (
+    <p role="alert" className="rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      {errorMessage(error)}
+    </p>
+  );
+}
+
+function criterion(
+  id: string,
+  stage: ReviewCriterion["stage"],
+  type: ReviewCriterion["type"],
+  label: string,
+  order: number
+): ReviewCriterion {
+  return { id, stage, type, label, order };
+}
+function criterionDraft(criteria: ReviewCriterion[]): {
+  abstractInclusion: string;
+  abstractExclusion: string;
+  fullTextInclusion: string;
+  fullTextExclusion: string;
+} {
+  const text = (stage: ReviewCriterion["stage"], type: ReviewCriterion["type"]) =>
+    criteria
+      .filter((item) => item.stage === stage && item.type === type)
+      .sort((a, b) => a.order - b.order)
+      .map((item) => item.label)
+      .join("\n");
+  return {
+    abstractInclusion: text("title-abstract", "inclusion"),
+    abstractExclusion: text("title-abstract", "exclusion"),
+    fullTextInclusion: text("full-text", "inclusion"),
+    fullTextExclusion: text("full-text", "exclusion")
+  };
+}
+function lines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+function slug(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 32) || "criterion"
+  );
+}
+function toggledSet(current: Set<string>, value: string, enabled: boolean): Set<string> {
+  const next = new Set(current);
+  if (enabled) next.add(value);
+  else next.delete(value);
+  return next;
+}
+function reviewYear(value: string): number | undefined {
+  if (!/^\d{4}$/.test(value)) return undefined;
+  const year = Number(value);
+  return year >= 1500 && year <= 3000 ? year : undefined;
+}
+function sourceLabel(source: ReviewPaperSummary["source"]): string {
+  return paperSourceFilters.find((item) => item.value === source)?.label ?? source;
+}
+function isFormControl(target: EventTarget): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    target instanceof HTMLButtonElement
+  );
+}
+function extractionDraft(value: ExtractionPrimitiveValue | undefined): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (value === null || value === undefined) return "";
+  return String(value);
+}
+function parseExtractionDraft(value: string, type: ExtractionFieldType): ExtractionPrimitiveValue {
+  if (type === "number") return value.trim() ? Number(value) : null;
+  if (type === "boolean") return value === "" ? null : value === "true";
+  if (type === "multi-select")
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  return value;
+}
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : typeof error === "string"
+      ? error
+      : "An unexpected review error occurred.";
+}
+async function invalidateReviewData(queryClient: ReturnType<typeof useQueryClient>, reviewId: string): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["review-papers", reviewId] }),
+    queryClient.invalidateQueries({ queryKey: ["review-fields", reviewId] }),
+    queryClient.invalidateQueries({ queryKey: ["review-values", reviewId] }),
+    queryClient.invalidateQueries({ queryKey: ["review-summary", reviewId] }),
+    queryClient.invalidateQueries({ queryKey: ["review-runs", reviewId] }),
+    queryClient.invalidateQueries({ queryKey: ["review-run-items"] })
+  ]);
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -16,6 +16,11 @@ export const sourceIdSchema = z.enum([
 ]);
 export type SourceId = z.infer<typeof sourceIdSchema>;
 
+// Paper provenance includes file-based imports, while crawl configuration and
+// source definitions intentionally remain limited to actual crawler sources.
+export const paperSourceIdSchema = sourceIdSchema.or(z.literal("reference-import"));
+export type PaperSourceId = z.infer<typeof paperSourceIdSchema>;
+
 export const paperScoreSchema = z.object({
   overall: z.number().min(0).max(100),
   label: z.enum(["excellent", "strong", "solid", "emerging", "limited"]),
@@ -48,7 +53,7 @@ export const paperSchema = z.object({
   doi: z.string().optional(),
   url: z.string().url().optional(),
   pdfUrl: z.string().url().optional(),
-  source: sourceIdSchema,
+  source: paperSourceIdSchema,
   sourcePaperId: z.string().optional(),
   venue: z.string().optional(),
   citationCount: z.number().int().nonnegative().optional(),
@@ -540,6 +545,793 @@ export const paperUpdateSchema = z.object({
   })
 });
 export type PaperUpdate = z.infer<typeof paperUpdateSchema>;
+
+export const MAX_REFERENCE_IMPORT_BYTES = 50 * 1024 * 1024;
+export const MAX_REFERENCE_IMPORT_RECORDS = 50_000;
+export const MAX_EXTRACTION_FIELDS = 30;
+export const MAX_REVIEW_BATCH_PAPERS = 25;
+
+export const reviewTemplateSchema = z.enum(["blank", "general-empirical", "pico"]);
+export type ReviewTemplate = z.infer<typeof reviewTemplateSchema>;
+
+export const screeningStageSchema = z.enum(["title-abstract", "full-text"]);
+export type ScreeningStage = z.infer<typeof screeningStageSchema>;
+
+export const reviewStageSchema = z.enum(["title-abstract", "full-text", "extraction"]);
+export type ReviewStage = z.infer<typeof reviewStageSchema>;
+
+export const reviewCriterionTypeSchema = z.enum(["inclusion", "exclusion"]);
+export type ReviewCriterionType = z.infer<typeof reviewCriterionTypeSchema>;
+
+export const reviewCriterionSchema = z.object({
+  id: z.string(),
+  stage: screeningStageSchema,
+  type: reviewCriterionTypeSchema,
+  label: z.string().trim().min(1).max(240),
+  description: z.string().trim().max(2_000).optional(),
+  order: z.number().int().nonnegative()
+});
+export type ReviewCriterion = z.infer<typeof reviewCriterionSchema>;
+
+export const reviewProtocolRevisionSchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  version: z.number().int().positive(),
+  researchQuestion: z.string().trim().max(2_000),
+  objectives: z.array(z.string().trim().min(1).max(1_000)).max(50).default([]),
+  criteria: z.array(reviewCriterionSchema).max(100).default([]),
+  changeNote: z.string().trim().max(2_000).optional(),
+  createdAt: z.string()
+});
+export type ReviewProtocolRevision = z.infer<typeof reviewProtocolRevisionSchema>;
+
+export const reviewProtocolSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  template: reviewTemplateSchema,
+  currentRevisionId: z.string(),
+  currentRevisionNumber: z.number().int().positive(),
+  historicalCountsAvailable: z.boolean(),
+  activatedAt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+export type ReviewProtocol = z.infer<typeof reviewProtocolSchema>;
+
+export const discoveryBatchKindSchema = z.enum(["pre-existing", "reference-import", "crawl"]);
+export type DiscoveryBatchKind = z.infer<typeof discoveryBatchKindSchema>;
+
+export const discoveryBatchStatusSchema = z.enum(["pending", "running", "completed", "failed", "cancelled"]);
+export type DiscoveryBatchStatus = z.infer<typeof discoveryBatchStatusSchema>;
+
+export const referenceImportFormatSchema = z.enum(["ris", "bibtex", "csv"]);
+export type ReferenceImportFormat = z.infer<typeof referenceImportFormatSchema>;
+
+export const discoveryBatchCountsSchema = z.object({
+  identified: z.number().int().nonnegative().default(0),
+  filtered: z.number().int().nonnegative().default(0),
+  invalid: z.number().int().nonnegative().default(0),
+  duplicates: z.number().int().nonnegative().default(0),
+  merged: z.number().int().nonnegative().default(0),
+  newRecords: z.number().int().nonnegative().default(0)
+});
+export type DiscoveryBatchCounts = z.infer<typeof discoveryBatchCountsSchema>;
+
+export const discoveryBatchSchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  kind: discoveryBatchKindSchema,
+  label: z.string().trim().min(1).max(240),
+  sourceId: sourceIdSchema.optional(),
+  fileName: z.string().optional(),
+  importFormat: referenceImportFormatSchema.optional(),
+  status: discoveryBatchStatusSchema,
+  counts: discoveryBatchCountsSchema,
+  historicalCountsAvailable: z.boolean(),
+  createdAt: z.string(),
+  completedAt: z.string().optional(),
+  error: z.string().optional()
+});
+export type DiscoveryBatch = z.infer<typeof discoveryBatchSchema>;
+
+export const discoveryCandidateActionSchema = z.enum([
+  "created",
+  "duplicate",
+  "merged",
+  "kept-separate",
+  "skipped",
+  "invalid",
+  "filtered"
+]);
+export type DiscoveryCandidateAction = z.infer<typeof discoveryCandidateActionSchema>;
+
+export const discoveryCandidateSchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  batchId: z.string(),
+  paperId: z.string().optional(),
+  sourceRecordId: z.string().optional(),
+  title: z.string().optional(),
+  doi: z.string().optional(),
+  action: discoveryCandidateActionSchema,
+  createdAt: z.string()
+});
+export type DiscoveryCandidate = z.infer<typeof discoveryCandidateSchema>;
+
+export const screeningDecisionValueSchema = z.enum(["include", "exclude", "uncertain"]);
+export type ScreeningDecisionValue = z.infer<typeof screeningDecisionValueSchema>;
+
+const screeningDecisionShape = {
+  reviewId: z.string(),
+  paperId: z.string(),
+  stage: screeningStageSchema,
+  decision: screeningDecisionValueSchema,
+  protocolRevisionId: z.string(),
+  reasonCriterionId: z.string().optional(),
+  customReason: z.string().trim().max(2_000).optional(),
+  runItemId: z.string().optional()
+};
+
+function validateScreeningDecision(
+  decision: {
+    stage: ScreeningStage;
+    decision: ScreeningDecisionValue;
+    reasonCriterionId?: string;
+    customReason?: string;
+  },
+  context: z.RefinementCtx
+): void {
+  if (
+    decision.stage === "full-text" &&
+    decision.decision === "exclude" &&
+    !decision.reasonCriterionId &&
+    !decision.customReason?.trim()
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["customReason"],
+      message: "Full-text exclusions require a criterion or custom reason"
+    });
+  }
+}
+
+export const screeningDecisionSchema = z
+  .object({
+    id: z.string(),
+    ...screeningDecisionShape,
+    previousDecisionId: z.string().optional(),
+    createdAt: z.string()
+  })
+  .superRefine(validateScreeningDecision);
+export type ScreeningDecision = z.infer<typeof screeningDecisionSchema>;
+
+export const extractionFieldTypeSchema = z.enum([
+  "short-text",
+  "long-text",
+  "number",
+  "boolean",
+  "single-select",
+  "multi-select"
+]);
+export type ExtractionFieldType = z.infer<typeof extractionFieldTypeSchema>;
+
+export const extractionFieldSchema = z
+  .object({
+    id: z.string(),
+    reviewId: z.string(),
+    name: z.string().trim().min(1).max(240),
+    description: z.string().trim().max(2_000).optional(),
+    type: extractionFieldTypeSchema,
+    options: z.array(z.string().trim().min(1).max(240)).max(100).default([]),
+    order: z.number().int().nonnegative(),
+    revision: z.number().int().positive(),
+    active: z.boolean().default(true),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+  .superRefine((field, context) => {
+    const isSelect = field.type === "single-select" || field.type === "multi-select";
+    if (isSelect && field.options.length === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Select fields require at least one option"
+      });
+    }
+    if (!isSelect && field.options.length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Only select fields may define options"
+      });
+    }
+    if (new Set(field.options).size !== field.options.length) {
+      context.addIssue({ code: "custom", path: ["options"], message: "Field options must be unique" });
+    }
+  });
+export type ExtractionField = z.infer<typeof extractionFieldSchema>;
+
+export const extractionPrimitiveValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+  z.null()
+]);
+export type ExtractionPrimitiveValue = z.infer<typeof extractionPrimitiveValueSchema>;
+
+export function isBlankExtractionValue(value: ExtractionPrimitiveValue): boolean {
+  return (
+    value === null ||
+    (typeof value === "string" && value.trim().length === 0) ||
+    (Array.isArray(value) && !value.length)
+  );
+}
+
+export const extractionValueStatusSchema = z.enum(["suggested", "confirmed", "rejected", "not-found", "needs-review"]);
+export type ExtractionValueStatus = z.infer<typeof extractionValueStatusSchema>;
+
+export const extractionValueOriginSchema = z.enum(["manual", "ai"]);
+export type ExtractionValueOrigin = z.infer<typeof extractionValueOriginSchema>;
+
+export const extractionValueSchema = z
+  .object({
+    id: z.string(),
+    reviewId: z.string(),
+    paperId: z.string(),
+    fieldId: z.string(),
+    fieldRevision: z.number().int().positive(),
+    value: extractionPrimitiveValueSchema,
+    status: extractionValueStatusSchema,
+    origin: extractionValueOriginSchema,
+    evidenceIds: z.array(z.string()).default([]),
+    runItemId: z.string().optional(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    confirmedAt: z.string().optional()
+  })
+  .superRefine((value, context) => {
+    if (value.status === "not-found" && value.value !== null) {
+      context.addIssue({ code: "custom", path: ["value"], message: "Not-found values must be null" });
+    }
+    if (value.status === "confirmed" && isBlankExtractionValue(value.value)) {
+      context.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "Confirmed extraction values cannot be blank; use Not found instead"
+      });
+    }
+    if (value.origin === "ai" && value.status === "confirmed" && value.evidenceIds.length === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["evidenceIds"],
+        message: "Confirmed AI values require evidence"
+      });
+    }
+  });
+export type ExtractionValue = z.infer<typeof extractionValueSchema>;
+
+export const reviewEvidenceSourceTypeSchema = z.enum(["paper-metadata", "paper-abstract", "artifact-chunk"]);
+export type ReviewEvidenceSourceType = z.infer<typeof reviewEvidenceSourceTypeSchema>;
+
+export const reviewEvidenceSchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  evidenceId: z.string().trim().min(1),
+  runId: z.string().optional(),
+  runItemId: z.string().optional(),
+  paperId: z.string().optional(),
+  artifactId: z.string().optional(),
+  chunkId: z.string().optional(),
+  sourceType: reviewEvidenceSourceTypeSchema,
+  title: z.string().trim().min(1),
+  excerpt: z.string().trim().min(1),
+  locator: z.string().optional(),
+  page: z.number().int().positive().optional(),
+  doi: z.string().optional(),
+  url: z.string().url().optional(),
+  retrievalScore: z.number().optional(),
+  createdAt: z.string()
+});
+export type ReviewEvidence = z.infer<typeof reviewEvidenceSchema>;
+
+export const reviewDecisionStateSchema = screeningDecisionValueSchema.or(z.literal("pending"));
+export type ReviewDecisionState = z.infer<typeof reviewDecisionStateSchema>;
+
+export const reviewPaperExtractionProgressSchema = z.object({
+  total: z.number().int().nonnegative(),
+  confirmed: z.number().int().nonnegative(),
+  needsReview: z.number().int().nonnegative()
+});
+export type ReviewPaperExtractionProgress = z.infer<typeof reviewPaperExtractionProgressSchema>;
+
+export const reviewPaperSummarySchema = z.object({
+  reviewId: z.string(),
+  paperId: z.string(),
+  title: z.string(),
+  authors: z.array(z.string()).default([]),
+  abstract: z.string().optional(),
+  year: z.number().int().optional(),
+  venue: z.string().optional(),
+  doi: z.string().optional(),
+  source: paperSourceIdSchema,
+  discoveryBatchIds: z.array(z.string()).default([]),
+  hasFullText: z.boolean(),
+  titleAbstractDecision: screeningDecisionSchema.optional(),
+  fullTextDecision: screeningDecisionSchema.optional(),
+  extractionProgress: reviewPaperExtractionProgressSchema,
+  needsReReview: z.boolean().default(false),
+  aiSuggestionStale: z.boolean().default(false)
+});
+export type ReviewPaperSummary = z.infer<typeof reviewPaperSummarySchema>;
+
+export const reviewPaperSchema = reviewPaperSummarySchema.extend({
+  paper: paperSchema
+});
+export type ReviewPaper = z.infer<typeof reviewPaperSchema>;
+
+export const reviewFullTextFilterSchema = z.enum(["any", "available", "missing"]);
+export type ReviewFullTextFilter = z.infer<typeof reviewFullTextFilterSchema>;
+
+export const reviewPaperQuerySchema = z
+  .object({
+    reviewId: z.string(),
+    stage: reviewStageSchema.default("title-abstract"),
+    search: z.string().trim().max(500).optional(),
+    sources: z.array(paperSourceIdSchema).default([]),
+    yearFrom: z.number().int().min(1500).max(3000).optional(),
+    yearTo: z.number().int().min(1500).max(3000).optional(),
+    decisions: z.array(reviewDecisionStateSchema).default([]),
+    fullText: reviewFullTextFilterSchema.default("any"),
+    needsReReview: z.boolean().optional(),
+    sort: z.enum(["title", "year", "created"]).default("created"),
+    direction: z.enum(["asc", "desc"]).default("asc"),
+    page: z.number().int().positive().default(1),
+    pageSize: z.number().int().positive().max(100).default(25)
+  })
+  .refine((query) => query.yearFrom === undefined || query.yearTo === undefined || query.yearFrom <= query.yearTo, {
+    path: ["yearTo"],
+    message: "yearTo must be greater than or equal to yearFrom"
+  });
+export type ReviewPaperQuery = z.infer<typeof reviewPaperQuerySchema>;
+
+export const reviewPaperPageSchema = z.object({
+  items: z.array(reviewPaperSummarySchema),
+  page: z.number().int().positive(),
+  pageSize: z.number().int().positive(),
+  total: z.number().int().nonnegative(),
+  totalPages: z.number().int().nonnegative(),
+  counts: z.object({
+    pending: z.number().int().nonnegative(),
+    include: z.number().int().nonnegative(),
+    exclude: z.number().int().nonnegative(),
+    uncertain: z.number().int().nonnegative()
+  })
+});
+export type ReviewPaperPage = z.infer<typeof reviewPaperPageSchema>;
+
+export const reviewRunStageSchema = reviewStageSchema;
+export type ReviewRunStage = z.infer<typeof reviewRunStageSchema>;
+
+export const reviewRunStatusSchema = z.enum(["queued", "running", "completed", "partial", "cancelled", "failed"]);
+export type ReviewRunStatus = z.infer<typeof reviewRunStatusSchema>;
+
+export const reviewRunItemStatusSchema = z.enum(["queued", "running", "completed", "failed", "cancelled"]);
+export type ReviewRunItemStatus = z.infer<typeof reviewRunItemStatusSchema>;
+
+export const reviewExtractionSuggestionSchema = z
+  .object({
+    fieldId: z.string(),
+    value: extractionPrimitiveValueSchema,
+    status: z.enum(["suggested", "not-found", "needs-review"]),
+    evidenceIds: z.array(z.string()).default([]),
+    rationale: z.string().optional()
+  })
+  .superRefine((suggestion, context) => {
+    if (suggestion.status === "suggested" && isBlankExtractionValue(suggestion.value)) {
+      context.addIssue({ code: "custom", path: ["value"], message: "Suggested values cannot be blank" });
+    }
+    if (suggestion.status === "suggested" && !suggestion.evidenceIds.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["evidenceIds"],
+        message: "Suggested AI values require evidence"
+      });
+    }
+    if (suggestion.status !== "suggested" && suggestion.value !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "Not-found and unclear suggestions cannot contain a value"
+      });
+    }
+  });
+export type ReviewExtractionSuggestion = z.infer<typeof reviewExtractionSuggestionSchema>;
+
+export const reviewCriterionAssessmentSchema = z.object({
+  criterionId: z.string(),
+  assessment: z.enum(["met", "not-met", "unclear"]),
+  explanation: z.string().trim().min(1).max(2_000),
+  evidenceIds: z.array(z.string()).max(12).default([])
+});
+export type ReviewCriterionAssessment = z.infer<typeof reviewCriterionAssessmentSchema>;
+
+export const reviewRunItemSchema = z.object({
+  id: z.string(),
+  runId: z.string(),
+  paperId: z.string(),
+  status: reviewRunItemStatusSchema,
+  attemptCount: z.number().int().nonnegative(),
+  suggestedDecision: screeningDecisionValueSchema.optional(),
+  suggestedReasonCriterionId: z.string().optional(),
+  suggestedCustomReason: z.string().optional(),
+  rationale: z.string().optional(),
+  criterionAssessments: z.array(reviewCriterionAssessmentSchema).default([]),
+  extractionSuggestions: z.array(reviewExtractionSuggestionSchema).default([]),
+  evidence: z.array(reviewEvidenceSchema).default([]),
+  stale: z.boolean().default(false),
+  error: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  startedAt: z.string().optional(),
+  completedAt: z.string().optional()
+});
+export type ReviewRunItem = z.infer<typeof reviewRunItemSchema>;
+
+export const reviewRunSchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  stage: reviewRunStageSchema,
+  provider: aiProviderSchema,
+  model: z.string().trim().min(1),
+  protocolRevisionId: z.string(),
+  status: reviewRunStatusSchema,
+  paperIds: z.array(z.string()).min(1).max(MAX_REVIEW_BATCH_PAPERS),
+  fieldIds: z.array(z.string()).max(MAX_EXTRACTION_FIELDS).default([]),
+  completedCount: z.number().int().nonnegative().default(0),
+  failedCount: z.number().int().nonnegative().default(0),
+  cancelledCount: z.number().int().nonnegative().default(0),
+  error: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  startedAt: z.string().optional(),
+  completedAt: z.string().optional()
+});
+export type ReviewRun = z.infer<typeof reviewRunSchema>;
+
+export const reviewRunEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("status"),
+    runId: z.string(),
+    reviewId: z.string(),
+    status: reviewRunStatusSchema
+  }),
+  z.object({
+    type: z.literal("progress"),
+    runId: z.string(),
+    reviewId: z.string(),
+    completed: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    cancelled: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+    currentPaperId: z.string().optional()
+  }),
+  z.object({
+    type: z.literal("item"),
+    runId: z.string(),
+    reviewId: z.string(),
+    item: reviewRunItemSchema
+  }),
+  z.object({
+    type: z.literal("complete"),
+    runId: z.string(),
+    reviewId: z.string(),
+    run: reviewRunSchema
+  }),
+  z.object({
+    type: z.literal("error"),
+    runId: z.string(),
+    reviewId: z.string(),
+    error: z.string(),
+    status: z.enum(["cancelled", "failed"])
+  })
+]);
+export type ReviewRunEvent = z.infer<typeof reviewRunEventSchema>;
+
+export const reviewAuditEventKindSchema = z.enum([
+  "review-activated",
+  "protocol-revised",
+  "decision-recorded",
+  "decision-marked-for-review",
+  "extraction-field-created",
+  "extraction-field-revised",
+  "extraction-value-confirmed",
+  "extraction-value-rejected",
+  "extraction-value-not-found",
+  "import-committed",
+  "run-started",
+  "run-cancelled",
+  "run-completed",
+  "paper-pdf-attached"
+]);
+export type ReviewAuditEventKind = z.infer<typeof reviewAuditEventKindSchema>;
+
+export const reviewAuditEventSchema = z.object({
+  id: z.string(),
+  reviewId: z.string(),
+  kind: reviewAuditEventKindSchema,
+  actor: z.enum(["user", "system", "ai"]),
+  entityType: z.string().optional(),
+  entityId: z.string().optional(),
+  payload: z.record(z.string(), z.unknown()).default({}),
+  createdAt: z.string()
+});
+export type ReviewAuditEvent = z.infer<typeof reviewAuditEventSchema>;
+
+export const reviewExtractionCompletionSchema = z.object({
+  totalCells: z.number().int().nonnegative(),
+  confirmedCells: z.number().int().nonnegative(),
+  notFoundCells: z.number().int().nonnegative(),
+  needsReviewCells: z.number().int().nonnegative(),
+  completionPercent: z.number().min(0).max(100)
+});
+export type ReviewExtractionCompletion = z.infer<typeof reviewExtractionCompletionSchema>;
+
+export const reviewFlowSummarySchema = z.object({
+  reviewId: z.string(),
+  identifiedRecords: z.number().int().nonnegative(),
+  filteredRecords: z.number().int().nonnegative(),
+  invalidRecords: z.number().int().nonnegative(),
+  duplicateRecords: z.number().int().nonnegative(),
+  mergedRecords: z.number().int().nonnegative(),
+  newRecords: z.number().int().nonnegative(),
+  uniqueRecordsScreened: z.number().int().nonnegative(),
+  titleAbstractExclusions: z.number().int().nonnegative(),
+  fullTextsSought: z.number().int().nonnegative(),
+  fullTextsUnavailable: z.number().int().nonnegative(),
+  fullTextExclusionsByReason: z.record(z.string(), z.number().int().nonnegative()),
+  includedPapers: z.number().int().nonnegative(),
+  extraction: reviewExtractionCompletionSchema,
+  historicalCountsAvailable: z.boolean(),
+  warnings: z.array(z.string()).default([]),
+  generatedAt: z.string()
+});
+export type ReviewFlowSummary = z.infer<typeof reviewFlowSummarySchema>;
+
+export const referenceRecordSchema = z.object({
+  title: z.string().trim().min(1).max(2_000),
+  authors: z.array(z.string().trim().min(1)).default([]),
+  abstract: z.string().optional(),
+  year: z.number().int().min(1500).max(3000).optional(),
+  doi: z.string().optional(),
+  url: z.string().url().optional(),
+  pdfUrl: z.string().url().optional(),
+  venue: z.string().optional(),
+  sourceId: z.string().optional(),
+  sourceAuthority: z.string().optional(),
+  citationCount: z.number().int().nonnegative().optional()
+});
+export type ReferenceRecord = z.infer<typeof referenceRecordSchema>;
+
+export const referenceImportFieldSchema = z.enum([
+  "title",
+  "authors",
+  "abstract",
+  "year",
+  "doi",
+  "url",
+  "pdfUrl",
+  "venue",
+  "sourceId",
+  "sourceAuthority",
+  "citationCount"
+]);
+export type ReferenceImportField = z.infer<typeof referenceImportFieldSchema>;
+
+export const referenceImportMappingSchema = z.object({
+  title: z.string().min(1),
+  authors: z.string().optional(),
+  abstract: z.string().optional(),
+  year: z.string().optional(),
+  doi: z.string().optional(),
+  url: z.string().optional(),
+  pdfUrl: z.string().optional(),
+  venue: z.string().optional(),
+  sourceId: z.string().optional(),
+  sourceAuthority: z.string().optional(),
+  citationCount: z.string().optional()
+});
+export type ReferenceImportMapping = z.infer<typeof referenceImportMappingSchema>;
+
+export const referenceImportMatchSchema = z.object({
+  kind: z.enum(["none", "exact", "ambiguous"]),
+  matchedBy: z.enum(["doi", "source-id", "fingerprint"]).optional(),
+  paperId: z.string().optional(),
+  candidatePaperIds: z.array(z.string()).default([])
+});
+export type ReferenceImportMatch = z.infer<typeof referenceImportMatchSchema>;
+
+export const referenceImportPreviewItemSchema = z.object({
+  recordIndex: z.number().int().nonnegative(),
+  record: referenceRecordSchema.optional(),
+  rawTitle: z.string().optional(),
+  valid: z.boolean(),
+  errors: z.array(z.string()).default([]),
+  match: referenceImportMatchSchema
+});
+export type ReferenceImportPreviewItem = z.infer<typeof referenceImportPreviewItemSchema>;
+
+export const referenceImportPreviewRequestSchema = z.object({
+  projectId: z.string(),
+  reviewId: z.string(),
+  format: referenceImportFormatSchema.optional()
+});
+export type ReferenceImportPreviewRequest = z.infer<typeof referenceImportPreviewRequestSchema>;
+
+export const referenceImportPreviewSchema = z.object({
+  previewId: z.string(),
+  projectId: z.string(),
+  reviewId: z.string(),
+  fileName: z.string(),
+  format: referenceImportFormatSchema,
+  sizeBytes: z.number().int().nonnegative().max(MAX_REFERENCE_IMPORT_BYTES),
+  totalRecords: z.number().int().nonnegative().max(MAX_REFERENCE_IMPORT_RECORDS),
+  validRecords: z.number().int().nonnegative(),
+  invalidRecords: z.number().int().nonnegative(),
+  columns: z.array(z.string()).default([]),
+  suggestedMapping: referenceImportMappingSchema.partial().optional(),
+  items: z.array(referenceImportPreviewItemSchema),
+  warnings: z.array(z.string()).default([])
+});
+export type ReferenceImportPreview = z.infer<typeof referenceImportPreviewSchema>;
+
+export const referenceImportResolutionSchema = z
+  .object({
+    recordIndex: z.number().int().nonnegative(),
+    action: z.enum(["keep-separate", "merge", "skip"]),
+    paperId: z.string().optional()
+  })
+  .refine((resolution) => resolution.action !== "merge" || Boolean(resolution.paperId), {
+    path: ["paperId"],
+    message: "Merge resolutions require a paper ID"
+  });
+export type ReferenceImportResolution = z.infer<typeof referenceImportResolutionSchema>;
+
+export const referenceImportCommitRequestSchema = z.object({
+  projectId: z.string(),
+  reviewId: z.string(),
+  previewId: z.string(),
+  mapping: referenceImportMappingSchema.optional(),
+  resolutions: z.array(referenceImportResolutionSchema).max(MAX_REFERENCE_IMPORT_RECORDS).default([])
+});
+export type ReferenceImportCommitRequest = z.infer<typeof referenceImportCommitRequestSchema>;
+
+export const referenceImportCommitResponseSchema = z.object({
+  batch: discoveryBatchSchema,
+  counts: discoveryBatchCountsSchema
+});
+export type ReferenceImportCommitResponse = z.infer<typeof referenceImportCommitResponseSchema>;
+
+export const activateReviewRequestSchema = z.object({
+  projectId: z.string(),
+  template: reviewTemplateSchema.default("blank"),
+  researchQuestion: z.string().trim().max(2_000).default(""),
+  objectives: z.array(z.string().trim().min(1).max(1_000)).max(50).default([]),
+  criteria: z.array(reviewCriterionSchema).max(100).default([])
+});
+export type ActivateReviewRequest = z.infer<typeof activateReviewRequestSchema>;
+
+export const reviseReviewProtocolRequestSchema = z.object({
+  reviewId: z.string(),
+  expectedVersion: z.number().int().positive(),
+  researchQuestion: z.string().trim().max(2_000),
+  objectives: z.array(z.string().trim().min(1).max(1_000)).max(50).default([]),
+  criteria: z.array(reviewCriterionSchema).max(100).default([]),
+  changeNote: z.string().trim().max(2_000).optional()
+});
+export type ReviseReviewProtocolRequest = z.infer<typeof reviseReviewProtocolRequestSchema>;
+
+export const saveScreeningDecisionRequestSchema = z
+  .object(screeningDecisionShape)
+  .superRefine(validateScreeningDecision);
+export type SaveScreeningDecisionRequest = z.infer<typeof saveScreeningDecisionRequestSchema>;
+
+export const markReviewPapersForReviewRequestSchema = z.object({
+  reviewId: z.string(),
+  paperIds: z.array(z.string()).min(1).max(500),
+  stage: screeningStageSchema.optional()
+});
+export type MarkReviewPapersForReviewRequest = z.infer<typeof markReviewPapersForReviewRequestSchema>;
+
+export const upsertExtractionFieldRequestSchema = z
+  .object({
+    reviewId: z.string(),
+    fieldId: z.string().optional(),
+    expectedRevision: z.number().int().positive().optional(),
+    name: z.string().trim().min(1).max(240),
+    description: z.string().trim().max(2_000).optional(),
+    type: extractionFieldTypeSchema,
+    options: z.array(z.string().trim().min(1).max(240)).max(100).default([]),
+    order: z.number().int().nonnegative()
+  })
+  .superRefine((field, context) => {
+    const isSelect = field.type === "single-select" || field.type === "multi-select";
+    if (isSelect && field.options.length === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Select fields require at least one option"
+      });
+    }
+    if (!isSelect && field.options.length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Only select fields may define options"
+      });
+    }
+  });
+export type UpsertExtractionFieldRequest = z.infer<typeof upsertExtractionFieldRequestSchema>;
+
+export const reorderExtractionFieldsRequestSchema = z.object({
+  reviewId: z.string(),
+  fieldIds: z.array(z.string()).max(MAX_EXTRACTION_FIELDS)
+});
+export type ReorderExtractionFieldsRequest = z.infer<typeof reorderExtractionFieldsRequestSchema>;
+
+export const saveExtractionValueRequestSchema = z
+  .object({
+    reviewId: z.string(),
+    paperId: z.string(),
+    fieldId: z.string(),
+    expectedFieldRevision: z.number().int().positive(),
+    value: extractionPrimitiveValueSchema,
+    status: z.enum(["confirmed", "rejected", "not-found", "needs-review"]),
+    evidenceIds: z.array(z.string()).default([])
+  })
+  .superRefine((value, context) => {
+    if (value.status === "not-found" && value.value !== null) {
+      context.addIssue({ code: "custom", path: ["value"], message: "Not-found values must be null" });
+    }
+    if (value.status === "confirmed" && isBlankExtractionValue(value.value)) {
+      context.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "Confirmed extraction values cannot be blank; use Not found instead"
+      });
+    }
+  });
+export type SaveExtractionValueRequest = z.infer<typeof saveExtractionValueRequestSchema>;
+
+export const startReviewRunRequestSchema = z.object({
+  reviewId: z.string(),
+  stage: reviewRunStageSchema,
+  paperIds: z.array(z.string()).min(1).max(MAX_REVIEW_BATCH_PAPERS),
+  fieldIds: z.array(z.string()).max(MAX_EXTRACTION_FIELDS).optional()
+});
+export type StartReviewRunRequest = z.infer<typeof startReviewRunRequestSchema>;
+
+export const cancelReviewRunRequestSchema = z.object({ runId: z.string() });
+export type CancelReviewRunRequest = z.infer<typeof cancelReviewRunRequestSchema>;
+
+export const retryReviewRunRequestSchema = z.object({ runId: z.string() });
+export type RetryReviewRunRequest = z.infer<typeof retryReviewRunRequestSchema>;
+
+export const fetchReviewPaperFullTextRequestSchema = z.object({
+  projectId: z.string(),
+  reviewId: z.string(),
+  paperId: z.string()
+});
+export type FetchReviewPaperFullTextRequest = z.infer<typeof fetchReviewPaperFullTextRequestSchema>;
+
+export const attachReviewPaperPdfRequestSchema = fetchReviewPaperFullTextRequestSchema;
+export type AttachReviewPaperPdfRequest = z.infer<typeof attachReviewPaperPdfRequestSchema>;
+
+export const getReviewSummaryRequestSchema = z.object({ reviewId: z.string() });
+export type GetReviewSummaryRequest = z.infer<typeof getReviewSummaryRequestSchema>;
+
+export const exportReviewRequestSchema = z.object({ reviewId: z.string() });
+export type ExportReviewRequest = z.infer<typeof exportReviewRequestSchema>;
 
 export function normalizeTitle(title: string): string {
   return title

--- a/tests/conversation-migration.test.ts
+++ b/tests/conversation-migration.test.ts
@@ -85,7 +85,7 @@ describe("conversation persistence", () => {
     expect(conversation.title).toBe("Existing conversation");
     expect(db.listMessages("legacy_project", conversation.id)[0].content).toBe("preserve me");
     const migrated = new DatabaseSync(path);
-    expect((migrated.prepare("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(2);
+    expect((migrated.prepare("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(3);
     migrated.close();
     db.close();
   });
@@ -93,7 +93,7 @@ describe("conversation persistence", () => {
   it("refuses to open a database created by a newer schema", () => {
     const path = join(dir, "future.db");
     const future = new DatabaseSync(path);
-    future.exec("PRAGMA user_version = 3");
+    future.exec("PRAGMA user_version = 4");
     future.close();
     expect(() => new PaperPilotDb(path)).toThrow(/newer than this Paper Pilot build supports/i);
   });

--- a/tests/crawler-diagnostics.test.ts
+++ b/tests/crawler-diagnostics.test.ts
@@ -123,6 +123,258 @@ describe("crawler diagnostics", () => {
     ]);
     expect((await artifacts.readArtifact(digest!)).toString("utf8")).toContain("Source Diagnostics");
   });
+
+  it("captures active-review candidates before filtering and keeps metadata-only records by default", async () => {
+    const project = db.createProject("Review crawl", "intervention", { autoApproveSources: true });
+    db.savePaper(project.id, {
+      id: "existing",
+      title: "Existing trial",
+      authors: ["A. Researcher"],
+      year: 2024,
+      doi: "10.1000/existing",
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id, researchQuestion: "Which trials are relevant?" });
+    const connector: SourceConnector = {
+      definition: {
+        id: "openalex",
+        displayName: "OpenAlex",
+        kind: "api",
+        description: "Fixture connector",
+        requiresApiKey: false,
+        stable: true,
+        capabilities: [],
+        rateLimit: { requestsPerMinute: 60 }
+      },
+      crawlConfigSchema: {} as SourceConnector["crawlConfigSchema"],
+      async run(config) {
+        expect(config.openAccessOnly).toBe(false);
+        return {
+          papers: [
+            {
+              id: "same_doi",
+              title: "Existing trial",
+              abstract: "Enriched abstract",
+              authors: ["A. Researcher"],
+              year: 2024,
+              doi: "https://doi.org/10.1000/existing",
+              source: "openalex",
+              sourcePaperId: "W1",
+              isOpenAccess: false,
+              fieldsOfStudy: []
+            },
+            {
+              id: "metadata_only",
+              title: "Paywalled but screenable",
+              authors: ["B. Researcher"],
+              year: 2025,
+              source: "openalex",
+              sourcePaperId: "W2",
+              isOpenAccess: false,
+              fieldsOfStudy: []
+            }
+          ],
+          warnings: [],
+          provenance: {}
+        };
+      }
+    };
+    const crawl = new CrawlService(
+      db,
+      new SourceRegistry([connector]),
+      { getMany: () => ({}) },
+      new ArtifactService(db, dir),
+      new JobQueue()
+    );
+
+    const result = await crawl.runCrawl(project.id, {
+      topic: "intervention",
+      sourceIds: ["openalex"],
+      maxPapers: 10
+    });
+
+    expect(result.papers.map((paper) => paper.title)).toContain("Paywalled but screenable");
+    const crawlBatch = db.listDiscoveryBatches(review.id).find((batch) => batch.kind === "crawl");
+    expect(crawlBatch).toMatchObject({
+      status: "completed",
+      counts: { identified: 2, filtered: 0, merged: 1, newRecords: 1 }
+    });
+    expect(db.listReviewCandidateOrigins(review.id, crawlBatch!.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resolution: "merged", sourceRecordId: "W1" }),
+        expect.objectContaining({ resolution: "created", sourceRecordId: "W2" })
+      ])
+    );
+  });
+
+  it("uses staged identity matching and retains stronger crawler identifiers with occurrence provenance", async () => {
+    const project = db.createProject("Identity crawl", "identity", { autoApproveSources: true });
+    db.savePaper(project.id, {
+      id: "fingerprint-record",
+      title: "A staged identity study",
+      authors: ["Doe, Jane"],
+      year: 2024,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id });
+    let calls = 0;
+    const connector: SourceConnector = {
+      definition: {
+        id: "openalex",
+        displayName: "OpenAlex",
+        kind: "api",
+        description: "Identity fixture",
+        requiresApiKey: false,
+        stable: true,
+        capabilities: [],
+        rateLimit: { requestsPerMinute: 60 }
+      },
+      crawlConfigSchema: {} as SourceConnector["crawlConfigSchema"],
+      async run() {
+        calls += 1;
+        return {
+          papers: [
+            {
+              id: `openalex-${calls}`,
+              title: calls === 1 ? "A staged identity study" : "Updated connector title",
+              abstract: "Connector metadata",
+              authors: ["Jane Doe"],
+              year: 2024,
+              doi: calls === 1 ? "10.1000/staged" : undefined,
+              source: "openalex",
+              sourcePaperId: "W-STRONG",
+              isOpenAccess: false,
+              fieldsOfStudy: []
+            }
+          ],
+          warnings: [],
+          provenance: {}
+        };
+      }
+    };
+    const crawl = new CrawlService(
+      db,
+      new SourceRegistry([connector]),
+      { getMany: () => ({}) },
+      new ArtifactService(db, dir),
+      new JobQueue()
+    );
+    const config = { topic: "identity", sourceIds: ["openalex" as const], maxPapers: 5 };
+
+    const first = await crawl.runCrawl(project.id, config);
+    const enriched = db.getPaper(project.id, "fingerprint-record");
+    expect(first.papers).toHaveLength(1);
+    expect(enriched).toMatchObject({
+      id: "fingerprint-record",
+      source: "crossref",
+      doi: "10.1000/staged",
+      abstract: "Connector metadata"
+    });
+    expect(enriched?.sourcePaperId).toBeUndefined();
+    expect(enriched?.raw?.identitySourceIdentifiers).toEqual([{ authority: "openalex", identifier: "w-strong" }]);
+
+    const second = await crawl.runCrawl(project.id, config);
+    expect(second.papers).toEqual([expect.objectContaining({ id: "fingerprint-record" })]);
+    expect(db.listPapers(project.id)).toHaveLength(1);
+    const crawlBatches = db.listDiscoveryBatches(review.id).filter((batch) => batch.kind === "crawl");
+    expect(crawlBatches).toHaveLength(2);
+    const mergedBatch = crawlBatches.find((batch) => batch.counts.merged === 1)!;
+    const duplicateBatch = crawlBatches.find((batch) => batch.counts.duplicates === 1)!;
+    expect(mergedBatch.counts).toMatchObject({ merged: 1, newRecords: 0 });
+    expect(duplicateBatch.counts).toMatchObject({ duplicates: 1, newRecords: 0 });
+    expect(db.listReviewCandidateOrigins(review.id, mergedBatch.id)[0]).toMatchObject({
+      paperId: "fingerprint-record",
+      matchedPaperId: "fingerprint-record",
+      sourceRecordId: "W-STRONG",
+      resolution: "merged"
+    });
+    expect(db.listReviewCandidateOrigins(review.id, duplicateBatch.id)[0]).toMatchObject({
+      paperId: "fingerprint-record",
+      matchedPaperId: "fingerprint-record",
+      sourceRecordId: "W-STRONG",
+      resolution: "duplicate"
+    });
+  });
+
+  it("preserves partial discovery counts when candidate persistence fails mid-source", async () => {
+    const project = db.createProject("Partial crawl", "partial", { autoApproveSources: true });
+    const review = db.createReview({ projectId: project.id });
+    const connector: SourceConnector = {
+      definition: {
+        id: "openalex",
+        displayName: "OpenAlex",
+        kind: "api",
+        description: "Partial failure fixture",
+        requiresApiKey: false,
+        stable: true,
+        capabilities: [],
+        rateLimit: { requestsPerMinute: 60 }
+      },
+      crawlConfigSchema: {} as SourceConnector["crawlConfigSchema"],
+      async run() {
+        return {
+          papers: [
+            {
+              id: "partial-one",
+              title: "First persisted candidate",
+              authors: ["Jane Doe"],
+              year: 2024,
+              source: "openalex",
+              sourcePaperId: "W-PARTIAL-1",
+              isOpenAccess: false,
+              fieldsOfStudy: []
+            },
+            {
+              id: "partial-two",
+              title: "Second failed candidate",
+              authors: ["John Doe"],
+              year: 2024,
+              source: "openalex",
+              sourcePaperId: "W-PARTIAL-2",
+              isOpenAccess: false,
+              fieldsOfStudy: []
+            }
+          ],
+          warnings: [],
+          provenance: {}
+        };
+      }
+    };
+    const savePaper = db.savePaper.bind(db);
+    let calls = 0;
+    vi.spyOn(db, "savePaper").mockImplementation((projectId, candidate) => {
+      calls += 1;
+      if (calls === 2) throw new Error("fixture persistence failure");
+      return savePaper(projectId, candidate);
+    });
+    const crawl = new CrawlService(
+      db,
+      new SourceRegistry([connector]),
+      { getMany: () => ({}) },
+      new ArtifactService(db, dir),
+      new JobQueue()
+    );
+
+    const result = await crawl.runCrawl(project.id, {
+      topic: "partial",
+      sourceIds: ["openalex"],
+      maxPapers: 5
+    });
+
+    expect(result.warnings).toContain("OpenAlex: fixture persistence failure");
+    const batch = db.listDiscoveryBatches(review.id).find((candidate) => candidate.kind === "crawl")!;
+    expect(batch).toMatchObject({
+      status: "failed",
+      counts: { identified: 2, newRecords: 1, filtered: 0, duplicates: 0, merged: 0 }
+    });
+    expect(db.listReviewCandidateOrigins(review.id, batch.id)).toEqual([
+      expect.objectContaining({ paperId: "partial-one", resolution: "created" })
+    ]);
+  });
 });
 
 describe("BrowserCrawlerService diagnostics", () => {

--- a/tests/project-conversation-portability.test.ts
+++ b/tests/project-conversation-portability.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PaperPilotDb } from "../src/main/db";
 import { buildProjectExportBundle, importProjectBundle, type IpcServices } from "../src/main/ipc";
 import { ArtifactService } from "../src/main/services/artifact-service";
@@ -17,6 +17,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   db.close();
   await rm(dir, { recursive: true, force: true });
 });
@@ -141,5 +142,517 @@ describe("project conversation portability", () => {
 
     await expect(importProjectBundle(services, corrupt)).rejects.toThrow(/checksum mismatch/i);
     expect(db.listProjects().some((candidate) => candidate.title === "Corrupt import")).toBe(false);
+  });
+
+  it("rejects invalid review references before creating project rows or artifact files", async () => {
+    const project = db.createProject("Semantic source");
+    db.createReview({ projectId: project.id, researchQuestion: "Is this portable?" });
+    await artifacts.writeArtifact({
+      projectId: project.id,
+      type: "markdown",
+      title: "Semantic source artifact",
+      content: "source"
+    });
+    const services = { db, artifacts } as IpcServices;
+    const bundle = await buildProjectExportBundle(services, project.id);
+    const invalid = {
+      ...bundle,
+      project: { ...bundle.project, title: "Invalid semantic import" },
+      review: {
+        ...bundle.review!,
+        review: { ...bundle.review!.review, currentRevisionId: "missing-revision" }
+      }
+    };
+    const beforeEntries = await readdir(join(dir, "projects"), { recursive: true });
+
+    await expect(importProjectBundle(services, invalid)).rejects.toThrow(/current protocol revision/i);
+
+    expect(db.listProjects().some((candidate) => candidate.title === "Invalid semantic import")).toBe(false);
+    expect(await readdir(join(dir, "projects"), { recursive: true })).toEqual(beforeEntries);
+  });
+
+  it("compensates project rows and imported files when a late review import fails", async () => {
+    const project = db.createProject("Late failure source");
+    db.createReview({ projectId: project.id, researchQuestion: "Can a late failure be recovered?" });
+    await artifacts.writeArtifact({
+      projectId: project.id,
+      type: "markdown",
+      title: "Late failure artifact",
+      content: "recoverable content"
+    });
+    const services = { db, artifacts } as IpcServices;
+    const bundle = await buildProjectExportBundle(services, project.id);
+    const beforeFiles = (await readdir(join(dir, "projects"), { recursive: true })).filter((path) =>
+      path.endsWith(".md")
+    );
+    vi.spyOn(db, "importReviewPortabilityState").mockImplementationOnce(() => {
+      throw new Error("simulated late review failure");
+    });
+
+    await expect(
+      importProjectBundle(services, {
+        ...bundle,
+        project: { ...bundle.project, title: "Recovered failed import" }
+      })
+    ).rejects.toThrow("simulated late review failure");
+
+    expect(db.listProjects().some((candidate) => candidate.title === "Recovered failed import")).toBe(false);
+    expect((await readdir(join(dir, "projects"), { recursive: true })).filter((path) => path.endsWith(".md"))).toEqual(
+      beforeFiles
+    );
+  });
+
+  it("exports and remaps a complete version 3 evidence review without losing its audit graph", async () => {
+    const project = db.createProject("Portable evidence review");
+    const paper = db.savePaper(project.id, {
+      id: "original_review_paper",
+      title: "Portable randomized trial",
+      abstract: "The trial reports a measured recovery benefit.",
+      authors: ["Review Author"],
+      year: 2025,
+      doi: "10.1000/portable-review",
+      source: "pubmed",
+      isOpenAccess: true,
+      fieldsOfStudy: ["Medicine"]
+    });
+    const source = await artifacts.writeArtifact({
+      projectId: project.id,
+      type: "markdown",
+      title: "Portable full text",
+      content: "Methods\n\nThe trial randomized 120 participants.\n\nResults\n\nRecovery improved by 20 percent.",
+      metadata: { paperId: paper.id }
+    });
+    const chunk = db
+      .listArtifactChunks(project.id, source.id, 100)
+      .find((item) => item.text.includes("randomized 120 participants"))!;
+
+    const review = db.createReview({
+      projectId: project.id,
+      template: "general-empirical",
+      researchQuestion: "Do interventions improve recovery?",
+      objectives: ["Measure recovery"],
+      criteria: [
+        {
+          id: "criterion_original_abstract",
+          stage: "title-abstract",
+          type: "inclusion",
+          label: "Reports recovery outcomes",
+          order: 0
+        },
+        {
+          id: "criterion_original_fulltext",
+          stage: "full-text",
+          type: "exclusion",
+          label: "Wrong population",
+          order: 0
+        }
+      ]
+    });
+    const revisionOne = db.getReviewProtocolRevision(review.id)!;
+    const initialFullTextCriterion = revisionOne.criteria.find((criterion) => criterion.stage === "full-text")!;
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include",
+      protocolRevisionId: revisionOne.id
+    });
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "include",
+      protocolRevisionId: revisionOne.id
+    });
+    const field = db.saveExtractionField({
+      id: "field_original",
+      reviewId: review.id,
+      name: "Primary outcome",
+      type: "short-text",
+      order: 0
+    });
+    const runTimestamp = "2026-08-20T10:00:00.000Z";
+    db.saveReviewRun({
+      id: "review_run_original",
+      reviewId: review.id,
+      stage: "extraction",
+      provider: "ollama",
+      model: "portable-model",
+      protocolRevisionId: revisionOne.id,
+      status: "completed",
+      paperIds: [paper.id],
+      fieldIds: [field.id],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: runTimestamp,
+      updatedAt: runTimestamp,
+      startedAt: runTimestamp,
+      completedAt: runTimestamp
+    });
+    db.saveReviewRunItem({
+      id: "review_item_original",
+      runId: "review_run_original",
+      paperId: paper.id,
+      status: "completed",
+      attemptCount: 1,
+      rationale: "The full text reports a quantified recovery outcome.",
+      criterionAssessments: [
+        {
+          criterionId: initialFullTextCriterion.id,
+          assessment: "not-met",
+          explanation: "The population exclusion criterion was not met.",
+          evidenceIds: ["S1"]
+        }
+      ],
+      extractionSuggestions: [
+        {
+          fieldId: field.id,
+          value: "Recovery improved by 20 percent",
+          status: "suggested",
+          evidenceIds: ["S1"]
+        }
+      ],
+      evidence: [
+        {
+          id: "review_evidence_original",
+          reviewId: review.id,
+          evidenceId: "S1",
+          runId: "review_run_original",
+          runItemId: "review_item_original",
+          paperId: paper.id,
+          artifactId: source.id,
+          chunkId: chunk.chunkId,
+          sourceType: "artifact-chunk",
+          title: source.title,
+          excerpt: chunk.text,
+          locator: "Methods",
+          retrievalScore: 1,
+          createdAt: runTimestamp
+        }
+      ],
+      createdAt: runTimestamp,
+      updatedAt: runTimestamp,
+      startedAt: runTimestamp,
+      completedAt: runTimestamp
+    });
+    db.saveExtractionValue({
+      id: "extraction_value_original",
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Recovery improved by 20 percent",
+      status: "confirmed",
+      origin: "ai",
+      evidenceIds: ["review_evidence_original"],
+      runItemId: "review_item_original",
+      createdAt: runTimestamp,
+      updatedAt: runTimestamp,
+      confirmedAt: runTimestamp
+    });
+    db.appendReviewAuditEvent({
+      reviewId: review.id,
+      kind: "run-completed",
+      actor: "system",
+      entityType: "review-evidence",
+      entityId: "review_evidence_original",
+      payload: { evidenceId: "review_evidence_original", paperId: paper.id }
+    });
+    const revisedField = db.saveExtractionField({
+      id: field.id,
+      reviewId: review.id,
+      name: "Primary recovery outcome",
+      type: "short-text",
+      order: 0
+    });
+    expect(revisedField.revision).toBe(2);
+    const revisionTwo = db.reviseReviewProtocol({
+      reviewId: review.id,
+      researchQuestion: "Which interventions improve recovery?",
+      objectives: ["Measure recovery", "Record study design"],
+      criteria: [
+        {
+          id: "criterion_original_abstract_v2",
+          stage: "title-abstract",
+          type: "inclusion",
+          label: "Reports recovery outcomes",
+          order: 0
+        },
+        {
+          id: "criterion_original_fulltext_v2",
+          stage: "full-text",
+          type: "exclusion",
+          label: "Wrong population",
+          order: 0
+        }
+      ],
+      changeNote: "Clarified the research question"
+    });
+    db.markScreeningForRereview({
+      reviewId: review.id,
+      paperIds: [paper.id],
+      stage: "full-text"
+    });
+    const importBatch = db.saveDiscoveryBatch({
+      id: "batch_original_import",
+      reviewId: review.id,
+      kind: "reference-import",
+      label: "Imported RIS records",
+      fileName: "portable.ris",
+      importFormat: "ris",
+      status: "completed",
+      counts: { identified: 2, duplicates: 1, newRecords: 1 },
+      historicalCountsAvailable: true,
+      config: { parser: "ris", sourceFileHash: "portable-hash" },
+      createdAt: "2026-08-20T11:00:00.000Z",
+      completedAt: "2026-08-20T11:00:01.000Z"
+    });
+    db.recordReviewCandidateOrigin({
+      id: "origin_original_import",
+      reviewId: review.id,
+      batchId: importBatch.id,
+      paperId: paper.id,
+      matchedPaperId: paper.id,
+      sourceRecordId: "RIS-42",
+      resolution: "duplicate",
+      paperSnapshot: paper,
+      recordSnapshot: { title: paper.title, paperId: paper.id },
+      createdAt: "2026-08-20T11:00:00.500Z"
+    });
+
+    const services = { db, artifacts } as IpcServices;
+    const bundle = await buildProjectExportBundle(services, project.id);
+    expect(bundle.version).toBe(3);
+    expect(bundle.review).toBeDefined();
+    expect(bundle.review?.review.currentRevisionId).toBe(revisionTwo.id);
+    expect(bundle.review?.revisions.map((revision) => revision.version)).toEqual([2, 1]);
+    expect(bundle.review?.runItems[0]).toMatchObject({
+      id: "review_item_original",
+      stale: true,
+      evidenceIds: ["review_evidence_original"]
+    });
+    expect(bundle.review?.discoveryBatches.find((batch) => batch.id === importBatch.id)?.config).toEqual({
+      parser: "ris",
+      sourceFileHash: "portable-hash"
+    });
+
+    const untrustedBundle = structuredClone(bundle);
+    untrustedBundle.project.title = "Untrusted review evidence import";
+    untrustedBundle.artifacts.find((artifact) => artifact.id === source.id)!.type = "brief";
+    await expect(importProjectBundle(services, untrustedBundle)).rejects.toThrow(/untrusted or mismatched artifact/i);
+    expect(db.listProjects().some((candidate) => candidate.title === untrustedBundle.project.title)).toBe(false);
+
+    const missingChunkBundle = structuredClone(bundle);
+    missingChunkBundle.project.title = "Missing review chunk import";
+    missingChunkBundle.review!.evidence[0].chunkId = "missing-source-chunk";
+    missingChunkBundle.review!.evidence[0].excerpt = "Text that does not occur in the imported artifact.";
+    missingChunkBundle.review!.evidence[0].page = 7;
+    const filesBeforeMissingChunk = (await readdir(join(dir, "projects"), { recursive: true }))
+      .filter((path) => path.endsWith(".md"))
+      .sort();
+    const writeArtifact = artifacts.writeArtifact.bind(artifacts);
+    vi.spyOn(artifacts, "writeArtifact").mockImplementationOnce(async (input) => {
+      const imported = await writeArtifact(input);
+      const paperId = typeof input.metadata?.paperId === "string" ? input.metadata.paperId : undefined;
+      db.addDocumentChunks({
+        projectId: input.projectId,
+        artifactId: imported.id,
+        paperId,
+        chunks: [{ text: "Unrelated text on the same claimed page.", metadata: { page: 7 } }]
+      });
+      return imported;
+    });
+    await expect(importProjectBundle(services, missingChunkBundle)).rejects.toThrow(/trusted paper chunk/i);
+    expect(db.listProjects().some((candidate) => candidate.title === missingChunkBundle.project.title)).toBe(false);
+    expect(
+      (await readdir(join(dir, "projects"), { recursive: true })).filter((path) => path.endsWith(".md")).sort()
+    ).toEqual(filesBeforeMissingChunk);
+
+    const snapshotOnlyBundle = structuredClone(bundle);
+    snapshotOnlyBundle.project.title = "Snapshot-only review evidence import";
+    snapshotOnlyBundle.artifacts = snapshotOnlyBundle.artifacts.filter((artifact) => artifact.id !== source.id);
+    snapshotOnlyBundle.review!.evidence[0].artifactId = undefined;
+    snapshotOnlyBundle.review!.evidence[0].chunkId = undefined;
+    const snapshotOnlyProject = await importProjectBundle(services, snapshotOnlyBundle);
+    const snapshotOnlyReview = db.getReview(snapshotOnlyProject.id)!;
+    expect(db.exportReviewPortabilityState(snapshotOnlyReview.id).evidence[0]).toMatchObject({
+      artifactId: undefined,
+      chunkId: undefined,
+      excerpt: chunk.text
+    });
+
+    const duplicate = await importProjectBundle(services, {
+      ...bundle,
+      project: { ...bundle.project, title: "Portable evidence review copy" },
+      review: {
+        ...bundle.review!,
+        candidateOrigins: [
+          ...bundle.review!.candidateOrigins,
+          {
+            ...bundle.review!.candidateOrigins[0],
+            id: "origin-with-deleted-match",
+            sourceRecordId: "RIS-deleted-match",
+            matchedPaperId: "deleted-matched-paper",
+            recordSnapshot: { title: "Ambiguous source record" }
+          }
+        ]
+      }
+    });
+    const duplicateReview = db.getReview(duplicate.id)!;
+    const importedState = db.exportReviewPortabilityState(duplicateReview.id);
+    const duplicatePaper = db.listPapers(duplicate.id)[0];
+    const duplicateSource = db.listArtifacts(duplicate.id).find((artifact) => artifact.title === source.title)!;
+    const importedOrigin = importedState.candidateOrigins.find((origin) => origin.sourceRecordId === "RIS-42")!;
+    const importedEvidence = importedState.evidence[0];
+    const importedField = importedState.extractionFields[0];
+    const importedValue = importedState.extractionValues[0];
+    const importedRun = importedState.runs[0];
+    const importedItem = importedState.runItems[0];
+
+    expect(duplicateReview.id).not.toBe(review.id);
+    expect(duplicateReview.projectId).toBe(duplicate.id);
+    expect(duplicateReview.currentRevisionId).not.toBe(revisionTwo.id);
+    expect(importedState.revisions.map((revision) => revision.version)).toEqual([2, 1]);
+    expect(
+      importedState.revisions.flatMap((revision) => revision.criteria).map((criterion) => criterion.id)
+    ).not.toContain("criterion_original_abstract");
+    expect(importedOrigin).toMatchObject({
+      paperId: duplicatePaper.id,
+      matchedPaperId: duplicatePaper.id,
+      paperSnapshot: { id: duplicatePaper.id, projectId: duplicate.id }
+    });
+    expect(importedOrigin.recordSnapshot).toMatchObject({ paperId: duplicatePaper.id });
+    expect(
+      importedState.candidateOrigins.find((origin) => origin.sourceRecordId === "RIS-deleted-match")?.recordSnapshot
+    ).toMatchObject({ unavailableMatchedPaperId: "deleted-matched-paper" });
+    expect(importedState.screeningDecisions).toHaveLength(2);
+    expect(importedState.screeningDecisions.every((decision) => decision.paperId === duplicatePaper.id)).toBe(true);
+    expect(importedState.rereviewFlags).toHaveLength(1);
+    expect(importedState.rereviewFlags[0]).toMatchObject({
+      paperId: duplicatePaper.id,
+      stage: "full-text"
+    });
+    expect(importedField).toMatchObject({ name: "Primary recovery outcome", revision: 2 });
+    expect(importedField.id).not.toBe(field.id);
+    expect(importedState.extractionFieldHistory).not.toHaveLength(0);
+    expect(importedState.extractionFieldHistory?.every((entry) => entry.id === importedField.id)).toBe(true);
+    expect(importedValue).toMatchObject({
+      paperId: duplicatePaper.id,
+      fieldId: importedField.id,
+      fieldRevision: 2,
+      status: "needs-review",
+      origin: "ai",
+      runItemId: importedItem.id,
+      evidenceIds: [importedEvidence.id]
+    });
+    expect(importedState.extractionValueHistory).not.toHaveLength(0);
+    expect(importedState.extractionValueHistory?.every((entry) => entry.id === importedValue.id)).toBe(true);
+    expect(importedState.extractionValueHistory?.every((entry) => entry.paperId === duplicatePaper.id)).toBe(true);
+    expect(importedRun).toMatchObject({
+      status: "completed",
+      paperIds: [duplicatePaper.id],
+      fieldIds: [importedField.id],
+      protocolRevisionId: expect.not.stringMatching(revisionOne.id)
+    });
+    expect(importedRun.id).not.toBe("review_run_original");
+    expect(importedItem).toMatchObject({
+      runId: importedRun.id,
+      paperId: duplicatePaper.id,
+      stale: true,
+      evidenceIds: [importedEvidence.id],
+      paperSnapshot: { id: duplicatePaper.id, projectId: duplicate.id }
+    });
+    expect(importedItem.extractionSuggestions[0]?.fieldId).toBe(importedField.id);
+    expect(importedItem.criterionAssessments[0]?.criterionId).not.toBe(initialFullTextCriterion.id);
+    expect(
+      importedState.revisions
+        .flatMap((revision) => revision.criteria)
+        .some((criterion) =>
+          importedItem.criterionAssessments.some((assessment) => assessment.criterionId === criterion.id)
+        )
+    ).toBe(true);
+    expect(importedEvidence).toMatchObject({
+      paperId: duplicatePaper.id,
+      paperSnapshot: { id: duplicatePaper.id, projectId: duplicate.id },
+      artifactId: duplicateSource.id,
+      runId: importedRun.id,
+      runItemId: importedItem.id
+    });
+    expect(importedEvidence.id).not.toBe("review_evidence_original");
+    expect(importedEvidence.chunkId).toBeTruthy();
+    expect(importedEvidence.chunkId).not.toBe(chunk.chunkId);
+    expect(importedState.auditEvents.map((event) => event.kind)).toEqual(
+      bundle.review?.auditEvents.map((event) => event.kind)
+    );
+    expect(importedState.auditEvents).toHaveLength(bundle.review!.auditEvents.length);
+    expect(
+      importedState.auditEvents.find((event) => event.kind === "decision-marked-for-review")?.payload.paperIds
+    ).toEqual([duplicatePaper.id]);
+    expect(importedState.auditEvents.find((event) => event.entityType === "review-evidence")).toMatchObject({
+      entityId: importedEvidence.id,
+      payload: { evidenceId: importedEvidence.id, paperId: duplicatePaper.id }
+    });
+  });
+
+  it("preserves failed, partial, and cancelled review runs as terminal audit records", async () => {
+    const project = db.createProject("Terminal run review");
+    const paper = db.savePaper(project.id, {
+      id: "terminal-run-paper",
+      title: "Terminal run paper",
+      authors: [],
+      source: "reference-import",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id, researchQuestion: "What completed?" });
+    const revision = db.getReviewProtocolRevision(review.id)!;
+    for (const [index, status] of (["failed", "partial", "cancelled"] as const).entries()) {
+      db.saveReviewRun({
+        id: `terminal-run-${status}`,
+        reviewId: review.id,
+        stage: "title-abstract",
+        provider: "ollama",
+        model: "audit-model",
+        protocolRevisionId: revision.id,
+        status,
+        paperIds: [paper.id],
+        fieldIds: [],
+        completedCount: status === "partial" ? 1 : 0,
+        failedCount: status === "failed" ? 1 : 0,
+        cancelledCount: status === "cancelled" ? 1 : 0,
+        error: status === "failed" ? "provider unavailable" : undefined,
+        createdAt: `2026-08-2${index}T00:00:00.000Z`,
+        updatedAt: `2026-08-2${index}T00:01:00.000Z`,
+        completedAt: `2026-08-2${index}T00:01:00.000Z`
+      });
+    }
+    const services = { db, artifacts } as IpcServices;
+    const bundle = await buildProjectExportBundle(services, project.id);
+    expect(bundle.review?.runs.map((run) => run.status).sort()).toEqual(["cancelled", "failed", "partial"]);
+
+    const imported = await importProjectBundle(services, bundle);
+    const importedReview = db.getReview(imported.id)!;
+    expect(
+      db
+        .listReviewRuns(importedReview.id)
+        .map((run) => run.status)
+        .sort()
+    ).toEqual(["cancelled", "failed", "partial"]);
+  });
+
+  it.each([1, 2] as const)("continues importing legacy version %i bundles", async (version) => {
+    const project = db.createProject(`Legacy version ${version}`);
+    const services = { db, artifacts } as IpcServices;
+    const current = await buildProjectExportBundle(services, project.id);
+    const legacy = {
+      ...current,
+      version,
+      review: undefined,
+      ...(version === 1 ? { conversations: undefined, runs: undefined, citations: undefined } : {})
+    };
+
+    const imported = await importProjectBundle(services, legacy);
+    expect(imported.title).toBe(project.title);
+    expect(db.getReview(imported.id)).toBeUndefined();
   });
 });

--- a/tests/reference-import.test.ts
+++ b/tests/reference-import.test.ts
@@ -1,0 +1,520 @@
+import { describe, expect, it } from "vitest";
+import {
+  bibliographicFingerprint,
+  mergeAuthoritativeSourceIdentifiers,
+  normalizeDoi,
+  normalizeFirstAuthor,
+  normalizeSourceIdentifier,
+  PaperIdentityResolver,
+  resolvePaperIdentity
+} from "../src/main/services/paper-identity";
+import {
+  detectReferenceImportFormat,
+  inferCsvColumnMapping,
+  previewReferenceImport,
+  REFERENCE_IMPORT_MAX_BYTES,
+  REFERENCE_IMPORT_MAX_RECORDS,
+  ReferenceImportService
+} from "../src/main/services/reference-import-service";
+
+describe("ReferenceImportService", () => {
+  it("previews RIS records, including repeated authors and continued fields", () => {
+    const preview = previewReferenceImport({
+      format: "ris",
+      content: [
+        "TY  - JOUR",
+        "TI  - Evidence-Grounded Reviews",
+        "AU  - Doe, Jane",
+        "AU  - Smith, Alex",
+        "AB  - A structured abstract",
+        "      continued on the next line.",
+        "PY  - 2024/03/01",
+        "DO  - https://doi.org/10.1000/ABC.",
+        "UR  - https://example.test/article",
+        "L1  - https://example.test/article.pdf",
+        "JO  - Journal of Reviews",
+        "AN  - PMID-123",
+        "DP  - PubMed",
+        "TC  - 17",
+        "ER  -",
+        "TY  - JOUR",
+        "AU  - Missing, Title",
+        "ER  -"
+      ].join("\n")
+    });
+
+    expect(preview).toMatchObject({
+      format: "ris",
+      totalRecords: 2,
+      canCommit: true
+    });
+    expect(preview.records).toHaveLength(1);
+    expect(preview.invalidRecords).toEqual([
+      expect.objectContaining({ recordNumber: 2, errors: ["Title is required."] })
+    ]);
+    expect(preview.records[0].paper).toMatchObject({
+      title: "Evidence-Grounded Reviews",
+      abstract: "A structured abstract continued on the next line.",
+      authors: ["Doe, Jane", "Smith, Alex"],
+      year: 2024,
+      doi: "10.1000/abc",
+      url: "https://example.test/article",
+      pdfUrl: "https://example.test/article.pdf",
+      venue: "Journal of Reviews",
+      source: "reference-import",
+      sourcePaperId: "PMID-123",
+      sourceAuthority: "pubmed",
+      citationCount: 17,
+      isOpenAccess: false
+    });
+    expect(preview.records[0].provenance).toMatchObject({
+      source: "reference-import",
+      format: "ris",
+      recordNumber: 1,
+      sourceIdentifier: "PMID-123",
+      sourceAuthority: "pubmed"
+    });
+  });
+
+  it("parses nested BibTeX values and preserves source identity metadata", () => {
+    const preview = previewReferenceImport({
+      fileName: "library.bib",
+      content: `
+        @comment{ignored}
+        @article{smith2023,
+          title = {A {Grounded} Review},
+          author = {Smith, Jane and {Evidence Consortium}},
+          abstract = "An {auditable} result",
+          year = 2023,
+          doi = {doi:10.5555/EXAMPLE},
+          url = {https://example.test/record},
+          pdf = {https://example.test/record.pdf},
+          journal = {Review Science},
+          archivePrefix = {arXiv},
+          eprint = {2301.12345v2},
+          citationCount = {9}
+        }
+      `
+    });
+
+    expect(preview.fileErrors).toEqual([]);
+    expect(preview.records).toHaveLength(1);
+    expect(preview.records[0].paper).toMatchObject({
+      title: "A Grounded Review",
+      authors: ["Smith, Jane", "Evidence Consortium"],
+      abstract: "An auditable result",
+      year: 2023,
+      doi: "10.5555/example",
+      sourcePaperId: "2301.12345v2",
+      sourceAuthority: "arxiv",
+      citationCount: 9
+    });
+  });
+
+  it("reports malformed BibTeX and missing required titles per entry", () => {
+    const missingTitle = previewReferenceImport({
+      format: "bibtex",
+      content: "@article{key, author={Doe, Jane}, year={2020}}"
+    });
+    expect(missingTitle.records).toEqual([]);
+    expect(missingTitle.invalidRecords[0].errors).toContain("Title is required.");
+
+    const malformed = previewReferenceImport({
+      format: "bibtex",
+      content: "@article{key, title={Never closed}"
+    });
+    expect(malformed.canCommit).toBe(false);
+    expect(malformed.invalidRecords[0].errors[0]).toContain("no closing brace");
+  });
+
+  it("infers CSV columns and handles quoted commas, escaped quotes, and newlines", () => {
+    const content = [
+      "Paper Title,Authors,Abstract,Publication Year,DOI,Full Text URL,Citations",
+      '"A CSV Study","Doe, Jane; Smith, Alex","First line',
+      'second line with ""quoted"" text",2022,10.1000/csv,https://example.test/paper.pdf,4'
+    ].join("\n");
+    const preview = previewReferenceImport({ fileName: "references.csv", content });
+
+    expect(preview.csv?.suggestedMapping).toMatchObject({
+      title: "Paper Title",
+      authors: "Authors",
+      abstract: "Abstract",
+      year: "Publication Year",
+      pdfUrl: "Full Text URL",
+      citationCount: "Citations"
+    });
+    expect(preview.records[0].paper).toMatchObject({
+      title: "A CSV Study",
+      authors: ["Doe, Jane", "Smith, Alex"],
+      abstract: 'First line second line with "quoted" text',
+      year: 2022,
+      doi: "10.1000/csv",
+      citationCount: 4
+    });
+  });
+
+  it("applies editable CSV mappings and rejects unknown or absent title columns", () => {
+    const service = new ReferenceImportService();
+    const preview = service.preview({
+      format: "csv",
+      content: "Work,People,When,Identifier\nMapped study,Doe; Roe,2021,10.1234/mapped",
+      csvMapping: {
+        title: "Work",
+        authors: "People",
+        year: "When",
+        doi: "Identifier"
+      }
+    });
+    expect(preview.records[0].paper).toMatchObject({
+      title: "Mapped study",
+      authors: ["Doe", "Roe"],
+      year: 2021,
+      doi: "10.1234/mapped"
+    });
+
+    const missingTitle = service.preview({
+      format: "csv",
+      content: "Work,Year\nStudy,2020",
+      csvMapping: { year: "Year" }
+    });
+    expect(missingTitle.canCommit).toBe(false);
+    expect(missingTitle.fileErrors).toContain("CSV mapping must select a title column.");
+
+    const unknownColumn = service.preview({
+      format: "csv",
+      content: "Title\nStudy",
+      csvMapping: { title: "Not a column" }
+    });
+    expect(unknownColumn.fileErrors.join(" ")).toContain("unknown column");
+  });
+
+  it("reports invalid standard field values without discarding other rows", () => {
+    const preview = previewReferenceImport({
+      format: "csv",
+      content: [
+        "Title,Year,URL,Citation Count",
+        "Bad study,unknown,relative/path,-1",
+        "Good study,2020,https://example.test/good,2"
+      ].join("\n")
+    });
+
+    expect(preview.records).toHaveLength(1);
+    expect(preview.records[0].paper.title).toBe("Good study");
+    expect(preview.invalidRecords[0].errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Year must contain"),
+        expect.stringContaining("Citation count must"),
+        expect.stringContaining("URL must be")
+      ])
+    );
+  });
+
+  it("enforces configurable test limits and exposes the production limits", () => {
+    expect(REFERENCE_IMPORT_MAX_BYTES).toBe(50 * 1024 * 1024);
+    expect(REFERENCE_IMPORT_MAX_RECORDS).toBe(50_000);
+
+    const tooLarge = previewReferenceImport(
+      { format: "csv", content: "Title\nA record that is too large" },
+      { maxBytes: 10 }
+    );
+    expect(tooLarge.canCommit).toBe(false);
+    expect(tooLarge.fileErrors[0]).toContain("10 bytes");
+
+    const tooMany = previewReferenceImport({ format: "csv", content: "Title\nOne\nTwo\nThree" }, { maxRecords: 2 });
+    expect(tooMany.canCommit).toBe(false);
+    expect(tooMany.totalRecords).toBe(3);
+    expect(tooMany.fileErrors[0]).toContain("at most 2 records");
+  });
+
+  it("detects supported formats without retaining a supplied path", () => {
+    expect(detectReferenceImportFormat("C:\\private\\library.ris")).toBe("ris");
+    expect(detectReferenceImportFormat(undefined, "@article{key, title={Study}}")).toBe("bibtex");
+    expect(detectReferenceImportFormat(undefined, "Title,Year\nStudy,2020")).toBe("csv");
+    expect(inferCsvColumnMapping(["ARTICLE_TITLE", "times-cited"])).toEqual({
+      title: "ARTICLE_TITLE",
+      citationCount: "times-cited"
+    });
+  });
+});
+
+describe("paper identity resolution", () => {
+  it("normalizes DOI, source identifiers, and author name order", () => {
+    expect(normalizeDoi(" https://doi.org/10.1000%2FABC. ")).toBe("10.1000/abc");
+    expect(normalizeDoi("DOI: 10.5555/ABC-123")).toBe("10.5555/abc-123");
+    expect(normalizeDoi("urn:doi:10.1002/(SICI)1099-0844(199912)17:4<290::AID-CBF849>3.0.CO;2-P")).toBe(
+      "10.1002/(sici)1099-0844(199912)17:4<290::aid-cbf849>3.0.co;2-p"
+    );
+    expect(normalizeSourceIdentifier("https://arxiv.org/pdf/2301.12345v3.pdf", "arXiv")).toBe("2301.12345");
+    expect(normalizeFirstAuthor("Jane Q. Doe")).toBe("doe:jq");
+    expect(normalizeFirstAuthor("Doe, Jane Q.")).toBe("doe:jq");
+  });
+
+  it("treats placeholder and malformed DOI values as absent identity evidence", () => {
+    const invalidDois = [
+      "N/A",
+      "unknown",
+      "not available",
+      "-",
+      "arbitrary-reference-value",
+      "10.123/too-short-prefix",
+      "10.1234/contains whitespace",
+      "10.1234/bad%ZZencoding"
+    ];
+
+    for (const doi of invalidDois) {
+      expect(normalizeDoi(doi)).toBeUndefined();
+      expect(
+        resolvePaperIdentity({ title: `Incoming ${doi}`, doi }, [
+          { id: `existing-${doi}`, title: `Unrelated ${doi}`, doi }
+        ])
+      ).toEqual({ kind: "none", candidates: [] });
+    }
+  });
+
+  it("exact-matches equivalent valid DOI prefix and URL forms", () => {
+    const candidates = [{ id: "valid-doi", title: "Stored record", doi: "DOI: 10.5555/ABC-123" }];
+
+    expect(
+      resolvePaperIdentity({ title: "Incoming record", doi: "https://doi.org/10.5555%2Fabc-123" }, candidates)
+    ).toMatchObject({
+      kind: "exact",
+      strategy: "doi",
+      candidate: { id: "valid-doi" }
+    });
+    expect(
+      resolvePaperIdentity({ title: "Incoming record", doi: "URN:DOI:10.5555/ABC-123" }, candidates)
+    ).toMatchObject({
+      kind: "exact",
+      strategy: "doi",
+      candidate: { id: "valid-doi" }
+    });
+    expect(
+      resolvePaperIdentity({ title: "Incoming record", doi: "http://dx.doi.org/10.5555/ABC-123." }, candidates)
+    ).toMatchObject({ kind: "exact", strategy: "doi", candidate: { id: "valid-doi" } });
+  });
+
+  it("uses DOI, authoritative source IDs, then full bibliographic fingerprints", () => {
+    const candidates = [
+      {
+        id: "doi-paper",
+        title: "Different metadata",
+        doi: "10.1000/exact",
+        authors: ["One Author"],
+        year: 2018
+      },
+      {
+        id: "source-paper",
+        title: "Source record",
+        source: "arxiv",
+        sourcePaperId: "2301.12345",
+        authors: ["Two Author"],
+        year: 2019
+      },
+      {
+        id: "fingerprint-paper",
+        title: "The Same: Study!",
+        authors: ["Doe, Jane"],
+        year: 2020
+      }
+    ];
+
+    expect(resolvePaperIdentity({ title: "Incoming", doi: "https://doi.org/10.1000/EXACT" }, candidates)).toMatchObject(
+      { kind: "exact", strategy: "doi", candidate: { id: "doi-paper" } }
+    );
+    expect(
+      resolvePaperIdentity({ title: "Incoming", sourceAuthority: "arXiv", sourcePaperId: "2301.12345v2" }, candidates)
+    ).toMatchObject({ kind: "exact", strategy: "source-identifier", candidate: { id: "source-paper" } });
+    expect(
+      resolvePaperIdentity({ title: "Incoming", sourceAuthority: "arXiv", sourcePaperId: "2301.12345v2" }, [
+        {
+          id: "imported-source-paper",
+          title: "Imported source record",
+          source: "reference-import",
+          sourcePaperId: "2301.12345",
+          raw: { sourceAuthority: "arxiv" }
+        }
+      ])
+    ).toMatchObject({ kind: "exact", strategy: "source-identifier", candidate: { id: "imported-source-paper" } });
+    expect(
+      resolvePaperIdentity({ title: "The same study", authors: ["Jane Doe"], year: 2020 }, candidates)
+    ).toMatchObject({
+      kind: "exact",
+      strategy: "bibliographic-fingerprint",
+      candidate: { id: "fingerprint-paper" }
+    });
+    expect(bibliographicFingerprint({ title: "The same study", authors: ["Jane Doe"], year: 2020 })).toBe(
+      "bibliographic:the same study|2020|doe:j"
+    );
+    expect(bibliographicFingerprint({ title: "临床试验结果", authors: ["王, 小明"], year: 2024 })).toBe(
+      "bibliographic:临床试验结果|2024|王:小"
+    );
+  });
+
+  it("never auto-merges a title-only match", () => {
+    const result = resolvePaperIdentity({ title: "A Shared Title" }, [
+      { id: "existing", title: "A shared title", authors: ["Someone Else"], year: 2019 }
+    ]);
+    expect(result).toMatchObject({
+      kind: "ambiguous",
+      strategy: "title-only",
+      candidates: [{ id: "existing" }]
+    });
+  });
+
+  it("returns ambiguity for duplicate fingerprints and conflicting persistent IDs", () => {
+    const duplicateFingerprint = resolvePaperIdentity({ title: "Same", authors: ["Jane Doe"], year: 2020 }, [
+      { id: "one", title: "Same", authors: ["Doe, Jane"], year: 2020 },
+      { id: "two", title: "Same", authors: ["Jane Doe"], year: 2020 }
+    ]);
+    expect(duplicateFingerprint).toMatchObject({
+      kind: "ambiguous",
+      strategy: "bibliographic-fingerprint"
+    });
+
+    const conflicting = resolvePaperIdentity({ title: "Same", authors: ["Jane Doe"], year: 2020, doi: "10.1234/new" }, [
+      { id: "old", title: "Same", authors: ["Doe, Jane"], year: 2020, doi: "10.1234/old" }
+    ]);
+    expect(conflicting).toMatchObject({ kind: "ambiguous", strategy: "conflicting-identifiers" });
+  });
+
+  it("supports incremental batch resolution", () => {
+    const resolver = new PaperIdentityResolver<{ id: string; title: string; authors: string[]; year: number }>();
+    expect(resolver.resolve({ title: "First" })).toEqual({ kind: "none", candidates: [] });
+    resolver.add({ id: "first", title: "First", authors: ["Jane Doe"], year: 2024 });
+    expect(resolver.list()).toHaveLength(1);
+    expect(resolver.resolve({ title: "First", authors: ["Doe, Jane"], year: 2024 })).toMatchObject({
+      kind: "exact",
+      strategy: "bibliographic-fingerprint"
+    });
+  });
+
+  it("rejects duplicate candidate IDs without corrupting the resolver", () => {
+    const first = { id: "paper-1", title: "First", authors: ["Jane Doe"], year: 2024 };
+    const second = { id: "paper-2", title: "Second", authors: ["Alex Smith"], year: 2023 };
+    const resolver = new PaperIdentityResolver([first, second]);
+
+    expect(() => resolver.add({ id: "paper-1", title: "Duplicate", authors: ["Taylor Jones"], year: 2022 })).toThrow(
+      "duplicate paper identity candidate ID: paper-1"
+    );
+    expect(() => resolver.replace(first, { ...first, id: "paper-2" })).toThrow("duplicate ID: paper-2");
+
+    expect(resolver.list()).toEqual([first, second]);
+    expect(resolver.resolve({ title: "First", authors: ["Doe, Jane"], year: 2024 })).toMatchObject({
+      kind: "exact",
+      candidate: { id: "paper-1" }
+    });
+  });
+
+  it("retains a foreign authoritative identifier without assigning it to the wrong source", () => {
+    const current = {
+      id: "crossref-paper",
+      title: "Shared record",
+      source: "crossref",
+      authors: ["Jane Doe"],
+      year: 2024
+    };
+    const identity = mergeAuthoritativeSourceIdentifiers(current, {
+      title: "Shared record",
+      source: "openalex",
+      sourcePaperId: "https://openalex.org/W123"
+    });
+
+    expect(identity.sourcePaperId).toBeUndefined();
+    expect(identity.raw.identitySourceIdentifiers).toEqual([{ authority: "openalex", identifier: "w123" }]);
+    expect(
+      resolvePaperIdentity({ title: "Updated title", source: "openalex", sourcePaperId: "W123" }, [
+        { ...current, raw: identity.raw }
+      ])
+    ).toMatchObject({ kind: "exact", strategy: "source-identifier", candidate: { id: "crossref-paper" } });
+  });
+
+  it("indexes the full 50,000-record import limit and updates keys incrementally", () => {
+    const candidates = Array.from({ length: REFERENCE_IMPORT_MAX_RECORDS }, (_, index) => ({
+      id: `paper-${index}`,
+      title: `Unique paper ${index}`,
+      authors: [`Author ${index}`],
+      year: 2020,
+      source: "openalex",
+      sourcePaperId: `W${index}`
+    }));
+    const resolver = new PaperIdentityResolver(candidates);
+
+    expect(resolver.resolve({ title: "Changed title", source: "openalex", sourcePaperId: "W49999" })).toMatchObject({
+      kind: "exact",
+      strategy: "source-identifier",
+      candidate: { id: "paper-49999" }
+    });
+
+    const previous = candidates[12345];
+    const enriched = { ...previous, doi: "10.1000/new-identifier" };
+    resolver.replace({ ...previous }, enriched);
+    expect(resolver.resolve({ title: "Unrelated", doi: "10.1000/new-identifier" })).toMatchObject({
+      kind: "exact",
+      strategy: "doi",
+      candidate: { id: "paper-12345" }
+    });
+  });
+
+  it("keeps repeated replacement lookups bounded instead of scanning the candidate set", () => {
+    type CountedCandidate = {
+      id: string;
+      title: string;
+      authors: string[];
+      year: number;
+      source: string;
+      sourcePaperId: string;
+    };
+    let storedIdReads = 0;
+    const candidateCount = 4_000;
+    const replacementCount = 250;
+    const candidates = Array.from({ length: candidateCount }, (_, index) => {
+      const candidate = {
+        title: `Scale paper ${index}`,
+        authors: [`Author ${index}`],
+        year: 2020,
+        source: "openalex",
+        sourcePaperId: `W${index}`
+      } as CountedCandidate;
+      Object.defineProperty(candidate, "id", {
+        configurable: false,
+        enumerable: true,
+        get: () => {
+          storedIdReads += 1;
+          return `paper-${index}`;
+        }
+      });
+      return candidate;
+    });
+    const resolver = new PaperIdentityResolver(candidates);
+    storedIdReads = 0;
+
+    for (let offset = 0; offset < replacementCount; offset += 1) {
+      const index = candidateCount - replacementCount + offset;
+      resolver.replace(
+        {
+          id: `paper-${index}`,
+          title: "Lookup placeholder",
+          authors: [],
+          year: 2020,
+          source: "openalex",
+          sourcePaperId: `W${index}`
+        },
+        {
+          id: `paper-${index}`,
+          title: `Enriched scale paper ${index}`,
+          authors: [`Author ${index}`],
+          year: 2020,
+          source: "openalex",
+          sourcePaperId: `W${index}`
+        }
+      );
+    }
+
+    expect(storedIdReads).toBeLessThanOrEqual(replacementCount);
+    expect(resolver.list()).toHaveLength(candidateCount);
+    expect(resolver.resolve({ title: "Unrelated", source: "openalex", sourcePaperId: "W3999" })).toMatchObject({
+      kind: "exact",
+      candidate: { id: "paper-3999", title: "Enriched scale paper 3999" }
+    });
+  });
+});

--- a/tests/review-agent-service.test.ts
+++ b/tests/review-agent-service.test.ts
@@ -1,0 +1,665 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PaperPilotDb } from "../src/main/db";
+import { ReviewAgentService, type ReviewProvider } from "../src/main/services/review-agent-service";
+import type { CredentialService } from "../src/main/services/credential-service";
+import type { ProviderChatInput, ProviderChatResult } from "../src/main/services/research-provider";
+import type { SettingsService } from "../src/main/services/settings-service";
+import type { AppSettings, ReviewRun, ReviewRunEvent } from "../src/shared/schemas";
+
+let directory: string;
+let db: PaperPilotDb;
+
+const settings: AppSettings = {
+  ui: { theme: "system" },
+  ai: {
+    provider: "ollama",
+    baseUrl: "http://ollama.test",
+    model: "review-model",
+    hasApiKey: false,
+    reasoningEnabled: false
+  },
+  python: { runtimeMode: "managed", markitdownEnabled: true },
+  sources: { disabledSourceIds: [] }
+};
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "paper-pilot-review-agent-"));
+  db = new PaperPilotDb(join(directory, "test.db"));
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe("ReviewAgentService", () => {
+  it("persists an evidence-backed advisory screening item without model tools", async () => {
+    const fixture = createFixture();
+    const provider = queueProvider([
+      JSON.stringify({
+        decision: "include",
+        rationale: "The population is relevant.",
+        assessments: [
+          {
+            criterionId: fixture.criterionId,
+            assessment: "met",
+            explanation: "The abstract describes the target population.",
+            evidenceIds: ["S2"]
+          }
+        ]
+      })
+    ]);
+    const service = createService(provider);
+
+    const complete = completionPromise();
+    const run = await service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    const event = await complete.promise;
+
+    expect(event.type).toBe("complete");
+    expect(db.getReviewRun(run.id)?.status).toBe("completed");
+    expect(db.listReviewRunItems(run.id)[0]).toMatchObject({
+      status: "completed",
+      suggestedDecision: "include",
+      attemptCount: 1,
+      criterionAssessments: [expect.objectContaining({ criterionId: fixture.criterionId, evidenceIds: ["S2"] })]
+    });
+    expect(db.listReviewEvidence(fixture.reviewId, { runId: run.id })).toEqual(
+      expect.arrayContaining([expect.objectContaining({ evidenceId: "S2", sourceType: "paper-abstract" })])
+    );
+    expect(provider.chat).toHaveBeenCalledWith(expect.not.objectContaining({ tools: expect.anything() }));
+  });
+
+  it("repairs malformed provider output once and then fails closed", async () => {
+    const fixture = createFixture();
+    const provider = queueProvider(["not json", "still not json"]);
+    const service = createService(provider);
+    const complete = completionPromise();
+
+    const run = await service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    await complete.promise;
+
+    expect(provider.chat).toHaveBeenCalledTimes(2);
+    expect(db.getReviewRun(run.id)).toMatchObject({ status: "failed", failedCount: 1 });
+    expect(db.listReviewRunItems(run.id)[0]).toMatchObject({
+      status: "failed",
+      suggestedDecision: undefined,
+      evidence: []
+    });
+    expect(db.listReviewEvidence(fixture.reviewId, { runId: run.id })).toEqual([]);
+  });
+
+  it("finalizes an unexpected persistence failure instead of leaving the run active", async () => {
+    const fixture = createFixture();
+    const provider = queueProvider([validIncludeResponse(fixture.criterionId).content]);
+    const originalUpdate = db.updateReviewRunItem.bind(db);
+    let injectedFailures = 2;
+    vi.spyOn(db, "updateReviewRunItem").mockImplementation((itemId, patch) => {
+      if ((patch.status === "completed" || patch.status === "failed") && injectedFailures > 0) {
+        injectedFailures -= 1;
+        throw new Error("Injected persistence failure");
+      }
+      return originalUpdate(itemId, patch);
+    });
+    const service = createService(provider);
+    const complete = completionPromise();
+
+    const run = await service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    const event = await complete.promise;
+
+    expect(event.run).toMatchObject({ id: run.id, status: "failed" });
+    expect(db.getReviewRun(run.id)).toMatchObject({ status: "failed", error: expect.stringMatching(/unexpectedly/i) });
+    await vi.waitFor(() => expect(service.isProjectActive(db.getReviewById(fixture.reviewId)!.projectId)).toBe(false));
+  });
+
+  it("refuses an in-place retry when global provider provenance changed", async () => {
+    const fixture = createFixture();
+    const provider = queueProvider(["not json", "still not json"]);
+    const changedSettings: AppSettings = {
+      ...settings,
+      ai: { ...settings.ai, provider: "vercel", model: "different-model" }
+    };
+    const settingsService = {
+      get: vi.fn().mockResolvedValueOnce(settings).mockResolvedValue(changedSettings)
+    } as unknown as SettingsService;
+    const service = new ReviewAgentService(db, settingsService, {} as CredentialService, provider);
+    const complete = completionPromise();
+    const run = await service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    await complete.promise;
+
+    await expect(service.retry(run.id, () => undefined)).rejects.toThrow(/original ollama model review-model/i);
+    expect(db.getReviewRun(run.id)?.status).toBe("failed");
+    expect(db.listReviewRunItems(run.id)[0]?.status).toBe("failed");
+  });
+
+  it("atomically reserves a project across simultaneous retry calls", async () => {
+    const fixture = createFixture();
+    const failedRun = createFailedRun(fixture, "failed-concurrent-retry");
+    const settingsGate = deferred<AppSettings>();
+    const settingsService = {
+      get: vi.fn(() => settingsGate.promise)
+    } as unknown as SettingsService;
+    const provider = queueProvider([validIncludeResponse(fixture.criterionId).content]);
+    const service = new ReviewAgentService(db, settingsService, {} as CredentialService, provider);
+    const complete = completionPromise();
+
+    const firstRetry = service.retry(failedRun.id, complete.emit);
+    expect(service.isProjectActive(db.getReviewById(fixture.reviewId)!.projectId)).toBe(true);
+    await expect(service.retry(failedRun.id, () => undefined)).rejects.toThrow(/already has an active review run/i);
+
+    settingsGate.resolve(settings);
+    await firstRetry;
+    await complete.promise;
+
+    expect(settingsService.get).toHaveBeenCalledTimes(1);
+    expect(provider.chat).toHaveBeenCalledTimes(1);
+    expect(db.getReviewRun(failedRun.id)).toMatchObject({ status: "completed", completedCount: 1 });
+  });
+
+  it("shares the atomic reservation between start and retry", async () => {
+    const fixture = createFixture();
+    const failedRun = createFailedRun(fixture, "failed-start-versus-retry");
+    const settingsGate = deferred<AppSettings>();
+    const settingsService = {
+      get: vi.fn(() => settingsGate.promise)
+    } as unknown as SettingsService;
+    const provider = queueProvider([validIncludeResponse(fixture.criterionId).content]);
+    const service = new ReviewAgentService(db, settingsService, {} as CredentialService, provider);
+    const complete = completionPromise();
+
+    const starting = service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    await expect(service.retry(failedRun.id, () => undefined)).rejects.toThrow(/already has an active review run/i);
+
+    settingsGate.resolve(settings);
+    const startedRun = await starting;
+    await complete.promise;
+
+    expect(startedRun.id).not.toBe(failedRun.id);
+    expect(settingsService.get).toHaveBeenCalledTimes(1);
+    expect(provider.chat).toHaveBeenCalledTimes(1);
+    expect(db.getReviewRun(failedRun.id)?.status).toBe("failed");
+    expect(db.getReviewRun(startedRun.id)?.status).toBe("completed");
+  });
+
+  it("releases a reservation when setup fails before launch", async () => {
+    const fixture = createFixture();
+    const settingsService = {
+      get: vi.fn().mockRejectedValueOnce(new Error("Settings unavailable")).mockResolvedValue(settings)
+    } as unknown as SettingsService;
+    const provider = queueProvider([validIncludeResponse(fixture.criterionId).content]);
+    const service = new ReviewAgentService(db, settingsService, {} as CredentialService, provider);
+
+    await expect(
+      service.start(
+        { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+        () => undefined
+      )
+    ).rejects.toThrow(/settings unavailable/i);
+    expect(service.isProjectActive(db.getReviewById(fixture.reviewId)!.projectId)).toBe(false);
+
+    const complete = completionPromise();
+    const run = await service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    await complete.promise;
+    expect(db.getReviewRun(run.id)?.status).toBe("completed");
+    expect(provider.chat).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a finishing run clear a newer reservation", async () => {
+    const fixture = createFixture();
+    const secondSettings = deferred<AppSettings>();
+    const settingsService = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce(settings)
+        .mockImplementation(() => secondSettings.promise)
+    } as unknown as SettingsService;
+    const provider = queueProvider([
+      validIncludeResponse(fixture.criterionId).content,
+      validIncludeResponse(fixture.criterionId).content
+    ]);
+    const service = new ReviewAgentService(db, settingsService, {} as CredentialService, provider);
+    const firstCompleted = deferred<void>();
+    const secondComplete = completionPromise();
+    let secondStart: Promise<ReviewRun> | undefined;
+
+    await service.start(
+      { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+      (event) => {
+        if (event.type !== "complete") return;
+        secondStart = service.start(
+          { reviewId: fixture.reviewId, stage: "title-abstract", paperIds: [fixture.paperId] },
+          secondComplete.emit
+        );
+        firstCompleted.resolve(undefined);
+      }
+    );
+    await firstCompleted.promise;
+    await Promise.resolve();
+    expect(service.isProjectActive(db.getReviewById(fixture.reviewId)!.projectId)).toBe(true);
+
+    secondSettings.resolve(settings);
+    expect(secondStart).toBeDefined();
+    await secondStart!;
+    await secondComplete.promise;
+    expect(provider.chat).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses an AbortController, retains completed work, and retries only cancelled items", async () => {
+    const fixture = createFixture(true);
+    let runId = "";
+    const provider: ReviewProvider = {
+      chat: vi
+        .fn<ReviewProvider["chat"]>()
+        .mockResolvedValueOnce(validIncludeResponse(fixture.criterionId))
+        .mockImplementationOnce((input) => {
+          queueMicrotask(() => service.cancel(runId));
+          return abortableProviderResponse(input);
+        })
+        .mockResolvedValueOnce(validIncludeResponse(fixture.criterionId))
+    };
+    const service = createService(provider);
+    const cancelled = completionPromise();
+    const run = await service.start(
+      {
+        reviewId: fixture.reviewId,
+        stage: "title-abstract",
+        paperIds: [fixture.paperId, fixture.secondPaperId!]
+      },
+      cancelled.emit
+    );
+    runId = run.id;
+    await cancelled.promise;
+    expect(db.getReviewRun(run.id)).toMatchObject({ status: "cancelled", completedCount: 1, cancelledCount: 1 });
+
+    const retried = completionPromise();
+    await service.retry(run.id, retried.emit);
+    await retried.promise;
+
+    expect(db.getReviewRun(run.id)).toMatchObject({ status: "completed", completedCount: 2 });
+    expect(provider.chat).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not call a provider for full-text screening without trusted indexed text", async () => {
+    const fixture = createFixture();
+    db.setScreeningDecision({
+      reviewId: fixture.reviewId,
+      paperId: fixture.paperId,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    const provider = queueProvider([]);
+    const service = createService(provider);
+    const complete = completionPromise();
+
+    const run = await service.start(
+      { reviewId: fixture.reviewId, stage: "full-text", paperIds: [fixture.paperId] },
+      complete.emit
+    );
+    await complete.promise;
+
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(db.listReviewRunItems(run.id)[0]).toMatchObject({
+      status: "completed",
+      suggestedDecision: "uncertain",
+      rationale: expect.stringMatching(/no trusted indexed full text/i)
+    });
+  });
+
+  it("processes extraction fields in groups of at most six and stores evidence-backed suggestions", async () => {
+    const fixture = createFixture();
+    db.setScreeningDecision({
+      reviewId: fixture.reviewId,
+      paperId: fixture.paperId,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    db.setScreeningDecision({
+      reviewId: fixture.reviewId,
+      paperId: fixture.paperId,
+      stage: "full-text",
+      decision: "include"
+    });
+    db.saveArtifact({
+      id: "full_text",
+      projectId: db.getReviewById(fixture.reviewId)!.projectId,
+      type: "paper-pdf",
+      title: "Indexed full text",
+      path: join(directory, "full-text.pdf"),
+      mime: "application/pdf",
+      hash: "fixture",
+      source: "test",
+      metadata: { paperId: fixture.paperId },
+      createdAt: new Date().toISOString()
+    });
+    db.addDocumentChunks({
+      projectId: db.getReviewById(fixture.reviewId)!.projectId,
+      artifactId: "full_text",
+      paperId: fixture.paperId,
+      chunks: [{ text: "The measured result was 42 participants.", metadata: { page: 3 } }]
+    });
+    const fields = Array.from({ length: 7 }, (_, index) =>
+      db.saveExtractionField({
+        reviewId: fixture.reviewId,
+        name: `Field ${index + 1}`,
+        type: "number",
+        order: index
+      })
+    );
+    const provider = queueProvider([
+      extractionResponse(fields.slice(0, 6).map((field) => field.id)),
+      extractionResponse(fields.slice(6).map((field) => field.id))
+    ]);
+    const service = createService(provider);
+    const complete = completionPromise();
+
+    const run = await service.start(
+      {
+        reviewId: fixture.reviewId,
+        stage: "extraction",
+        paperIds: [fixture.paperId],
+        fieldIds: fields.map((field) => field.id)
+      },
+      complete.emit
+    );
+    await complete.promise;
+
+    expect(provider.chat).toHaveBeenCalledTimes(2);
+    expect(db.listReviewRunItems(run.id)[0]?.error).toBeUndefined();
+    expect(db.getReviewRun(run.id)?.status).toBe("completed");
+    expect(db.listExtractionValues(fixture.reviewId, fixture.paperId)).toHaveLength(7);
+    expect(db.listExtractionValues(fixture.reviewId, fixture.paperId)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: 42, status: "suggested", origin: "ai", evidenceIds: [expect.any(String)] })
+      ])
+    );
+  });
+
+  it("keeps missing-evidence not-found results advisory until a reviewer accepts them", async () => {
+    const fixture = createFixture();
+    includeForExtraction(fixture.reviewId, fixture.paperId);
+    const field = db.saveExtractionField({
+      reviewId: fixture.reviewId,
+      name: "Outcome",
+      type: "short-text"
+    });
+    const provider = queueProvider([]);
+    const service = createService(provider);
+    const complete = completionPromise();
+
+    const run = await service.start(
+      {
+        reviewId: fixture.reviewId,
+        stage: "extraction",
+        paperIds: [fixture.paperId],
+        fieldIds: [field.id]
+      },
+      complete.emit
+    );
+    await complete.promise;
+
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(db.listReviewRunItems(run.id)[0]?.extractionSuggestions).toEqual([
+      expect.objectContaining({ fieldId: field.id, status: "not-found", value: null })
+    ]);
+    expect(db.listExtractionValues(fixture.reviewId, fixture.paperId)).toEqual([
+      expect.objectContaining({ fieldId: field.id, status: "suggested", value: null, origin: "ai" })
+    ]);
+    expect(db.getReviewFlowSummary(fixture.reviewId).extraction).toMatchObject({
+      totalCells: 1,
+      confirmedCells: 0,
+      notFoundCells: 0,
+      needsReviewCells: 1,
+      completionPercent: 0
+    });
+  });
+
+  it("persists model uncertainty as an unresolved needs-review advisory", async () => {
+    const fixture = createFixture();
+    includeForExtraction(fixture.reviewId, fixture.paperId);
+    addIndexedFullText(fixture.reviewId, fixture.paperId, "The report gives conflicting descriptions of the outcome.");
+    const field = db.saveExtractionField({
+      reviewId: fixture.reviewId,
+      name: "Outcome",
+      type: "short-text"
+    });
+    const provider = queueProvider([
+      JSON.stringify({
+        values: [
+          {
+            fieldId: field.id,
+            status: "unclear",
+            note: "The indexed passages conflict.",
+            evidenceIds: ["S1"]
+          }
+        ]
+      })
+    ]);
+    const service = createService(provider);
+    const complete = completionPromise();
+
+    const run = await service.start(
+      {
+        reviewId: fixture.reviewId,
+        stage: "extraction",
+        paperIds: [fixture.paperId],
+        fieldIds: [field.id]
+      },
+      complete.emit
+    );
+    await complete.promise;
+
+    expect(db.listReviewRunItems(run.id)[0]?.extractionSuggestions).toEqual([
+      expect.objectContaining({ fieldId: field.id, status: "needs-review", value: null, evidenceIds: ["S1"] })
+    ]);
+    expect(db.listExtractionValues(fixture.reviewId, fixture.paperId)).toEqual([
+      expect.objectContaining({ fieldId: field.id, status: "needs-review", value: null, origin: "ai" })
+    ]);
+    expect(db.getReviewFlowSummary(fixture.reviewId).extraction).toMatchObject({
+      confirmedCells: 0,
+      notFoundCells: 0,
+      needsReviewCells: 1,
+      completionPercent: 0
+    });
+  });
+});
+
+function includeForExtraction(reviewId: string, paperId: string): void {
+  db.setScreeningDecision({ reviewId, paperId, stage: "title-abstract", decision: "include" });
+  db.setScreeningDecision({ reviewId, paperId, stage: "full-text", decision: "include" });
+}
+
+function addIndexedFullText(reviewId: string, paperId: string, text: string): void {
+  const projectId = db.getReviewById(reviewId)!.projectId;
+  const artifactId = `full_text_${paperId}`;
+  db.saveArtifact({
+    id: artifactId,
+    projectId,
+    type: "paper-pdf",
+    title: "Indexed full text",
+    path: join(directory, `${artifactId}.pdf`),
+    mime: "application/pdf",
+    hash: artifactId,
+    source: "test",
+    metadata: { paperId },
+    createdAt: new Date().toISOString()
+  });
+  db.addDocumentChunks({
+    projectId,
+    artifactId,
+    paperId,
+    chunks: [{ text, metadata: { page: 3 } }]
+  });
+}
+
+function createFixture(withSecondPaper = false): {
+  reviewId: string;
+  paperId: string;
+  secondPaperId?: string;
+  criterionId: string;
+} {
+  const project = db.createProject("Review project");
+  const addPaper = (paperId: string) =>
+    db.savePaper(project.id, {
+      id: paperId,
+      title: `Study ${paperId}`,
+      abstract: "Adults receiving the intervention had a measured outcome.",
+      authors: ["Ada Researcher"],
+      year: 2025,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+  const paper = addPaper("paper_one");
+  const second = withSecondPaper ? addPaper("paper_two") : undefined;
+  const review = db.createReview({
+    projectId: project.id,
+    researchQuestion: "Does the intervention improve the outcome?",
+    criteria: [
+      {
+        id: "relevant_population",
+        stage: "title-abstract",
+        type: "inclusion",
+        label: "Relevant population"
+      }
+    ]
+  });
+  const criterionId = db.getReviewProtocolRevision(review.id)!.criteria[0]!.id;
+  return { reviewId: review.id, paperId: paper.id, secondPaperId: second?.id, criterionId };
+}
+
+function createFailedRun(fixture: { reviewId: string; paperId: string }, runId: string): ReviewRun {
+  const review = db.getReviewById(fixture.reviewId)!;
+  const timestamp = new Date().toISOString();
+  const run = db.saveReviewRun({
+    id: runId,
+    reviewId: fixture.reviewId,
+    stage: "title-abstract",
+    provider: settings.ai.provider,
+    model: settings.ai.model,
+    protocolRevisionId: review.currentRevisionId,
+    status: "failed",
+    paperIds: [fixture.paperId],
+    fieldIds: [],
+    completedCount: 0,
+    failedCount: 1,
+    cancelledCount: 0,
+    error: "Provider unavailable.",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    completedAt: timestamp
+  });
+  db.saveReviewRunItem({
+    id: `${runId}-item`,
+    runId,
+    paperId: fixture.paperId,
+    status: "failed",
+    attemptCount: 1,
+    criterionAssessments: [],
+    extractionSuggestions: [],
+    evidence: [],
+    error: "Provider unavailable.",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    completedAt: timestamp
+  });
+  return run;
+}
+
+function createService(provider: ReviewProvider): ReviewAgentService {
+  const settingsService = { get: vi.fn().mockResolvedValue(settings) } as unknown as SettingsService;
+  return new ReviewAgentService(db, settingsService, {} as CredentialService, provider);
+}
+
+function queueProvider(contents: string[]): ReviewProvider & { chat: ReturnType<typeof vi.fn> } {
+  return {
+    chat: vi.fn(async (): Promise<ProviderChatResult> => ({
+      content: contents.shift() ?? "",
+      toolCalls: []
+    }))
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function completionPromise(): {
+  promise: Promise<Extract<ReviewRunEvent, { type: "complete" }>>;
+  emit: (event: ReviewRunEvent) => void;
+} {
+  let resolve!: (event: Extract<ReviewRunEvent, { type: "complete" }>) => void;
+  const promise = new Promise<Extract<ReviewRunEvent, { type: "complete" }>>((done) => {
+    resolve = done;
+  });
+  return {
+    promise,
+    emit: (event) => {
+      if (event.type === "complete") resolve(event);
+    }
+  };
+}
+
+function validIncludeResponse(criterionId: string): ProviderChatResult {
+  return {
+    content: JSON.stringify({
+      decision: "include",
+      rationale: "The population is relevant.",
+      assessments: [
+        {
+          criterionId,
+          assessment: "met",
+          explanation: "The evidence describes the relevant population.",
+          evidenceIds: ["S2"]
+        }
+      ]
+    }),
+    toolCalls: []
+  };
+}
+
+function abortableProviderResponse(input: ProviderChatInput): Promise<ProviderChatResult> {
+  return new Promise((_resolve, reject) => {
+    input.signal.addEventListener("abort", () => reject(new DOMException("Stopped", "AbortError")), { once: true });
+  });
+}
+
+function extractionResponse(fieldIds: string[]): string {
+  return JSON.stringify({
+    values: fieldIds.map((fieldId) => ({
+      fieldId,
+      status: "found",
+      value: 42,
+      evidenceIds: ["S1"]
+    }))
+  });
+}

--- a/tests/review-agent-utils.test.ts
+++ b/tests/review-agent-utils.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  fitReviewEvidenceBudget,
+  parseReviewAgentJson,
+  validateExtractionSuggestion,
+  validateScreeningSuggestion,
+  type ReviewAgentCriterion,
+  type ReviewAgentEvidence
+} from "../src/main/services/review-agent-utils";
+
+const evidence: ReviewAgentEvidence[] = [
+  {
+    evidenceId: "S1",
+    paperId: "paper-1",
+    sourceType: "paper",
+    title: "Trial",
+    excerpt: "Adults receiving the intervention improved."
+  }
+];
+const criteria: ReviewAgentCriterion[] = [
+  { id: "include-adults", kind: "inclusion", text: "Adults are studied." },
+  { id: "exclude-animals", kind: "exclusion", text: "Animal-only study." }
+];
+
+describe("review agent validation", () => {
+  it("parses fenced and surrounded JSON", () => {
+    expect(parseReviewAgentJson('```json\n{"decision":"uncertain"}\n```')).toEqual({ decision: "uncertain" });
+    expect(parseReviewAgentJson('Result:\n{"decision":"uncertain"}\nDone')).toEqual({ decision: "uncertain" });
+  });
+
+  it("fits evidence to local and hosted context budgets without changing evidence IDs", () => {
+    const oversized = Array.from({ length: 12 }, (_, index) => ({
+      ...evidence[0],
+      evidenceId: `S${index + 1}`,
+      excerpt: "e".repeat(10_000)
+    }));
+    const local = fitReviewEvidenceBudget(oversized, "ollama");
+    const hosted = fitReviewEvidenceBudget(oversized, "openai-compatible");
+
+    expect(local.map((entry) => entry.evidenceId)).toEqual(oversized.map((entry) => entry.evidenceId));
+    expect(local.reduce((total, entry) => total + entry.excerpt.length, 0)).toBeLessThanOrEqual(16_000);
+    expect(hosted.reduce((total, entry) => total + entry.excerpt.length, 0)).toBeLessThanOrEqual(40_000);
+  });
+
+  it("accepts a criterion-consistent evidence-backed screening suggestion", () => {
+    const result = validateScreeningSuggestion({
+      paperId: "paper-1",
+      criteria,
+      evidence,
+      value: {
+        decision: "include",
+        rationale: "The eligible adult population is present and no animal-only exclusion applies.",
+        assessments: [
+          {
+            criterionId: "include-adults",
+            assessment: "met",
+            explanation: "Adults received the intervention.",
+            evidenceIds: ["S1"]
+          },
+          {
+            criterionId: "exclude-animals",
+            assessment: "not-met",
+            explanation: "The study concerns adults.",
+            evidenceIds: ["S1"]
+          }
+        ]
+      }
+    });
+    expect(result.decision).toBe("include");
+  });
+
+  it("rejects invalid evidence and inconsistent decisions", () => {
+    const base = {
+      rationale: "Unclear",
+      assessments: [
+        {
+          criterionId: "include-adults",
+          assessment: "unclear",
+          explanation: "No population is stated.",
+          evidenceIds: []
+        },
+        {
+          criterionId: "exclude-animals",
+          assessment: "unclear",
+          explanation: "No population is stated.",
+          evidenceIds: []
+        }
+      ]
+    };
+    expect(() =>
+      validateScreeningSuggestion({ paperId: "paper-1", criteria, evidence, value: { ...base, decision: "include" } })
+    ).toThrow("inconsistent");
+    expect(() =>
+      validateScreeningSuggestion({
+        paperId: "paper-1",
+        criteria,
+        evidence,
+        value: {
+          ...base,
+          decision: "uncertain",
+          assessments: [{ ...base.assessments[0], assessment: "met", evidenceIds: ["S9"] }, base.assessments[1]]
+        }
+      })
+    ).toThrow("Unknown review evidence");
+  });
+
+  it("fails advisory screening closed to uncertain when a blank protocol has no criteria", () => {
+    expect(
+      validateScreeningSuggestion({
+        paperId: "paper-1",
+        criteria: [],
+        evidence,
+        value: { decision: "uncertain", rationale: "No screening criteria are configured.", assessments: [] }
+      }).decision
+    ).toBe("uncertain");
+    expect(() =>
+      validateScreeningSuggestion({
+        paperId: "paper-1",
+        criteria: [],
+        evidence,
+        value: { decision: "include", rationale: "No criteria were assessed.", assessments: [] }
+      })
+    ).toThrow("inconsistent");
+  });
+
+  it("validates typed extraction values and evidence", () => {
+    const result = validateExtractionSuggestion({
+      paperId: "paper-1",
+      evidence,
+      fields: [
+        { id: "sample-size", type: "number" },
+        { id: "design", type: "single-select", options: ["RCT", "Cohort"] }
+      ],
+      value: {
+        values: [
+          { fieldId: "sample-size", status: "found", value: 42, evidenceIds: ["S1"] },
+          { fieldId: "design", status: "not-found", evidenceIds: [] }
+        ]
+      }
+    });
+    expect(result.values[0].value).toBe(42);
+    expect(() =>
+      validateExtractionSuggestion({
+        paperId: "paper-1",
+        evidence,
+        fields: [{ id: "sample-size", type: "number" }],
+        value: { values: [{ fieldId: "sample-size", status: "found", value: "42", evidenceIds: ["S1"] }] }
+      })
+    ).toThrow();
+  });
+});

--- a/tests/review-db.test.ts
+++ b/tests/review-db.test.ts
@@ -1,0 +1,1544 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PaperPilotDb, type ReviewPortabilityState } from "../src/main/db";
+
+let dir: string;
+const openDatabases: PaperPilotDb[] = [];
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "paper-pilot-review-db-"));
+});
+
+afterEach(async () => {
+  for (const database of openDatabases.splice(0)) database.close();
+  await rm(dir, { recursive: true, force: true });
+});
+
+function open(name = "review.db"): PaperPilotDb {
+  const database = new PaperPilotDb(join(dir, name));
+  openDatabases.push(database);
+  return database;
+}
+
+function addPaper(database: PaperPilotDb, projectId: string, paperId: string, title = paperId) {
+  return database.savePaper(projectId, {
+    id: paperId,
+    title,
+    abstract: `${title} abstract`,
+    authors: ["Ada Researcher"],
+    year: 2025,
+    source: "crossref",
+    isOpenAccess: false,
+    fieldsOfStudy: []
+  });
+}
+
+function includeThroughFullText(database: PaperPilotDb, reviewId: string, paperId: string): void {
+  database.setScreeningDecision({
+    reviewId,
+    paperId,
+    stage: "title-abstract",
+    decision: "include"
+  });
+  database.setScreeningDecision({ reviewId, paperId, stage: "full-text", decision: "include" });
+}
+
+function addIndexedArtifact(
+  database: PaperPilotDb,
+  input: {
+    projectId: string;
+    artifactId: string;
+    artifactType: "paper-pdf" | "markdown" | "table" | "brief" | "chat-answer";
+    paperId: string;
+    metadataPaperId?: string;
+    chunkPaperId?: string;
+    source?: string;
+  }
+): { artifactId: string; chunkId: string } {
+  const createdAt = new Date().toISOString();
+  database.saveArtifact({
+    id: input.artifactId,
+    projectId: input.projectId,
+    type: input.artifactType,
+    title: input.artifactId,
+    path: join(dir, `${input.artifactId}.md`),
+    mime: "text/markdown",
+    hash: `hash-${input.artifactId}`,
+    source: input.source,
+    metadata: { paperId: input.metadataPaperId ?? input.paperId },
+    createdAt
+  });
+  database.addDocumentChunks({
+    projectId: input.projectId,
+    artifactId: input.artifactId,
+    paperId: input.chunkPaperId ?? input.paperId,
+    chunks: [{ text: "Indexed full text evidence.", metadata: { page: 1 } }]
+  });
+  return {
+    artifactId: input.artifactId,
+    chunkId: database.listArtifactChunks(input.projectId, input.artifactId, 1)[0].chunkId
+  };
+}
+
+function downgradeRawDatabase(raw: DatabaseSync): void {
+  raw.exec(`
+    PRAGMA foreign_keys = OFF;
+    DROP TABLE extraction_value_revisions;
+    DROP TABLE extraction_field_revisions;
+    DROP TABLE review_extraction_value_evidence;
+    DROP TABLE review_audit_events;
+    DROP TABLE review_evidence;
+    DROP TABLE extraction_values;
+    DROP TABLE review_run_items;
+    DROP TABLE review_runs;
+    DROP TABLE extraction_fields;
+    DROP TABLE review_rereview_flags;
+    DROP TABLE review_screening_decisions;
+    DROP TABLE review_candidate_origins;
+    DROP TABLE discovery_batches;
+    DROP TABLE review_criteria;
+    DROP TABLE review_protocol_revisions;
+    DROP TABLE reviews;
+    PRAGMA user_version = 2;
+  `);
+}
+
+function downgradeFixture(path: string): void {
+  const database = new PaperPilotDb(path);
+  const project = database.createProject("Version two data");
+  addPaper(database, project.id, "paper_v2", "Preserved paper");
+  database.close();
+  const raw = new DatabaseSync(path);
+  downgradeRawDatabase(raw);
+  raw.close();
+}
+
+describe("review schema migrations", () => {
+  it("migrates version two data to version three without loss", () => {
+    const path = join(dir, "v2.db");
+    downgradeFixture(path);
+
+    const database = new PaperPilotDb(path);
+    openDatabases.push(database);
+
+    const [project] = database.listProjects();
+    expect(project.title).toBe("Version two data");
+    expect(database.listPapers(project.id)[0].title).toBe("Preserved paper");
+    expect(database.getReview(project.id)).toBeUndefined();
+    const raw = new DatabaseSync(path);
+    expect((raw.prepare("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(3);
+    raw.close();
+  });
+
+  it("rewrites swapped legacy dedupe keys in two phases without unique collisions", () => {
+    const path = join(dir, "dedupe-swap.db");
+    const seeded = new PaperPilotDb(path);
+    const project = seeded.createProject("Dedupe migration");
+    seeded.savePaper(project.id, {
+      id: "paper_a",
+      title: "First identity",
+      authors: ["Author A"],
+      year: 2024,
+      doi: "10.1000/first",
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    seeded.savePaper(project.id, {
+      id: "paper_b",
+      title: "Second identity",
+      authors: ["Author B"],
+      year: 2025,
+      doi: "10.1000/second",
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    seeded.close();
+
+    const raw = new DatabaseSync(path);
+    const originalRows = raw
+      .prepare("SELECT id, dedupe_key FROM papers WHERE project_id = ? ORDER BY id")
+      .all(project.id) as Array<{ id: string; dedupe_key: string }>;
+    const firstKey = originalRows[0].dedupe_key;
+    const secondKey = originalRows[1].dedupe_key;
+    raw.prepare("UPDATE papers SET dedupe_key = ? WHERE id = 'paper_a'").run("temporary:paper_a");
+    raw.prepare("UPDATE papers SET dedupe_key = ? WHERE id = 'paper_b'").run(firstKey);
+    raw.prepare("UPDATE papers SET dedupe_key = ? WHERE id = 'paper_a'").run(secondKey);
+    downgradeRawDatabase(raw);
+    raw.close();
+
+    const migrated = new PaperPilotDb(path);
+    openDatabases.push(migrated);
+    const migratedRows = new DatabaseSync(path);
+    expect(
+      migratedRows.prepare("SELECT id, dedupe_key FROM papers WHERE project_id = ? ORDER BY id").all(project.id)
+    ).toEqual(originalRows);
+    migratedRows.close();
+    expect(migrated.listPapers(project.id)).toHaveLength(2);
+  });
+
+  it("rolls back the complete version-three migration when a step fails", () => {
+    const path = join(dir, "rollback.db");
+    downgradeFixture(path);
+    const raw = new DatabaseSync(path);
+    raw.exec("CREATE TABLE reviews (id INTEGER PRIMARY KEY)");
+    raw.close();
+
+    expect(() => new PaperPilotDb(path)).toThrow();
+
+    const inspected = new DatabaseSync(path);
+    expect((inspected.prepare("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(2);
+    expect((inspected.prepare("SELECT title FROM projects").get() as { title: string }).title).toBe("Version two data");
+    expect(
+      (
+        inspected
+          .prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'review_runs'")
+          .get() as {
+          count: number;
+        }
+      ).count
+    ).toBe(0);
+    inspected.close();
+  });
+
+  it("refuses a database newer than schema version three", () => {
+    const path = join(dir, "future.db");
+    const raw = new DatabaseSync(path);
+    raw.exec("PRAGMA user_version = 4");
+    raw.close();
+
+    expect(() => new PaperPilotDb(path)).toThrow(/newer than this Paper Pilot build supports/i);
+  });
+});
+
+describe("review activation and isolation", () => {
+  it("never merges papers on title alone", () => {
+    const database = open();
+    const project = database.createProject("Conservative identities");
+    database.savePaper(project.id, {
+      id: "same_title_2024",
+      title: "A shared study title",
+      authors: ["Ada Alpha"],
+      year: 2024,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    database.savePaper(project.id, {
+      id: "same_title_2025",
+      title: "A shared study title",
+      authors: ["Grace Beta"],
+      year: 2025,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+
+    expect(database.listPapers(project.id).map((paper) => paper.id)).toEqual(["same_title_2025", "same_title_2024"]);
+
+    database.savePaper(project.id, {
+      id: "keep_separate_one",
+      title: "Ambiguous imported title",
+      authors: ["Same Author"],
+      year: 2026,
+      source: "reference-import",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    database.savePaper(project.id, {
+      id: "keep_separate_two",
+      title: "Ambiguous imported title",
+      authors: ["Same Author"],
+      year: 2026,
+      source: "reference-import",
+      isOpenAccess: false,
+      fieldsOfStudy: [],
+      raw: { forceSeparateIdentity: "keep_separate_two" }
+    });
+    expect(database.listPapers(project.id).filter((paper) => paper.title === "Ambiguous imported title")).toHaveLength(
+      2
+    );
+  });
+
+  it("preserves stronger source identity metadata when enriching a paper", () => {
+    const database = open();
+    const project = database.createProject("Identity enrichment");
+    const paper = addPaper(database, project.id, "identity_paper");
+
+    const updated = database.updatePaper(project.id, paper.id, {
+      source: "reference-import",
+      sourcePaperId: "W-123",
+      raw: { sourceAuthority: "openalex", alternateIds: { doi: "10.1000/example" } }
+    });
+
+    expect(updated).toMatchObject({
+      source: "reference-import",
+      sourcePaperId: "W-123",
+      raw: { sourceAuthority: "openalex", alternateIds: { doi: "10.1000/example" } }
+    });
+  });
+
+  it("activates one review per project and records pre-existing paper provenance", () => {
+    const database = open();
+    const project = database.createProject("Existing corpus");
+    addPaper(database, project.id, "paper_one", "First study");
+    addPaper(database, project.id, "paper_two", "Second study");
+
+    const review = database.createReview({
+      projectId: project.id,
+      template: "general-empirical",
+      researchQuestion: "Which interventions work?",
+      objectives: ["Compare outcomes"],
+      criteria: [
+        {
+          id: "criterion_population",
+          stage: "title-abstract",
+          type: "inclusion",
+          label: "Relevant population"
+        }
+      ]
+    });
+    expect(database.createReview({ projectId: project.id }).id).toBe(review.id);
+    expect(review).toMatchObject({
+      projectId: project.id,
+      template: "general-empirical",
+      currentRevisionNumber: 1,
+      historicalCountsAvailable: false
+    });
+    expect(database.getReviewProtocolRevision(review.id)).toMatchObject({
+      researchQuestion: "Which interventions work?",
+      objectives: ["Compare outcomes"]
+    });
+    expect(database.listDiscoveryBatches(review.id)[0]).toMatchObject({
+      kind: "pre-existing",
+      label: "Pre-existing project papers",
+      counts: { identified: 2, newRecords: 2 },
+      historicalCountsAvailable: false
+    });
+    expect(database.listReviewCandidateOrigins(review.id)).toHaveLength(2);
+    const page = database.listReviewPapers({
+      reviewId: review.id,
+      stage: "title-abstract",
+      sources: [],
+      decisions: [],
+      fullText: "any",
+      sort: "title",
+      direction: "asc",
+      page: 1,
+      pageSize: 25
+    });
+    expect(page.items.map((paper) => paper.title)).toEqual(["First study", "Second study"]);
+    expect(page.counts.pending).toBe(2);
+  });
+
+  it("records candidate provenance in atomic prepared batches", () => {
+    const database = open();
+    const project = database.createProject("Bulk provenance");
+    const paper = addPaper(database, project.id, "bulk_paper");
+    const review = database.createReview({ projectId: project.id });
+    const batch = database.saveDiscoveryBatch({
+      reviewId: review.id,
+      kind: "reference-import",
+      label: "Bulk import",
+      status: "running"
+    });
+
+    const inserted = database.recordReviewCandidateOriginsBulk([
+      {
+        id: "bulk_origin_one",
+        reviewId: review.id,
+        batchId: batch.id,
+        paperId: paper.id,
+        resolution: "created",
+        recordSnapshot: { title: paper.title }
+      },
+      {
+        id: "bulk_origin_two",
+        reviewId: review.id,
+        batchId: batch.id,
+        matchedPaperId: paper.id,
+        resolution: "skipped",
+        recordSnapshot: { title: "Duplicate" }
+      }
+    ]);
+    expect(inserted.map((origin) => origin.id)).toEqual(["bulk_origin_one", "bulk_origin_two"]);
+
+    expect(() =>
+      database.recordReviewCandidateOriginsBulk([
+        {
+          id: "rolled_back_origin",
+          reviewId: review.id,
+          batchId: batch.id,
+          paperId: paper.id,
+          resolution: "duplicate"
+        },
+        {
+          id: "invalid_origin",
+          reviewId: review.id,
+          batchId: "missing_batch",
+          resolution: "invalid"
+        }
+      ])
+    ).toThrow(/batch not found/i);
+    expect(database.listReviewCandidateOrigins(review.id).map((origin) => origin.id)).not.toContain(
+      "rolled_back_origin"
+    );
+  });
+
+  it("keeps protocols, screening, and queues isolated between projects", () => {
+    const database = open();
+    const firstProject = database.createProject("First project");
+    const secondProject = database.createProject("Second project");
+    const firstPaper = addPaper(database, firstProject.id, "first_paper");
+    addPaper(database, secondProject.id, "second_paper");
+    const firstReview = database.createReview({ projectId: firstProject.id, researchQuestion: "First?" });
+    const secondReview = database.createReview({ projectId: secondProject.id, researchQuestion: "Second?" });
+
+    database.setScreeningDecision({
+      reviewId: firstReview.id,
+      paperId: firstPaper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+
+    expect(database.listScreeningDecisionHistory(firstReview.id)).toHaveLength(1);
+    expect(database.listScreeningDecisionHistory(secondReview.id)).toHaveLength(0);
+    expect(
+      database
+        .listReviewPapers({
+          reviewId: secondReview.id,
+          stage: "title-abstract",
+          sources: [],
+          decisions: [],
+          fullText: "any",
+          sort: "created",
+          direction: "asc",
+          page: 1,
+          pageSize: 25
+        })
+        .items.map((paper) => paper.paperId)
+    ).toEqual(["second_paper"]);
+    expect(() =>
+      database.setScreeningDecision({
+        reviewId: secondReview.id,
+        paperId: firstPaper.id,
+        stage: "title-abstract",
+        decision: "include"
+      })
+    ).toThrow(/paper not found in review project/i);
+  });
+
+  it("keeps 50,000-record review pagination bounded and counts stable before decision filtering", () => {
+    const path = join(dir, "scale.db");
+    const seeded = new PaperPilotDb(path);
+    const project = seeded.createProject("Scale review");
+    const review = seeded.createReview({ projectId: project.id });
+    seeded.close();
+
+    const raw = new DatabaseSync(path);
+    const insertPaper = raw.prepare(
+      `INSERT INTO papers (
+         id, project_id, dedupe_key, title, normalized_title, abstract, authors_json,
+         year, source, is_open_access, fields_json, raw_json, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, '[]', 2025, 'reference-import', 0, '[]', '{}', ?, ?)`
+    );
+    const insertDecision = raw.prepare(
+      `INSERT INTO review_screening_decisions (
+         id, review_id, paper_id, paper_snapshot_json, stage, decision,
+         protocol_revision_id, created_at
+       ) VALUES (?, ?, ?, ?, 'title-abstract', ?, ?, ?)`
+    );
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    raw.exec("BEGIN");
+    for (let index = 0; index < 50_000; index += 1) {
+      const paperId = `scale_${index.toString().padStart(5, "0")}`;
+      const title = `Scale paper ${index.toString().padStart(5, "0")}`;
+      insertPaper.run(
+        paperId,
+        project.id,
+        `record:${paperId}`,
+        title,
+        title.toLowerCase(),
+        "Abstract",
+        timestamp,
+        timestamp
+      );
+      if (index < 1_000) {
+        insertDecision.run(
+          `scale_old_${index}`,
+          review.id,
+          paperId,
+          JSON.stringify({ id: paperId, title }),
+          "uncertain",
+          review.currentRevisionId,
+          "2026-01-01T00:00:01.000Z"
+        );
+        insertDecision.run(
+          `scale_current_${index}`,
+          review.id,
+          paperId,
+          JSON.stringify({ id: paperId, title }),
+          "include",
+          review.currentRevisionId,
+          "2026-01-01T00:00:02.000Z"
+        );
+      }
+    }
+    raw.exec("COMMIT");
+    raw.close();
+
+    const database = new PaperPilotDb(path);
+    openDatabases.push(database);
+    const startedAt = performance.now();
+    const page = database.listReviewPapers({
+      reviewId: review.id,
+      stage: "title-abstract",
+      sources: [],
+      decisions: ["include"],
+      fullText: "any",
+      sort: "title",
+      direction: "asc",
+      page: 1,
+      pageSize: 25
+    });
+    const elapsed = performance.now() - startedAt;
+
+    expect(page.items).toHaveLength(25);
+    expect(page.total).toBe(1_000);
+    expect(page.counts).toEqual({ pending: 49_000, include: 1_000, exclude: 0, uncertain: 0 });
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});
+
+describe("review protocol and screening policies", () => {
+  it("stores criteria as globally unique revision snapshots and validates duplicate requests", () => {
+    const database = open();
+    const firstProject = database.createProject("First template review");
+    const secondProject = database.createProject("Second template review");
+    const templateCriteria = [
+      {
+        id: "template_population",
+        stage: "title-abstract" as const,
+        type: "inclusion" as const,
+        label: "Eligible population",
+        order: 0
+      },
+      {
+        id: "template_wrong_design",
+        stage: "title-abstract" as const,
+        type: "exclusion" as const,
+        label: "Wrong design",
+        order: 0
+      }
+    ];
+    const firstReview = database.createReview({ projectId: firstProject.id, criteria: templateCriteria });
+    const secondReview = database.createReview({ projectId: secondProject.id, criteria: templateCriteria });
+    const firstIds = database.listReviewCriteria(firstReview.id).map((criterion) => criterion.id);
+    const secondIds = database.listReviewCriteria(secondReview.id).map((criterion) => criterion.id);
+    expect(new Set([...firstIds, ...secondIds]).size).toBe(4);
+
+    expect(() =>
+      database.reviseReviewProtocol({
+        reviewId: firstReview.id,
+        researchQuestion: "Duplicate request IDs?",
+        criteria: [templateCriteria[0], { ...templateCriteria[0], label: "Duplicate" }]
+      })
+    ).toThrow(/duplicate review criterion request id/i);
+    expect(() =>
+      database.reviseReviewProtocol({
+        reviewId: firstReview.id,
+        researchQuestion: "Duplicate order?",
+        criteria: [templateCriteria[0], { ...templateCriteria[0], id: "another", label: "Duplicate order" }]
+      })
+    ).toThrow(/duplicate inclusion criterion order/i);
+  });
+
+  it("fails interrupted runs and releases the one-active-run constraint after restart", () => {
+    const database = open();
+    const project = database.createProject("Interrupted review run");
+    const paper = addPaper(database, project.id, "interrupted_paper");
+    const review = database.createReview({ projectId: project.id });
+    const timestamp = new Date().toISOString();
+    database.saveReviewRun({
+      id: "interrupted_run",
+      reviewId: review.id,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "test-model",
+      protocolRevisionId: review.currentRevisionId,
+      status: "queued",
+      paperIds: [paper.id],
+      fieldIds: [],
+      completedCount: 0,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    });
+    database.saveReviewRunItem({
+      id: "interrupted_item",
+      runId: "interrupted_run",
+      paperId: paper.id,
+      status: "queued",
+      attemptCount: 0,
+      extractionSuggestions: [],
+      evidence: [],
+      createdAt: timestamp,
+      updatedAt: timestamp
+    });
+
+    expect(database.markInterruptedReviewRuns()).toBe(1);
+    expect(database.getReviewRun("interrupted_run")).toMatchObject({ status: "failed" });
+    expect(database.getReviewRunItem("interrupted_item")).toMatchObject({ status: "cancelled" });
+    expect(() =>
+      database.saveReviewRun({
+        id: "replacement_run",
+        reviewId: review.id,
+        stage: "title-abstract",
+        provider: "ollama",
+        model: "test-model",
+        protocolRevisionId: review.currentRevisionId,
+        status: "queued",
+        paperIds: [paper.id],
+        fieldIds: [],
+        completedCount: 0,
+        failedCount: 0,
+        cancelledCount: 0,
+        createdAt: timestamp,
+        updatedAt: timestamp
+      })
+    ).not.toThrow();
+  });
+
+  it("requires title inclusion before full text and a reason for full-text exclusions", () => {
+    const database = open();
+    const project = database.createProject("Screening policy");
+    const paper = addPaper(database, project.id, "policy_paper");
+    const review = database.createReview({
+      projectId: project.id,
+      criteria: [
+        {
+          id: "full_text_wrong_population",
+          stage: "full-text",
+          type: "exclusion",
+          label: "Wrong population"
+        },
+        {
+          id: "abstract_relevant",
+          stage: "title-abstract",
+          type: "inclusion",
+          label: "Relevant topic"
+        }
+      ]
+    });
+    const criteria = database.listReviewCriteria(review.id);
+    const fullTextCriterion = criteria.find((criterion) => criterion.label === "Wrong population")!;
+    const abstractCriterion = criteria.find((criterion) => criterion.label === "Relevant topic")!;
+
+    expect(() =>
+      database.setScreeningDecision({
+        reviewId: review.id,
+        paperId: paper.id,
+        stage: "full-text",
+        decision: "include"
+      })
+    ).toThrow(/title\/abstract screening/i);
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    expect(() =>
+      database.setScreeningDecision({
+        reviewId: review.id,
+        paperId: paper.id,
+        stage: "full-text",
+        decision: "exclude"
+      })
+    ).toThrow(/require a criterion or custom reason/i);
+    expect(() =>
+      database.setScreeningDecision({
+        reviewId: review.id,
+        paperId: paper.id,
+        stage: "full-text",
+        decision: "exclude",
+        reasonCriterionId: abstractCriterion.id
+      })
+    ).toThrow(/does not belong to this protocol stage/i);
+
+    const excluded = database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "exclude",
+      reasonCriterionId: fullTextCriterion.id
+    });
+    expect(excluded.reasonCriterionId).toBe(fullTextCriterion.id);
+    const changed = database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "uncertain"
+    });
+    expect(changed.previousDecisionId).toBe(excluded.id);
+    expect(database.listScreeningDecisionHistory(review.id, paper.id, "full-text")).toHaveLength(2);
+  });
+
+  it("invalidates downstream review state when title screening is no longer included", () => {
+    const database = open();
+    const project = database.createProject("Downstream eligibility");
+    const paper = addPaper(database, project.id, "eligibility_paper");
+    const review = database.createReview({ projectId: project.id });
+    includeThroughFullText(database, review.id, paper.id);
+    const field = database.saveExtractionField({ reviewId: review.id, name: "Outcome", type: "short-text" });
+    const value = database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Improved",
+      status: "confirmed",
+      origin: "manual"
+    });
+    expect(database.getReviewFlowSummary(review.id).includedPapers).toBe(1);
+
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "exclude"
+    });
+
+    expect(database.listScreeningDecisionHistory(review.id, paper.id, "full-text")).toHaveLength(1);
+    expect(database.getExtractionValue(value.id)?.status).toBe("needs-review");
+    expect(database.getReviewFlowSummary(review.id).includedPapers).toBe(0);
+    expect(
+      database.listReviewPapers({
+        reviewId: review.id,
+        stage: "extraction",
+        sources: [],
+        decisions: [],
+        fullText: "any",
+        sort: "created",
+        direction: "asc",
+        page: 1,
+        pageSize: 25
+      }).items
+    ).toHaveLength(0);
+    expect(() =>
+      database.saveExtractionValue({
+        reviewId: review.id,
+        paperId: paper.id,
+        fieldId: field.id,
+        value: "Changed",
+        status: "confirmed",
+        origin: "manual"
+      })
+    ).toThrow(/both screening stages/i);
+
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    expect(
+      database.listReviewPapers({
+        reviewId: review.id,
+        stage: "extraction",
+        sources: [],
+        decisions: [],
+        fullText: "any",
+        sort: "created",
+        direction: "asc",
+        page: 1,
+        pageSize: 25
+      }).items
+    ).toHaveLength(0);
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "include"
+    });
+    expect(database.getReviewFlowSummary(review.id).includedPapers).toBe(1);
+  });
+
+  it("preserves human decisions and marks earlier AI suggestions stale after protocol revision", () => {
+    const database = open();
+    const project = database.createProject("Revision history");
+    const paper = addPaper(database, project.id, "revision_paper");
+    const review = database.createReview({
+      projectId: project.id,
+      researchQuestion: "Original question",
+      criteria: [
+        {
+          id: "retained_criterion",
+          stage: "title-abstract",
+          type: "inclusion",
+          label: "Relevant design"
+        }
+      ]
+    });
+    const decision = database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    const timestamp = new Date().toISOString();
+    database.saveReviewRun({
+      id: "run_before_revision",
+      reviewId: review.id,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "test-model",
+      protocolRevisionId: review.currentRevisionId,
+      status: "completed",
+      paperIds: [paper.id],
+      fieldIds: [],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    database.saveReviewRunItem({
+      id: "run_item_before_revision",
+      runId: "run_before_revision",
+      paperId: paper.id,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      extractionSuggestions: [],
+      evidence: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+
+    const revision = database.reviseReviewProtocol({
+      reviewId: review.id,
+      researchQuestion: "Revised question",
+      changeNote: "Clarified the outcome",
+      criteria: [
+        {
+          id: "retained_criterion",
+          stage: "title-abstract",
+          type: "inclusion",
+          label: "Relevant study design"
+        }
+      ]
+    });
+
+    expect(revision.version).toBe(2);
+    const revisionHistory = database.listReviewProtocolRevisions(review.id);
+    expect(revisionHistory.map((item) => item.criteria[0]?.label)).toEqual([
+      "Relevant study design",
+      "Relevant design"
+    ]);
+    expect(new Set(revisionHistory.map((item) => item.criteria[0]?.id)).size).toBe(2);
+    expect(database.getCurrentScreeningDecision(review.id, paper.id, "title-abstract")?.id).toBe(decision.id);
+    expect(
+      database.listReviewPapers({
+        reviewId: review.id,
+        stage: "title-abstract",
+        sources: [],
+        decisions: [],
+        fullText: "any",
+        sort: "created",
+        direction: "asc",
+        page: 1,
+        pageSize: 25
+      }).items[0].aiSuggestionStale
+    ).toBe(true);
+    expect(database.getReviewRunItem("run_item_before_revision")?.stale).toBe(true);
+
+    database.saveReviewRun({
+      id: "run_after_revision",
+      reviewId: review.id,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "test-model",
+      protocolRevisionId: revision.id,
+      status: "completed",
+      paperIds: [paper.id],
+      fieldIds: [],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const currentItem = database.saveReviewRunItem({
+      id: "run_item_after_revision",
+      runId: "run_after_revision",
+      paperId: paper.id,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      extractionSuggestions: [],
+      evidence: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    expect(currentItem.stale).toBe(false);
+    expect(
+      database.listReviewPapers({
+        reviewId: review.id,
+        stage: "title-abstract",
+        sources: [],
+        decisions: [],
+        fullText: "any",
+        sort: "created",
+        direction: "asc",
+        page: 1,
+        pageSize: 25
+      }).items[0].aiSuggestionStale
+    ).toBe(false);
+    expect(
+      database.markScreeningForRereview({ reviewId: review.id, paperIds: [paper.id], stage: "title-abstract" })
+    ).toBe(1);
+    expect(
+      database.markScreeningForRereview({ reviewId: review.id, paperIds: [paper.id], stage: "title-abstract" })
+    ).toBe(0);
+    expect(() => database.deleteProject(project.id)).not.toThrow();
+    expect(database.getReview(project.id)).toBeUndefined();
+  });
+
+  it("marks late run items stale, retains criterion provenance, and downgrades stale extraction suggestions", () => {
+    const database = open();
+    const project = database.createProject("Late AI completion");
+    const paper = addPaper(database, project.id, "late_paper");
+    const review = database.createReview({
+      projectId: project.id,
+      criteria: [
+        {
+          stage: "full-text",
+          type: "inclusion",
+          label: "Eligible design"
+        }
+      ]
+    });
+    includeThroughFullText(database, review.id, paper.id);
+    const field = database.saveExtractionField({ reviewId: review.id, name: "Result", type: "short-text" });
+    const timestamp = new Date().toISOString();
+    database.saveReviewRun({
+      id: "late_extraction_run",
+      reviewId: review.id,
+      stage: "extraction",
+      provider: "ollama",
+      model: "test-model",
+      protocolRevisionId: review.currentRevisionId,
+      status: "running",
+      paperIds: [paper.id],
+      fieldIds: [field.id],
+      completedCount: 0,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    });
+    const revised = database.reviseReviewProtocol({
+      reviewId: review.id,
+      researchQuestion: "Revised while running",
+      criteria: []
+    });
+    const evidence = {
+      id: "late_evidence",
+      reviewId: review.id,
+      evidenceId: "E1",
+      paperId: paper.id,
+      sourceType: "paper-abstract" as const,
+      title: paper.title,
+      excerpt: "The result improved.",
+      createdAt: timestamp
+    };
+    const item = database.saveReviewRunItem({
+      id: "late_extraction_item",
+      runId: "late_extraction_run",
+      paperId: paper.id,
+      status: "completed",
+      attemptCount: 1,
+      criterionAssessments: [
+        {
+          criterionId: database.listReviewProtocolRevisions(review.id)[1].criteria[0].id,
+          assessment: "met",
+          explanation: "The design matched.",
+          evidenceIds: ["E1"]
+        }
+      ],
+      extractionSuggestions: [
+        {
+          fieldId: field.id,
+          value: "Improved",
+          status: "suggested",
+          evidenceIds: ["E1"]
+        }
+      ],
+      evidence: [evidence],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    expect(item.criterionAssessments[0]?.assessment).toBe("met");
+    expect(revised.version).toBe(2);
+    expect(
+      database.listReviewPapers({
+        reviewId: review.id,
+        stage: "extraction",
+        sources: [],
+        decisions: [],
+        fullText: "any",
+        sort: "created",
+        direction: "asc",
+        page: 1,
+        pageSize: 25
+      }).items[0].aiSuggestionStale
+    ).toBe(true);
+    const value = database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Improved",
+      status: "suggested",
+      origin: "ai",
+      runItemId: item.id,
+      evidenceIds: [evidence.id]
+    });
+    expect(value.status).toBe("needs-review");
+  });
+});
+
+describe("review extraction and durable evidence", () => {
+  it("allows same-paper evidence reuse while rejecting cross-paper evidence, including after deletion", () => {
+    const database = open();
+    const project = database.createProject("Evidence ownership");
+    const firstPaper = addPaper(database, project.id, "evidence_paper_one");
+    const secondPaper = addPaper(database, project.id, "evidence_paper_two");
+    const review = database.createReview({ projectId: project.id });
+    includeThroughFullText(database, review.id, firstPaper.id);
+    includeThroughFullText(database, review.id, secondPaper.id);
+    const firstField = database.saveExtractionField({ reviewId: review.id, name: "Outcome", type: "short-text" });
+    const secondField = database.saveExtractionField({ reviewId: review.id, name: "Measure", type: "short-text" });
+    const evidence = database.saveReviewEvidence({
+      id: "shared_evidence",
+      reviewId: review.id,
+      evidenceId: "E1",
+      paperId: firstPaper.id,
+      sourceType: "paper-abstract",
+      title: firstPaper.title,
+      excerpt: "The outcome improved on the selected measure.",
+      createdAt: new Date().toISOString()
+    });
+    const firstValue = database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: firstPaper.id,
+      fieldId: firstField.id,
+      value: "Improved",
+      status: "confirmed",
+      origin: "ai",
+      evidenceIds: [evidence.id]
+    });
+    const secondValue = database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: firstPaper.id,
+      fieldId: secondField.id,
+      value: "Validated scale",
+      status: "confirmed",
+      origin: "ai",
+      evidenceIds: [evidence.id]
+    });
+    expect(firstValue.evidenceIds).toEqual([evidence.id]);
+    expect(secondValue.evidenceIds).toEqual([evidence.id]);
+    expect(() =>
+      database.saveExtractionValue({
+        reviewId: review.id,
+        paperId: secondPaper.id,
+        fieldId: firstField.id,
+        value: "Wrong paper",
+        status: "confirmed",
+        origin: "ai",
+        evidenceIds: [evidence.id]
+      })
+    ).toThrow(/same paper/i);
+
+    database.deletePaper(project.id, firstPaper.id);
+    const durable = database.getReviewEvidence(evidence.id)!;
+    expect(durable.paperId).toBeUndefined();
+    expect(() => database.saveReviewEvidence(durable, secondValue.id)).not.toThrow();
+    expect(database.getExtractionValue(secondValue.id)?.evidenceIds).toEqual([evidence.id]);
+  });
+
+  it("requires evidence for confirmed AI values and invalidates values on semantic field changes", () => {
+    const database = open();
+    const project = database.createProject("Extraction");
+    const paper = addPaper(database, project.id, "extract_paper");
+    const review = database.createReview({ projectId: project.id });
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    database.setScreeningDecision({ reviewId: review.id, paperId: paper.id, stage: "full-text", decision: "include" });
+    const field = database.saveExtractionField({
+      reviewId: review.id,
+      name: "Sample size",
+      type: "number"
+    });
+
+    for (const blank of [null, "", "   ", []] as const) {
+      expect(() =>
+        database.saveExtractionValue({
+          reviewId: review.id,
+          paperId: paper.id,
+          fieldId: field.id,
+          value: blank,
+          status: "confirmed",
+          origin: "manual"
+        })
+      ).toThrow(/cannot be blank.*not found/i);
+    }
+
+    expect(() =>
+      database.saveExtractionValue({
+        reviewId: review.id,
+        paperId: paper.id,
+        fieldId: field.id,
+        value: 42,
+        status: "confirmed",
+        origin: "ai"
+      })
+    ).toThrow(/require evidence/i);
+
+    const evidence = database.saveReviewEvidence({
+      id: "review_evidence_one",
+      reviewId: review.id,
+      evidenceId: "E1",
+      paperId: paper.id,
+      sourceType: "paper-abstract",
+      title: paper.title,
+      excerpt: "The study enrolled 42 participants.",
+      locator: "Abstract",
+      createdAt: new Date().toISOString()
+    });
+    const value = database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: 42,
+      status: "confirmed",
+      origin: "ai",
+      evidenceIds: [evidence.id]
+    });
+    expect(value.evidenceIds).toEqual([evidence.id]);
+
+    const reordered = database.saveExtractionField({
+      id: field.id,
+      reviewId: review.id,
+      name: field.name,
+      type: field.type,
+      order: 5
+    });
+    expect(reordered.revision).toBe(1);
+    const revised = database.saveExtractionField({
+      id: field.id,
+      reviewId: review.id,
+      name: "Enrolled sample size",
+      type: field.type,
+      order: 5
+    });
+    expect(revised.revision).toBe(2);
+    expect(database.getExtractionValue(value.id)?.status).toBe("needs-review");
+    expect(database.listExtractionFieldHistory(field.id).map((entry) => entry.revision)).toEqual([1, 2]);
+    expect(database.listExtractionValueHistory(value.id).map((entry) => entry.status)).toEqual([
+      "confirmed",
+      "needs-review"
+    ]);
+  });
+
+  it("retains evidence and decision snapshots when linked records are deleted", () => {
+    const database = open();
+    const project = database.createProject("Evidence snapshots");
+    const paper = addPaper(database, project.id, "deleted_paper", "Durable citation");
+    const review = database.createReview({ projectId: project.id });
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    const evidence = database.saveReviewEvidence({
+      id: "durable_evidence",
+      reviewId: review.id,
+      evidenceId: "E1",
+      paperId: paper.id,
+      sourceType: "paper-abstract",
+      title: paper.title,
+      excerpt: "This excerpt must survive deletion.",
+      createdAt: new Date().toISOString()
+    });
+
+    database.deletePaper(project.id, paper.id);
+
+    expect(database.getReviewEvidence(evidence.id)).toMatchObject({
+      title: "Durable citation",
+      excerpt: "This excerpt must survive deletion."
+    });
+    expect(database.getReviewEvidence(evidence.id)?.paperId).toBeUndefined();
+    expect(database.listScreeningDecisionHistory(review.id)[0].paperId).toBe(paper.id);
+  });
+
+  it("partitions current decisions by immutable paper snapshots after multiple papers are deleted", () => {
+    const database = open();
+    const project = database.createProject("Deleted decision partitions");
+    const includedPaper = addPaper(database, project.id, "deleted_included");
+    const excludedPaper = addPaper(database, project.id, "deleted_excluded");
+    const review = database.createReview({ projectId: project.id });
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: includedPaper.id,
+      stage: "title-abstract",
+      decision: "uncertain"
+    });
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: includedPaper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: excludedPaper.id,
+      stage: "title-abstract",
+      decision: "exclude"
+    });
+    database.deletePaper(project.id, includedPaper.id);
+    database.deletePaper(project.id, excludedPaper.id);
+
+    expect(database.getCurrentScreeningDecision(review.id, includedPaper.id, "title-abstract")?.decision).toBe(
+      "include"
+    );
+    expect(database.getCurrentScreeningDecision(review.id, excludedPaper.id, "title-abstract")?.decision).toBe(
+      "exclude"
+    );
+    expect(database.getReviewFlowSummary(review.id)).toMatchObject({
+      uniqueRecordsScreened: 2,
+      titleAbstractExclusions: 1,
+      fullTextsSought: 1
+    });
+  });
+
+  it("reports fresh-review history accurately and counts unresolved extraction states", () => {
+    const database = open();
+    const project = database.createProject("Summary review");
+    const review = database.createReview({ projectId: project.id });
+    const paper = addPaper(database, project.id, "summary_paper");
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    database.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "include"
+    });
+    const suggestedField = database.saveExtractionField({
+      reviewId: review.id,
+      name: "Suggested outcome",
+      type: "short-text"
+    });
+    const rejectedField = database.saveExtractionField({
+      reviewId: review.id,
+      name: "Rejected outcome",
+      type: "short-text"
+    });
+    database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: suggestedField.id,
+      value: "Candidate value",
+      status: "suggested",
+      origin: "ai"
+    });
+    database.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: rejectedField.id,
+      value: "Rejected value",
+      status: "rejected",
+      origin: "ai"
+    });
+
+    expect(database.getReviewFlowSummary(review.id)).toMatchObject({
+      historicalCountsAvailable: true,
+      warnings: [],
+      extraction: { totalCells: 2, confirmedCells: 0, notFoundCells: 0, needsReviewCells: 2 }
+    });
+  });
+
+  it("counts only trusted, correctly paper-linked artifacts as indexed review full text", () => {
+    const database = open();
+    const project = database.createProject("Trusted full text");
+    const trustedPaper = addPaper(database, project.id, "trusted_paper");
+    const briefPaper = addPaper(database, project.id, "brief_paper");
+    const generatedPaper = addPaper(database, project.id, "generated_paper");
+    const metadataMismatchPaper = addPaper(database, project.id, "metadata_mismatch_paper");
+    const chunkMismatchPaper = addPaper(database, project.id, "chunk_mismatch_paper");
+    const review = database.createReview({ projectId: project.id });
+    for (const paper of [trustedPaper, briefPaper, generatedPaper, metadataMismatchPaper, chunkMismatchPaper]) {
+      database.setScreeningDecision({
+        reviewId: review.id,
+        paperId: paper.id,
+        stage: "title-abstract",
+        decision: "include"
+      });
+    }
+    const trusted = addIndexedArtifact(database, {
+      projectId: project.id,
+      artifactId: "trusted_markdown",
+      artifactType: "markdown",
+      paperId: trustedPaper.id
+    });
+    addIndexedArtifact(database, {
+      projectId: project.id,
+      artifactId: "generated_brief",
+      artifactType: "brief",
+      paperId: briefPaper.id
+    });
+    addIndexedArtifact(database, {
+      projectId: project.id,
+      artifactId: "research_chat_markdown",
+      artifactType: "markdown",
+      paperId: generatedPaper.id,
+      source: "research-chat"
+    });
+    addIndexedArtifact(database, {
+      projectId: project.id,
+      artifactId: "wrong_metadata",
+      artifactType: "paper-pdf",
+      paperId: metadataMismatchPaper.id,
+      metadataPaperId: trustedPaper.id
+    });
+    addIndexedArtifact(database, {
+      projectId: project.id,
+      artifactId: "wrong_chunk_paper",
+      artifactType: "table",
+      paperId: chunkMismatchPaper.id,
+      chunkPaperId: trustedPaper.id
+    });
+
+    const available = database.listReviewPapers({
+      reviewId: review.id,
+      stage: "full-text",
+      sources: [],
+      decisions: [],
+      fullText: "available",
+      sort: "title",
+      direction: "asc",
+      page: 1,
+      pageSize: 25
+    });
+    expect(available.items.map((paper) => paper.paperId)).toEqual([trustedPaper.id]);
+    expect(database.getReviewFlowSummary(review.id)).toMatchObject({
+      fullTextsSought: 5,
+      fullTextsUnavailable: 4
+    });
+    expect(() =>
+      database.saveReviewEvidence({
+        id: "trusted_chunk_evidence",
+        reviewId: review.id,
+        evidenceId: "S1",
+        paperId: trustedPaper.id,
+        artifactId: trusted.artifactId,
+        chunkId: trusted.chunkId,
+        sourceType: "artifact-chunk",
+        title: trustedPaper.title,
+        excerpt: "Indexed full text evidence.",
+        createdAt: new Date().toISOString()
+      })
+    ).not.toThrow();
+    const generatedChunk = database.listArtifactChunks(project.id, "research_chat_markdown", 1)[0];
+    expect(() =>
+      database.saveReviewEvidence({
+        id: "untrusted_chunk_evidence",
+        reviewId: review.id,
+        evidenceId: "S2",
+        paperId: generatedPaper.id,
+        artifactId: "research_chat_markdown",
+        chunkId: generatedChunk.chunkId,
+        sourceType: "artifact-chunk",
+        title: generatedPaper.title,
+        excerpt: generatedChunk.text,
+        createdAt: new Date().toISOString()
+      })
+    ).toThrow(/trusted indexed chunk/i);
+  });
+});
+
+describe("review portability and batch transactions", () => {
+  it("round trips the complete review state without regenerating audit history or snapshots", () => {
+    const source = open("portability-source.db");
+    const sourceProject = source.createProject("Portable review");
+    const paper = addPaper(source, sourceProject.id, "portable_paper", "Portable evidence");
+    const review = source.createReview({
+      projectId: sourceProject.id,
+      researchQuestion: "Does the evidence travel?",
+      criteria: [
+        {
+          id: "portable_exclusion",
+          stage: "full-text",
+          type: "exclusion",
+          label: "Ineligible design"
+        }
+      ]
+    });
+    source.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    source.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "include"
+    });
+    source.markScreeningForRereview({ reviewId: review.id, paperIds: [paper.id], stage: "full-text" });
+    const field = source.saveExtractionField({ reviewId: review.id, name: "Outcome", type: "short-text" });
+    source.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Improved",
+      status: "confirmed",
+      origin: "manual"
+    });
+    const timestamp = new Date().toISOString();
+    source.saveReviewRun({
+      id: "portable_run",
+      reviewId: review.id,
+      stage: "extraction",
+      provider: "ollama",
+      model: "test-model",
+      protocolRevisionId: review.currentRevisionId,
+      status: "completed",
+      paperIds: [paper.id],
+      fieldIds: [field.id],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    source.saveReviewRunItem({
+      id: "portable_run_item",
+      runId: "portable_run",
+      paperId: paper.id,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      extractionSuggestions: [],
+      evidence: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    source.saveReviewRun({
+      id: "portable_failed_run",
+      reviewId: review.id,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "test-model",
+      protocolRevisionId: review.currentRevisionId,
+      status: "failed",
+      paperIds: [paper.id],
+      fieldIds: [],
+      completedCount: 0,
+      failedCount: 1,
+      cancelledCount: 0,
+      error: "Provider unavailable.",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    source.saveReviewRunItem({
+      id: "portable_failed_item",
+      runId: "portable_failed_run",
+      paperId: paper.id,
+      status: "failed",
+      attemptCount: 2,
+      extractionSuggestions: [],
+      evidence: [],
+      error: "Provider unavailable.",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const batch = source.listDiscoveryBatches(review.id)[0];
+    source.saveDiscoveryBatch({ ...batch, config: { query: "portable query" } });
+    const exported = source.exportReviewPortabilityState(review.id);
+    expect(exported.runs.map((run) => run.status).sort()).toEqual(["completed", "failed"]);
+
+    const target = open("portability-target.db");
+    const targetProject = target.createProject("Imported review");
+    addPaper(target, targetProject.id, paper.id, paper.title);
+    const remapped: ReviewPortabilityState = {
+      ...structuredClone(exported),
+      review: { ...exported.review, projectId: targetProject.id }
+    };
+    const imported = target.importReviewPortabilityState(targetProject.id, remapped);
+
+    expect(imported.id).toBe(review.id);
+    expect(target.exportReviewPortabilityState(imported.id)).toEqual(remapped);
+    expect(target.listReviewAuditEvents(imported.id)).toHaveLength(exported.auditEvents.length);
+  });
+
+  it("rolls back a portability import atomically and supports nested batch transactions", () => {
+    const source = open("rollback-source.db");
+    const sourceProject = source.createProject("Rollback source");
+    addPaper(source, sourceProject.id, "rollback_paper");
+    const sourceReview = source.createReview({ projectId: sourceProject.id, researchQuestion: "Rollback?" });
+    const exported = source.exportReviewPortabilityState(sourceReview.id);
+
+    const target = open("rollback-target.db");
+    const targetProject = target.createProject("Rollback target");
+    addPaper(target, targetProject.id, "rollback_paper");
+    const corrupt: ReviewPortabilityState = {
+      ...structuredClone(exported),
+      review: { ...exported.review, projectId: targetProject.id },
+      revisions: [...exported.revisions, exported.revisions[0]]
+    };
+
+    expect(() => target.importReviewPortabilityState(targetProject.id, corrupt)).toThrow();
+    expect(target.getReview(targetProject.id)).toBeUndefined();
+
+    expect(() =>
+      target.transaction(() => {
+        target.savePaper(targetProject.id, {
+          id: "transaction_paper",
+          title: "Nested transaction paper",
+          authors: [],
+          source: "reference-import",
+          isOpenAccess: false,
+          fieldsOfStudy: []
+        });
+        throw new Error("force rollback");
+      })
+    ).toThrow(/force rollback/);
+    expect(target.getPaper(targetProject.id, "transaction_paper")).toBeUndefined();
+  });
+});

--- a/tests/review-evidence.test.ts
+++ b/tests/review-evidence.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PaperPilotDb } from "../src/main/db";
+import { collectReviewPaperEvidence, hasIndexedReviewFullText } from "../src/main/services/review-evidence";
+
+let dir: string;
+let db: PaperPilotDb;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "paper-pilot-review-evidence-"));
+  db = new PaperPilotDb(join(dir, "review.db"));
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("review evidence", () => {
+  it("uses only the selected paper abstract during title/abstract screening", () => {
+    const project = db.createProject("Review");
+    const paper = db.savePaper(project.id, {
+      id: "paper-a",
+      title: "Eligible trial",
+      abstract: "Adults received an intervention in a randomized trial.",
+      authors: [],
+      source: "pubmed",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    db.savePaper(project.id, {
+      id: "paper-b",
+      title: "Other trial",
+      abstract: "This evidence must not be included.",
+      authors: [],
+      source: "pubmed",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+
+    const result = collectReviewPaperEvidence({
+      db,
+      projectId: project.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      query: "adults"
+    });
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ paperId: paper.id, locator: "Paper metadata" }),
+        expect.objectContaining({ paperId: paper.id, locator: "Abstract" })
+      ])
+    );
+    expect(result.map((entry) => entry.excerpt).join("\n")).not.toContain("must not be included");
+  });
+
+  it("restricts full-text evidence to indexed artifacts linked to the paper", () => {
+    const project = db.createProject("Review");
+    const paper = db.savePaper(project.id, {
+      id: "paper-a",
+      title: "Eligible trial",
+      authors: [],
+      source: "pubmed",
+      isOpenAccess: true,
+      fieldsOfStudy: []
+    });
+    const linked = db.saveArtifact({
+      id: "artifact-a",
+      projectId: project.id,
+      type: "paper-pdf",
+      title: paper.title,
+      path: join(dir, "paper.pdf"),
+      mime: "application/pdf",
+      hash: "hash-a",
+      metadata: { paperId: paper.id },
+      createdAt: new Date().toISOString()
+    });
+    const unrelated = db.saveArtifact({
+      id: "artifact-b",
+      projectId: project.id,
+      type: "markdown",
+      title: "Unrelated",
+      path: join(dir, "other.md"),
+      mime: "text/markdown",
+      hash: "hash-b",
+      metadata: {},
+      createdAt: new Date().toISOString()
+    });
+    db.addDocumentChunks({
+      projectId: project.id,
+      artifactId: linked.id,
+      paperId: paper.id,
+      chunks: [{ text: "The intervention improved the measured outcome.", metadata: { page: 4 } }]
+    });
+    db.addDocumentChunks({
+      projectId: project.id,
+      artifactId: unrelated.id,
+      chunks: [{ text: "Unrelated intervention outcome." }]
+    });
+
+    expect(hasIndexedReviewFullText(db, project.id, paper.id)).toBe(true);
+    const result = collectReviewPaperEvidence({
+      db,
+      projectId: project.id,
+      paperId: paper.id,
+      stage: "full-text",
+      query: "intervention outcome"
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ artifactId: linked.id, paperId: paper.id, page: 4 });
+  });
+});

--- a/tests/review-export.test.ts
+++ b/tests/review-export.test.ts
@@ -139,6 +139,19 @@ describe("renderReviewExportPackage", () => {
     expect(svg).toContain(">2</text>");
   });
 
+  it("escapes existing backslashes before Markdown inline and table metacharacters", () => {
+    const input = exportFixture();
+    const files = renderReviewExportPackage({
+      ...input,
+      protocol: { ...input.protocol, id: "review\\archive" },
+      batches: input.batches.map((batch, index) => (index === 0 ? { ...batch, label: "Batch \\server|share" } : batch))
+    });
+    const summary = files.get("review-summary.md")!;
+
+    expect(summary).toContain("- Review ID: review\\\\archive");
+    expect(summary).toContain("| Batch \\\\server\\|share |");
+  });
+
   it("includes sorted protocol, provenance, run metadata, and audit history in JSON", () => {
     const json = renderReviewExportPackage(exportFixture()).get("review-audit.json")!;
     const parsed = JSON.parse(json) as {

--- a/tests/review-export.test.ts
+++ b/tests/review-export.test.ts
@@ -1,0 +1,658 @@
+import { describe, expect, it } from "vitest";
+import type {
+  DiscoveryBatch,
+  ExtractionField,
+  Paper,
+  ReviewAuditEvent,
+  ReviewEvidence,
+  ReviewFlowSummary,
+  ReviewProtocol,
+  ReviewProtocolRevision,
+  ReviewRun
+} from "../src/shared/schemas";
+import type {
+  PortableExtractionValue,
+  PortableReviewRunItem,
+  PortableScreeningDecision,
+  ReviewCandidateOrigin
+} from "../src/main/db";
+import {
+  renderReviewExportPackage,
+  REVIEW_EXPORT_FILE_NAMES,
+  type ReviewExportInput
+} from "../src/main/services/review-export-service";
+
+describe("renderReviewExportPackage", () => {
+  it("renders the complete deterministic package", () => {
+    const input = exportFixture();
+    const first = renderReviewExportPackage(input);
+    const reordered = renderReviewExportPackage({
+      ...input,
+      revisions: [...input.revisions].reverse(),
+      batches: [...input.batches].reverse(),
+      candidateOrigins: [...input.candidateOrigins].reverse(),
+      screeningDecisions: [...input.screeningDecisions].reverse(),
+      includedPapers: [...input.includedPapers].reverse(),
+      extractionFields: [...input.extractionFields].reverse(),
+      extractionFieldHistory: [...input.extractionFieldHistory].reverse(),
+      extractionValues: [...input.extractionValues].reverse(),
+      extractionValueHistory: [...input.extractionValueHistory].reverse(),
+      evidence: [...input.evidence].reverse(),
+      runs: [...input.runs].reverse(),
+      runItems: [...input.runItems].reverse(),
+      auditEvents: [...input.auditEvents].reverse()
+    });
+
+    expect([...first.keys()]).toEqual(REVIEW_EXPORT_FILE_NAMES);
+    expect(Object.fromEntries(reordered)).toEqual(Object.fromEntries(first));
+    for (const content of first.values()) expect(content.endsWith("\n")).toBe(true);
+  });
+
+  it("exports only current confirmed extraction values with correct CSV escaping", () => {
+    const files = renderReviewExportPackage(exportFixture());
+    const matrix = files.get("evidence-matrix.csv")!;
+
+    expect(matrix.split("\n", 1)[0]).toBe('paper_id,title,authors,year,doi,Study notes,"Effect, estimate"');
+    expect(matrix.indexOf("paper-alpha")).toBeLessThan(matrix.indexOf("paper-beta"));
+    expect(matrix).toContain('"Alpha & ""Trial"""');
+    expect(matrix).toContain('"Doe, Jane; Roe, John"');
+    expect(matrix).toContain('"Line one,\n""quoted"""');
+    expect(matrix).toContain(",1.25\n");
+    expect(matrix).not.toContain("obsolete value");
+    expect(matrix).not.toContain("inactive value");
+    expect(matrix).not.toContain("excluded paper value");
+  });
+
+  it("neutralizes spreadsheet formulas in untrusted text cells without changing numeric values", () => {
+    const input = exportFixture();
+    const includedPapers = input.includedPapers.map((paper) =>
+      paper.id === "paper-alpha" ? { ...paper, title: '  =HYPERLINK("https://evil.test")' } : paper
+    );
+    const extractionValues = input.extractionValues.map((value) =>
+      value.id === "value-notes" ? { ...value, value: "+SUM(1,1)" } : value
+    );
+    const matrix = renderReviewExportPackage({ ...input, includedPapers, extractionValues }).get(
+      "evidence-matrix.csv"
+    )!;
+
+    expect(matrix).toContain("'  =HYPERLINK");
+    expect(matrix).toContain('"\'+SUM(1,1)"');
+    expect(matrix).toContain(",1.25\n");
+  });
+
+  it("links exported evidence to its confirmed value and preserves locators", () => {
+    const locators = renderReviewExportPackage(exportFixture()).get("evidence-locators.csv")!;
+
+    expect(locators).toContain("value-effect");
+    expect(locators).toContain("ev-db");
+    expect(locators).toContain("S1");
+    expect(locators).toContain("artifact-chunk");
+    expect(locators).toContain('"Evidence, line one\n""line two"""');
+    expect(locators).toContain(",7,Methods section,");
+    expect(locators).toContain("Unreferenced evidence");
+  });
+
+  it("renders current screening decisions and human-readable exclusion reasons", () => {
+    const decisions = renderReviewExportPackage(exportFixture()).get("screening-decisions.csv")!;
+
+    expect(decisions.indexOf("decision-ta")).toBeLessThan(decisions.indexOf("decision-ft"));
+    expect(decisions).toContain("Wrong population");
+    expect(decisions).toContain('"Not eligible, because ""wrong population"".\nVerified manually."');
+    expect(decisions).toContain("revision-2");
+  });
+
+  it("renders deterministic RIS and BibTeX reference round-trip files", () => {
+    const files = renderReviewExportPackage(exportFixture());
+    const ris = files.get("included-references.ris")!;
+    const bib = files.get("included-references.bib")!;
+
+    expect(ris.indexOf("TI  - Alpha")).toBeLessThan(ris.indexOf("TI  - Beta"));
+    expect(ris).toContain("AU  - Doe, Jane\nAU  - Roe, John");
+    expect(ris).toContain("AB  - First line second line");
+    expect(ris).toContain("DO  - 10.1/alpha");
+    expect(ris).toContain("ER  -\n");
+
+    expect(bib.indexOf("@article{doe2020alpha")).toBeLessThan(bib.indexOf("@article{alpha2021beta"));
+    expect(bib).toContain('title = {Alpha \\& "Trial"}');
+    expect(bib).toContain("author = {Doe, Jane and Roe, John}");
+    expect(bib).toContain("source = {reference-import}");
+  });
+
+  it("produces a factual summary and accessible explicitly non-PRISMA flow", () => {
+    const files = renderReviewExportPackage(exportFixture());
+    const summary = files.get("review-summary.md")!;
+    const svg = files.get("review-flow.svg")!;
+
+    expect(summary).toContain("not a PRISMA 2020-compliant report, diagram, or certification");
+    expect(summary).toContain("does not contain AI-generated conclusions");
+    expect(summary).toContain("Historical discovery and duplicate counts were unavailable");
+    expect(summary).toContain("| Wrong population | 1 |");
+    expect(summary).toContain("| Included papers | 2 |");
+    expect(summary).toContain("AI assistance was advisory");
+    expect(summary).not.toContain("Supports the effect estimate");
+
+    expect(svg).toContain('role="img"');
+    expect(svg).toContain('aria-labelledby="review-flow-title review-flow-desc"');
+    expect(svg).toContain('<title id="review-flow-title">Review flow</title>');
+    expect(svg).toContain("not a PRISMA 2020 diagram");
+    expect(svg).toContain("Included papers");
+    expect(svg).toContain(">2</text>");
+  });
+
+  it("includes sorted protocol, provenance, run metadata, and audit history in JSON", () => {
+    const json = renderReviewExportPackage(exportFixture()).get("review-audit.json")!;
+    const parsed = JSON.parse(json) as {
+      schemaVersion: number;
+      exportKind: string;
+      includedPapers: Paper[];
+      batches: DiscoveryBatch[];
+      auditEvents: ReviewAuditEvent[];
+      flowSummary: ReviewFlowSummary;
+      protocolHistory: ReviewProtocolRevision[];
+      candidateOrigins: ReviewCandidateOrigin[];
+      runItems: PortableReviewRunItem[];
+      paperSnapshots: Paper[];
+    };
+
+    expect(parsed).toMatchObject({
+      schemaVersion: 2,
+      exportKind: "paper-pilot-review-audit",
+      flowSummary: { reviewId: "review-1", includedPapers: 2 }
+    });
+    expect(parsed.includedPapers.map((paper) => paper.id)).toEqual(["paper-alpha", "paper-beta"]);
+    expect(parsed.batches.map((batch) => batch.id)).toEqual(["batch-old", "batch-import"]);
+    expect(parsed.auditEvents.map((event) => event.id)).toEqual(["audit-old", "audit-new"]);
+    expect(parsed.protocolHistory.map((revision) => revision.id)).toEqual(["revision-1", "revision-2"]);
+    expect(parsed.candidateOrigins[0]).toMatchObject({ sourceRecordId: "RIS-1", resolution: "duplicate" });
+    expect(parsed.runItems[0]).toMatchObject({ id: "run-item-1", evidenceIds: ["ev-db"] });
+    expect(parsed.paperSnapshots.some((paper) => paper.id === "paper-z-excluded")).toBe(true);
+    expect(json.indexOf('"a": 1')).toBeLessThan(json.indexOf('"z": 2'));
+  });
+
+  it("recovers deleted included references and excluded titles from immutable snapshots", () => {
+    const input = exportFixture();
+    const deleted = paperSnapshot("paper-deleted", "Deleted but included trial");
+    deleted.authors = ["Snapshot, Dana"];
+    deleted.year = 2019;
+    deleted.doi = "10.1/deleted";
+    const files = renderReviewExportPackage({
+      ...input,
+      includedPaperIds: [...input.includedPaperIds, deleted.id],
+      screeningDecisions: [
+        ...input.screeningDecisions,
+        {
+          id: "decision-deleted",
+          reviewId: "review-1",
+          paperId: deleted.id,
+          paperSnapshot: deleted,
+          stage: "full-text",
+          decision: "include",
+          protocolRevisionId: "revision-2",
+          createdAt: "2026-08-24T00:00:00.000Z"
+        }
+      ]
+    });
+
+    expect(files.get("included-references.ris")).toContain("TI  - Deleted but included trial");
+    expect(files.get("included-references.bib")).toContain("doi = {10.1/deleted}");
+    expect(files.get("screening-decisions.csv")).toContain("Excluded population study");
+  });
+});
+
+function exportFixture(): ReviewExportInput {
+  const protocol: ReviewProtocol = {
+    id: "review-1",
+    projectId: "project-1",
+    template: "general-empirical",
+    currentRevisionId: "revision-2",
+    currentRevisionNumber: 2,
+    historicalCountsAvailable: false,
+    activatedAt: "2026-08-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-20T00:00:00.000Z"
+  };
+  const revision: ReviewProtocolRevision = {
+    id: "revision-2",
+    reviewId: "review-1",
+    version: 2,
+    researchQuestion: "What is the effect?",
+    objectives: ["Estimate the effect", "Record study characteristics"],
+    criteria: [
+      {
+        id: "criterion-population",
+        stage: "full-text",
+        type: "exclusion",
+        label: "Wrong population",
+        description: "The population is outside scope.",
+        order: 1
+      },
+      {
+        id: "criterion-empirical",
+        stage: "title-abstract",
+        type: "inclusion",
+        label: "Empirical study",
+        order: 0
+      }
+    ],
+    changeNote: "Clarified the population.",
+    createdAt: "2026-08-20T00:00:00.000Z"
+  };
+  const firstRevision: ReviewProtocolRevision = {
+    id: "revision-1",
+    reviewId: "review-1",
+    version: 1,
+    researchQuestion: "What was studied?",
+    objectives: ["Describe the studies"],
+    criteria: [],
+    createdAt: "2026-08-01T00:00:00.000Z"
+  };
+  const batches: DiscoveryBatch[] = [
+    {
+      id: "batch-import",
+      reviewId: "review-1",
+      kind: "reference-import",
+      label: "Imported, library",
+      fileName: "library.csv",
+      importFormat: "csv",
+      status: "completed",
+      counts: { identified: 4, filtered: 0, invalid: 1, duplicates: 1, merged: 0, newRecords: 2 },
+      historicalCountsAvailable: true,
+      createdAt: "2026-08-03T00:00:00.000Z",
+      completedAt: "2026-08-03T00:01:00.000Z"
+    },
+    {
+      id: "batch-old",
+      reviewId: "review-1",
+      kind: "pre-existing",
+      label: "Pre-existing project papers",
+      status: "completed",
+      counts: { identified: 2, filtered: 0, invalid: 0, duplicates: 0, merged: 0, newRecords: 0 },
+      historicalCountsAvailable: false,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      completedAt: "2026-08-01T00:00:00.000Z"
+    }
+  ];
+  const screeningDecisions: PortableScreeningDecision[] = [
+    {
+      id: "decision-z",
+      reviewId: "review-1",
+      paperId: "paper-z-excluded",
+      paperSnapshot: paperSnapshot("paper-z-excluded", "Excluded population study"),
+      stage: "full-text",
+      decision: "exclude",
+      protocolRevisionId: "revision-2",
+      reasonCriterionId: "criterion-population",
+      customReason: 'Not eligible, because "wrong population".\nVerified manually.',
+      createdAt: "2026-08-23T00:00:00.000Z"
+    },
+    {
+      id: "decision-ft",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      stage: "full-text",
+      decision: "include",
+      protocolRevisionId: "revision-2",
+      createdAt: "2026-08-22T00:00:00.000Z"
+    },
+    {
+      id: "decision-ta",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      stage: "title-abstract",
+      decision: "include",
+      protocolRevisionId: "revision-2",
+      createdAt: "2026-08-21T00:00:00.000Z"
+    }
+  ];
+  const includedPapers: Paper[] = [
+    {
+      id: "paper-beta",
+      projectId: "project-1",
+      title: "Beta, Study",
+      authors: ["Team Alpha"],
+      year: 2021,
+      source: "reference-import",
+      sourcePaperId: "beta-key",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    },
+    {
+      id: "paper-alpha",
+      projectId: "project-1",
+      title: 'Alpha & "Trial"',
+      abstract: "First line\nsecond line",
+      authors: ["Doe, Jane", "Roe, John"],
+      year: 2020,
+      doi: "10.1/alpha",
+      url: "https://example.test/alpha",
+      pdfUrl: "https://example.test/alpha.pdf",
+      source: "arxiv",
+      sourcePaperId: "2001.00001",
+      venue: "Trials & Reviews",
+      citationCount: 12,
+      isOpenAccess: true,
+      fieldsOfStudy: []
+    }
+  ];
+  const extractionFields: ExtractionField[] = [
+    {
+      id: "field-effect",
+      reviewId: "review-1",
+      name: "Effect, estimate",
+      type: "number",
+      options: [],
+      order: 1,
+      revision: 2,
+      active: true,
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-20T00:00:00.000Z"
+    },
+    {
+      id: "field-inactive",
+      reviewId: "review-1",
+      name: "Retired field",
+      type: "short-text",
+      options: [],
+      order: 2,
+      revision: 1,
+      active: false,
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:00.000Z"
+    },
+    {
+      id: "field-notes",
+      reviewId: "review-1",
+      name: "Study notes",
+      type: "long-text",
+      options: [],
+      order: 0,
+      revision: 1,
+      active: true,
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z"
+    }
+  ];
+  const extractionValues: PortableExtractionValue[] = [
+    {
+      id: "value-excluded-paper",
+      reviewId: "review-1",
+      paperId: "paper-z-excluded",
+      paperSnapshot: paperSnapshot("paper-z-excluded", "Excluded population study"),
+      fieldId: "field-notes",
+      fieldRevision: 1,
+      value: "excluded paper value",
+      status: "confirmed",
+      origin: "manual",
+      evidenceIds: [],
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+      confirmedAt: "2026-08-22T00:00:00.000Z"
+    },
+    {
+      id: "value-needs-review",
+      reviewId: "review-1",
+      paperId: "paper-beta",
+      paperSnapshot: paperSnapshot("paper-beta", "Beta, Study"),
+      fieldId: "field-effect",
+      fieldRevision: 2,
+      value: 2.5,
+      status: "needs-review",
+      origin: "ai",
+      evidenceIds: ["ev-db"],
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:00:00.000Z"
+    },
+    {
+      id: "value-obsolete-revision",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      fieldId: "field-effect",
+      fieldRevision: 1,
+      value: "obsolete value",
+      status: "confirmed",
+      origin: "manual",
+      evidenceIds: [],
+      createdAt: "2026-08-12T00:00:00.000Z",
+      updatedAt: "2026-08-12T00:00:00.000Z",
+      confirmedAt: "2026-08-12T00:00:00.000Z"
+    },
+    {
+      id: "value-effect-old",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      fieldId: "field-effect",
+      fieldRevision: 2,
+      value: 0.5,
+      status: "confirmed",
+      origin: "ai",
+      evidenceIds: ["ev-db"],
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:00:00.000Z",
+      confirmedAt: "2026-08-21T00:00:00.000Z"
+    },
+    {
+      id: "value-effect",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      fieldId: "field-effect",
+      fieldRevision: 2,
+      value: 1.25,
+      status: "confirmed",
+      origin: "ai",
+      evidenceIds: ["ev-db"],
+      runItemId: "run-item-1",
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+      confirmedAt: "2026-08-22T00:00:00.000Z"
+    },
+    {
+      id: "value-notes",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      fieldId: "field-notes",
+      fieldRevision: 1,
+      value: 'Line one,\n"quoted"',
+      status: "confirmed",
+      origin: "manual",
+      evidenceIds: [],
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+      confirmedAt: "2026-08-22T00:00:00.000Z"
+    },
+    {
+      id: "value-inactive",
+      reviewId: "review-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      fieldId: "field-inactive",
+      fieldRevision: 1,
+      value: "inactive value",
+      status: "confirmed",
+      origin: "manual",
+      evidenceIds: [],
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+      confirmedAt: "2026-08-22T00:00:00.000Z"
+    }
+  ];
+  const evidence: ReviewEvidence[] = [
+    {
+      id: "ev-unused",
+      reviewId: "review-1",
+      evidenceId: "S2",
+      paperId: "paper-beta",
+      sourceType: "paper-abstract",
+      title: "Unreferenced evidence",
+      excerpt: "Not used by a confirmed value.",
+      createdAt: "2026-08-22T00:00:00.000Z"
+    },
+    {
+      id: "ev-db",
+      reviewId: "review-1",
+      evidenceId: "S1",
+      runId: "run-1",
+      runItemId: "run-item-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      artifactId: "artifact-1",
+      chunkId: "chunk-7",
+      sourceType: "artifact-chunk",
+      title: "Alpha evidence",
+      excerpt: 'Evidence, line one\n"line two"',
+      locator: "Methods section",
+      page: 7,
+      doi: "10.1/alpha",
+      url: "https://example.test/alpha#page=7",
+      retrievalScore: 0.91,
+      createdAt: "2026-08-22T00:00:00.000Z"
+    }
+  ];
+  const runs: ReviewRun[] = [
+    {
+      id: "run-1",
+      reviewId: "review-1",
+      stage: "extraction",
+      provider: "ollama",
+      model: "qwen3:8b",
+      protocolRevisionId: "revision-2",
+      status: "completed",
+      paperIds: ["paper-alpha"],
+      fieldIds: ["field-effect"],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:01:00.000Z",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      completedAt: "2026-08-22T00:01:00.000Z"
+    }
+  ];
+  const runItems: PortableReviewRunItem[] = [
+    {
+      id: "run-item-1",
+      runId: "run-1",
+      paperId: "paper-alpha",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      status: "completed",
+      attemptCount: 1,
+      rationale: "The reported value was extracted from S1.",
+      criterionAssessments: [],
+      extractionSuggestions: [
+        {
+          fieldId: "field-effect",
+          value: 1.25,
+          status: "suggested",
+          evidenceIds: ["S1"]
+        }
+      ],
+      evidenceIds: ["ev-db"],
+      stale: false,
+      createdAt: "2026-08-22T00:00:00.000Z",
+      updatedAt: "2026-08-22T00:01:00.000Z",
+      startedAt: "2026-08-22T00:00:00.000Z",
+      completedAt: "2026-08-22T00:01:00.000Z"
+    }
+  ];
+  const candidateOrigins: ReviewCandidateOrigin[] = [
+    {
+      id: "origin-1",
+      reviewId: "review-1",
+      batchId: "batch-import",
+      paperId: "paper-alpha",
+      matchedPaperId: "paper-alpha",
+      sourceRecordId: "RIS-1",
+      resolution: "duplicate",
+      paperSnapshot: paperSnapshot("paper-alpha", 'Alpha & "Trial"'),
+      recordSnapshot: { title: 'Alpha & "Trial"', doi: "10.1/alpha" },
+      createdAt: "2026-08-03T00:00:30.000Z"
+    }
+  ];
+  const auditEvents: ReviewAuditEvent[] = [
+    {
+      id: "audit-new",
+      reviewId: "review-1",
+      kind: "extraction-value-confirmed",
+      actor: "user",
+      entityType: "extraction-value",
+      entityId: "value-effect",
+      payload: { z: 2, a: 1 },
+      createdAt: "2026-08-22T00:02:00.000Z"
+    },
+    {
+      id: "audit-old",
+      reviewId: "review-1",
+      kind: "review-activated",
+      actor: "user",
+      entityType: "review",
+      entityId: "review-1",
+      payload: {},
+      createdAt: "2026-08-01T00:00:00.000Z"
+    }
+  ];
+  const flowSummary: ReviewFlowSummary = {
+    reviewId: "review-1",
+    identifiedRecords: 6,
+    filteredRecords: 0,
+    invalidRecords: 1,
+    duplicateRecords: 1,
+    mergedRecords: 0,
+    newRecords: 2,
+    uniqueRecordsScreened: 4,
+    titleAbstractExclusions: 1,
+    fullTextsSought: 3,
+    fullTextsUnavailable: 0,
+    fullTextExclusionsByReason: { "Wrong population": 1 },
+    includedPapers: 2,
+    extraction: {
+      totalCells: 4,
+      confirmedCells: 2,
+      notFoundCells: 0,
+      needsReviewCells: 1,
+      completionPercent: 50
+    },
+    historicalCountsAvailable: false,
+    warnings: ["Historical duplicate counts are unavailable."],
+    generatedAt: "2026-08-23T12:00:00.000Z"
+  };
+  return {
+    protocol,
+    revision,
+    revisions: [revision, firstRevision],
+    batches,
+    candidateOrigins,
+    screeningDecisions,
+    includedPapers,
+    includedPaperIds: ["paper-alpha", "paper-beta"],
+    extractionFields,
+    extractionFieldHistory: extractionFields.map((field) => ({ ...field, recordedAt: field.updatedAt })),
+    extractionValues,
+    extractionValueHistory: extractionValues.map((value) => ({
+      ...value,
+      changeRevision: 1,
+      recordedAt: value.updatedAt
+    })),
+    evidence,
+    runs,
+    runItems,
+    auditEvents,
+    flowSummary
+  };
+}
+
+function paperSnapshot(id: string, title: string): Paper {
+  return {
+    id,
+    projectId: "project-1",
+    title,
+    authors: [],
+    source: "reference-import",
+    isOpenAccess: false,
+    fieldsOfStudy: []
+  };
+}

--- a/tests/review-import-manager.test.ts
+++ b/tests/review-import-manager.test.ts
@@ -1,0 +1,320 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PaperPilotDb } from "../src/main/db";
+import { ReviewImportManager } from "../src/main/services/review-import-manager";
+
+let directory: string;
+let db: PaperPilotDb;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "paper-pilot-review-import-"));
+  db = new PaperPilotDb(join(directory, "test.db"));
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe("ReviewImportManager", () => {
+  it("previews title-only matches as ambiguous without exposing a raw path", async () => {
+    const fixture = reviewFixture();
+    db.savePaper(fixture.projectId, {
+      id: "existing",
+      title: "Shared title",
+      authors: ["Original Author"],
+      year: 2020,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const path = await csv("title,authors,year\nShared title,Different Author,2024\n");
+
+    const preview = await new ReviewImportManager(db).preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+
+    expect(preview).not.toHaveProperty("filePath");
+    expect(preview.items[0]).toMatchObject({
+      valid: true,
+      match: { kind: "ambiguous", candidatePaperIds: ["existing"] }
+    });
+  });
+
+  it("records an explicit skip and reconciles discovery counts", async () => {
+    const fixture = reviewFixture();
+    db.savePaper(fixture.projectId, {
+      id: "existing",
+      title: "Shared title",
+      authors: ["Original Author"],
+      year: 2020,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const path = await csv("title,authors,year\nShared title,Different Author,2024\n");
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+
+    const result = await manager.commit({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      previewId: preview.previewId,
+      resolutions: [{ recordIndex: 0, action: "skip" }]
+    });
+
+    expect(result.counts).toMatchObject({ identified: 1, filtered: 1, newRecords: 0 });
+    expect(db.listReviewCandidateOrigins(fixture.reviewId, result.batch.id)[0]).toMatchObject({
+      resolution: "skipped"
+    });
+    expect(db.listPapers(fixture.projectId)).toHaveLength(1);
+  });
+
+  it("requires ambiguous resolutions and restricts merges to the presented candidates", async () => {
+    const fixture = reviewFixture();
+    db.savePaper(fixture.projectId, {
+      id: "candidate",
+      title: "Shared title",
+      authors: ["Original Author"],
+      year: 2020,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    db.savePaper(fixture.projectId, {
+      id: "unrelated",
+      title: "Unrelated paper",
+      authors: ["Another Author"],
+      year: 2019,
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const path = await csv("title,authors,year\nShared title,Different Author,2024\n");
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+
+    await expect(
+      manager.commit({
+        projectId: fixture.projectId,
+        reviewId: fixture.reviewId,
+        previewId: preview.previewId,
+        resolutions: []
+      })
+    ).rejects.toThrow(/explicit ambiguous-match resolution/i);
+    await expect(
+      manager.commit({
+        projectId: fixture.projectId,
+        reviewId: fixture.reviewId,
+        previewId: preview.previewId,
+        resolutions: [{ recordIndex: 0, action: "merge", paperId: "unrelated" }]
+      })
+    ).rejects.toThrow(/invalid merge target/i);
+    expect(db.listDiscoveryBatches(fixture.reviewId).filter((batch) => batch.kind === "reference-import")).toEqual([]);
+  });
+
+  it("merges an exact normalized DOI, enriches metadata, and retains the source occurrence", async () => {
+    const fixture = reviewFixture();
+    db.savePaper(fixture.projectId, {
+      id: "existing",
+      title: "Original title",
+      authors: ["A. Author"],
+      year: 2022,
+      doi: "10.1000/example",
+      source: "crossref",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const path = await csv(
+      "title,authors,year,doi,abstract,citation count\nOriginal title,A. Author,2022,https://doi.org/10.1000/example,New abstract,9\n"
+    );
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+    expect(preview.items[0].match).toMatchObject({ kind: "exact", paperId: "existing", matchedBy: "doi" });
+
+    const result = await manager.commit({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      previewId: preview.previewId,
+      resolutions: []
+    });
+
+    expect(result.counts).toMatchObject({ identified: 1, merged: 1, duplicates: 0, newRecords: 0 });
+    expect(db.getPaper(fixture.projectId, "existing")).toMatchObject({ abstract: "New abstract", citationCount: 9 });
+    expect(db.listReviewCandidateOrigins(fixture.reviewId, result.batch.id)[0]).toMatchObject({
+      paperId: "existing",
+      matchedPaperId: "existing",
+      resolution: "merged"
+    });
+  });
+
+  it("rejects a file changed after preview without mutating review provenance", async () => {
+    const fixture = reviewFixture();
+    const path = await csv("title\nFirst record\n");
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+    await writeFile(path, "title\nChanged record\n", "utf8");
+
+    await expect(
+      manager.commit({
+        projectId: fixture.projectId,
+        reviewId: fixture.reviewId,
+        previewId: preview.previewId,
+        resolutions: []
+      })
+    ).rejects.toThrow(/changed after preview/i);
+    expect(db.listDiscoveryBatches(fixture.reviewId).filter((batch) => batch.kind === "reference-import")).toEqual([]);
+  });
+
+  it("does not copy an imported identifier into a different source authority", async () => {
+    const fixture = reviewFixture();
+    db.savePaper(fixture.projectId, {
+      id: "crossref-record",
+      title: "Authority-safe merge",
+      authors: ["Doe, Jane"],
+      year: 2024,
+      source: "crossref",
+      sourcePaperId: "CR-9",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const path = await csv(
+      "title,authors,year,source id,source authority,abstract\nAuthority-safe merge,Jane Doe,2024,W123,OpenAlex,Enriched abstract\n"
+    );
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+
+    expect(preview.items[0].match).toMatchObject({ kind: "exact", matchedBy: "fingerprint" });
+    await manager.commit({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      previewId: preview.previewId,
+      resolutions: []
+    });
+
+    const merged = db.getPaper(fixture.projectId, "crossref-record");
+    expect(merged).toMatchObject({ source: "crossref", sourcePaperId: "CR-9", abstract: "Enriched abstract" });
+    expect(merged?.raw?.identitySourceIdentifiers).toEqual([{ authority: "openalex", identifier: "w123" }]);
+  });
+
+  it("deduplicates records created earlier in the same import using the incremental identity index", async () => {
+    const fixture = reviewFixture();
+    const path = await csv(
+      [
+        "title,authors,year,abstract",
+        "One batched study,Jane Doe,2024,First occurrence",
+        "One batched study,Jane Doe,2024,Second occurrence"
+      ].join("\n")
+    );
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+    expect(preview.items[1].match).toMatchObject({
+      kind: "exact",
+      matchedBy: "fingerprint",
+      paperId: "preview-paper:1"
+    });
+    const result = await manager.commit({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      previewId: preview.previewId,
+      resolutions: []
+    });
+
+    expect(result.counts).toMatchObject({ identified: 2, newRecords: 1, duplicates: 1 });
+    expect(db.listPapers(fixture.projectId)).toHaveLength(1);
+    expect(db.listReviewCandidateOrigins(fixture.reviewId, result.batch.id)).toHaveLength(2);
+  });
+
+  it("uses preview record identities as explicit merge targets in cross-record order", async () => {
+    const fixture = reviewFixture();
+    const path = await csv(["title,authors,year", "Same title,Jane Doe,2024", "Same title,John Roe,2023"].join("\n"));
+    const manager = new ReviewImportManager(db);
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+
+    expect(preview.items[0].match.kind).toBe("none");
+    expect(preview.items[1].match).toMatchObject({
+      kind: "ambiguous",
+      candidatePaperIds: ["preview-paper:1"]
+    });
+    const result = await manager.commit({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      previewId: preview.previewId,
+      resolutions: [{ recordIndex: 1, action: "merge", paperId: "preview-paper:1" }]
+    });
+
+    expect(result.counts).toMatchObject({ identified: 2, newRecords: 1, merged: 1 });
+    expect(db.listPapers(fixture.projectId)).toHaveLength(1);
+    expect(db.listReviewCandidateOrigins(fixture.reviewId, result.batch.id)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ resolution: "merged" })])
+    );
+  });
+
+  it("buffers large imports into bounded prepared provenance writes", async () => {
+    const fixture = reviewFixture();
+    const records = Array.from({ length: 1_201 }, (_, index) =>
+      [`Unique import ${index}`, `Author ${index}`, "2024"].join(",")
+    );
+    const path = await csv(["title,authors,year", ...records].join("\n"));
+    const manager = new ReviewImportManager(db);
+    const bulkOrigins = vi.spyOn(db, "recordReviewCandidateOriginsBulk");
+    const preview = await manager.preview({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      filePath: path
+    });
+    const result = await manager.commit({
+      projectId: fixture.projectId,
+      reviewId: fixture.reviewId,
+      previewId: preview.previewId,
+      resolutions: []
+    });
+
+    expect(result.counts).toMatchObject({ identified: 1_201, newRecords: 1_201 });
+    expect(bulkOrigins.mock.calls.map(([inputs]) => inputs.length)).toEqual([500, 500, 201]);
+  });
+});
+
+function reviewFixture(): { projectId: string; reviewId: string } {
+  const project = db.createProject("Imported review");
+  const review = db.createReview({ projectId: project.id });
+  return { projectId: project.id, reviewId: review.id };
+}
+
+async function csv(content: string): Promise<string> {
+  const path = join(directory, `references-${Math.random().toString(16).slice(2)}.csv`);
+  await writeFile(path, content, "utf8");
+  return path;
+}

--- a/tests/review-ipc.test.ts
+++ b/tests/review-ipc.test.ts
@@ -1,0 +1,634 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IpcMainInvokeEvent } from "electron";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PaperPilotDb } from "../src/main/db";
+import { registerReviewIpc, type ReviewIpcRuntime, type ReviewIpcServices } from "../src/main/review-ipc";
+import type { ReviewRun, ReviewRunEvent } from "../src/shared/schemas";
+
+let directory: string;
+let db: PaperPilotDb;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "paper-pilot-review-ipc-"));
+  db = new PaperPilotDb(join(directory, "review-ipc.db"));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  db.close();
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe("registerReviewIpc", () => {
+  it("registers the complete review API and returns validated review state", async () => {
+    const project = db.createProject("IPC review");
+    const runtime = new FakeReviewRuntime();
+    registerReviewIpc(fakeServices(), runtime);
+
+    expect([...runtime.handlers.keys()].sort()).toEqual(
+      [
+        "review:activate",
+        "review:attachPdf",
+        "review:cancelRun",
+        "review:commitImport",
+        "review:export",
+        "review:fetchFullText",
+        "review:get",
+        "review:getSummary",
+        "review:listDiscoveryBatches",
+        "review:listEvidence",
+        "review:listExtractionFields",
+        "review:listExtractionValues",
+        "review:listPapers",
+        "review:listProtocolRevisions",
+        "review:listRunItems",
+        "review:listRuns",
+        "review:markForReview",
+        "review:previewImport",
+        "review:remapImport",
+        "review:reorderExtractionFields",
+        "review:retryRun",
+        "review:reviseProtocol",
+        "review:saveDecision",
+        "review:saveExtractionValue",
+        "review:startRun",
+        "review:upsertExtractionField"
+      ].sort()
+    );
+    expect(await runtime.invoke("review:get", project.id)).toBeUndefined();
+
+    const activated = (await runtime.invoke("review:activate", {
+      projectId: project.id,
+      template: "blank",
+      researchQuestion: "What works?",
+      objectives: [],
+      criteria: []
+    })) as { protocol: { id: string; currentRevisionNumber: number }; revision: { researchQuestion: string } };
+    expect(activated.protocol.currentRevisionNumber).toBe(1);
+    expect(activated.revision.researchQuestion).toBe("What works?");
+    expect(await runtime.invoke("review:get", project.id)).toEqual(activated);
+
+    await expect(
+      runtime.invoke("review:reviseProtocol", {
+        reviewId: activated.protocol.id,
+        expectedVersion: 9,
+        researchQuestion: "Stale update",
+        objectives: [],
+        criteria: []
+      })
+    ).rejects.toThrow("changed from version 9 to 1");
+  });
+
+  it("keeps selected import paths inside the main-process manager", async () => {
+    const project = db.createProject("Import review");
+    const review = db.createReview({ projectId: project.id });
+    const selectedPath = "C:\\private\\references.ris";
+    const preview = {
+      previewId: "preview-1",
+      projectId: project.id,
+      reviewId: review.id,
+      fileName: "references.ris",
+      format: "ris" as const,
+      sizeBytes: 42,
+      totalRecords: 1,
+      validRecords: 1,
+      invalidRecords: 0,
+      columns: [],
+      items: [
+        {
+          recordIndex: 0,
+          record: { title: "Imported study", authors: [] },
+          rawTitle: "Imported study",
+          valid: true,
+          errors: [],
+          match: { kind: "none" as const, candidatePaperIds: [] }
+        }
+      ],
+      warnings: []
+    };
+    const importPreview = vi.fn(async (input: { filePath: string }) => {
+      expect(input.filePath).toBe(selectedPath);
+      return preview;
+    });
+    const remap = vi.fn(async (previewId: string, mapping: { title: string }) => {
+      expect(previewId).toBe(preview.previewId);
+      expect(mapping).toEqual({ title: "Study title" });
+      return preview;
+    });
+    const runtime = new FakeReviewRuntime([{ canceled: false, filePaths: [selectedPath] }]);
+    registerReviewIpc(fakeServices({ imports: { preview: importPreview, remap } }), runtime);
+
+    const result = await runtime.invoke("review:previewImport", {
+      projectId: project.id,
+      reviewId: review.id
+    });
+    expect(result).toEqual(preview);
+    expect(JSON.stringify(result)).not.toContain(selectedPath);
+    expect(importPreview).toHaveBeenCalledOnce();
+    expect(
+      await runtime.invoke("review:remapImport", {
+        previewId: preview.previewId,
+        mapping: { title: "Study title" }
+      })
+    ).toEqual(preview);
+    expect(remap).toHaveBeenCalledOnce();
+  });
+
+  it("copies a verified PDF while returning no selected or internal path", async () => {
+    const project = db.createProject("PDF review");
+    const paper = db.savePaper(project.id, {
+      id: "paper-pdf",
+      title: "Attached PDF study",
+      authors: [],
+      source: "arxiv",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id });
+    const selectedPath = join(directory, "selected-secret.pdf");
+    const internalPath = join(directory, "internal-artifact.pdf");
+    await writeFile(selectedPath, "%PDF-1.7\nfixture");
+    const importFile = vi.fn(async (input: { sourcePath: string; metadata?: Record<string, unknown> }) => {
+      expect(input.sourcePath).toBe(selectedPath);
+      expect(input.metadata).not.toHaveProperty("sourcePath");
+      return {
+        id: "artifact-pdf",
+        projectId: project.id,
+        type: "paper-pdf" as const,
+        title: paper.title,
+        path: internalPath,
+        mime: "application/pdf",
+        hash: "hash",
+        source: "review-pdf-attachment",
+        metadata: { paperId: paper.id },
+        createdAt: "2026-08-23T00:00:00.000Z"
+      };
+    });
+    const runtime = new FakeReviewRuntime([{ canceled: false, filePaths: [selectedPath] }]);
+    registerReviewIpc(fakeServices({ artifacts: { importFile } }), runtime);
+
+    const result = await runtime.invoke("review:attachPdf", {
+      projectId: project.id,
+      reviewId: review.id,
+      paperId: paper.id
+    });
+    expect(result).toEqual({ ok: true, artifactId: "artifact-pdf" });
+    expect(JSON.stringify(result)).not.toContain(selectedPath);
+    expect(JSON.stringify(result)).not.toContain(internalPath);
+    expect(db.listReviewAuditEvents(review.id).at(-1)).toMatchObject({
+      kind: "paper-pdf-attached",
+      entityId: paper.id,
+      payload: { artifactId: "artifact-pdf", method: "manual-attachment" }
+    });
+  });
+
+  it("preserves AI provenance only for an unchanged evidence-backed confirmation", async () => {
+    const project = db.createProject("Extraction review");
+    const paper = db.savePaper(project.id, {
+      id: "paper-extraction",
+      title: "Extraction paper",
+      abstract: "The reported outcome improved.",
+      authors: [],
+      source: "pubmed",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id });
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "include"
+    });
+    const field = db.saveExtractionField({
+      reviewId: review.id,
+      name: "Outcome",
+      type: "short-text"
+    });
+    const timestamp = "2026-08-23T00:00:00.000Z";
+    const run = db.saveReviewRun({
+      id: "run-extraction",
+      reviewId: review.id,
+      stage: "extraction",
+      provider: "ollama",
+      model: "review-model",
+      protocolRevisionId: review.currentRevisionId,
+      status: "completed",
+      paperIds: [paper.id],
+      fieldIds: [field.id],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      startedAt: timestamp,
+      completedAt: timestamp
+    });
+    const runItem = db.saveReviewRunItem({
+      id: "run-item-extraction",
+      runId: run.id,
+      paperId: paper.id,
+      status: "completed",
+      attemptCount: 1,
+      criterionAssessments: [],
+      extractionSuggestions: [],
+      evidence: [
+        {
+          id: "evidence-extraction",
+          reviewId: review.id,
+          evidenceId: "S1",
+          runId: run.id,
+          runItemId: "run-item-extraction",
+          paperId: paper.id,
+          sourceType: "paper-abstract",
+          title: paper.title,
+          excerpt: paper.abstract!,
+          locator: "Abstract",
+          createdAt: timestamp
+        }
+      ],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      startedAt: timestamp,
+      completedAt: timestamp
+    });
+    const evidence = runItem.evidence[0];
+    const suggestion = db.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Improved",
+      status: "suggested",
+      origin: "ai",
+      evidenceIds: [evidence.id],
+      runItemId: runItem.id
+    });
+    const runtime = new FakeReviewRuntime();
+    registerReviewIpc(fakeServices(), runtime);
+
+    const rejected = await runtime.invoke("review:saveExtractionValue", {
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      expectedFieldRevision: field.revision,
+      value: "Renderer-tampered value",
+      status: "rejected",
+      evidenceIds: []
+    });
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      origin: "ai",
+      value: "Improved",
+      evidenceIds: [evidence.id],
+      runItemId: runItem.id
+    });
+    db.saveExtractionValue({
+      id: suggestion.id,
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Improved",
+      status: "suggested",
+      origin: "ai",
+      evidenceIds: [evidence.id],
+      runItemId: runItem.id,
+      createdAt: suggestion.createdAt
+    });
+
+    const confirmed = await runtime.invoke("review:saveExtractionValue", {
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      expectedFieldRevision: field.revision,
+      value: "Improved",
+      status: "confirmed",
+      evidenceIds: [evidence.id]
+    });
+    expect(confirmed).toMatchObject({ status: "confirmed", origin: "ai" });
+
+    const manualOverride = await runtime.invoke("review:saveExtractionValue", {
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      expectedFieldRevision: field.revision,
+      value: "No improvement",
+      status: "confirmed",
+      evidenceIds: []
+    });
+    expect(manualOverride).toMatchObject({ status: "confirmed", origin: "manual", evidenceIds: [] });
+
+    db.saveExtractionValue({
+      id: suggestion.id,
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: null,
+      status: "suggested",
+      origin: "ai",
+      evidenceIds: [],
+      runItemId: runItem.id,
+      createdAt: suggestion.createdAt
+    });
+    const acceptedNotFound = await runtime.invoke("review:saveExtractionValue", {
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      expectedFieldRevision: field.revision,
+      value: null,
+      status: "not-found",
+      evidenceIds: []
+    });
+    expect(acceptedNotFound).toMatchObject({
+      status: "not-found",
+      origin: "manual",
+      value: null,
+      runItemId: runItem.id
+    });
+    expect(db.listReviewAuditEvents(review.id).at(-1)).toMatchObject({
+      kind: "extraction-value-not-found",
+      actor: "user",
+      payload: { origin: "manual", runItemId: runItem.id }
+    });
+  });
+
+  it("validates and scopes run events to the renderer that started the run", async () => {
+    const project = db.createProject("Agent review");
+    const paper = db.savePaper(project.id, {
+      id: "paper-run",
+      title: "Run paper",
+      authors: [],
+      source: "openalex",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id });
+    const run: ReviewRun = {
+      id: "run-1",
+      reviewId: review.id,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "qwen3:8b",
+      protocolRevisionId: review.currentRevisionId,
+      status: "queued",
+      paperIds: [paper.id],
+      fieldIds: [],
+      completedCount: 0,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: "2026-08-23T00:00:00.000Z",
+      updatedAt: "2026-08-23T00:00:00.000Z"
+    };
+    const event: ReviewRunEvent = {
+      type: "status",
+      runId: run.id,
+      reviewId: review.id,
+      status: "running"
+    };
+    const start = vi.fn(async (_input: unknown, emit: (value: ReviewRunEvent) => void) => {
+      emit(event);
+      return run;
+    });
+    const runtime = new FakeReviewRuntime();
+    registerReviewIpc(fakeServices({ agent: { start } }), runtime);
+    const sender = new FakeSender();
+
+    expect(
+      await runtime.invoke(
+        "review:startRun",
+        { reviewId: review.id, stage: "title-abstract", paperIds: [paper.id] },
+        sender
+      )
+    ).toEqual(run);
+    expect(sender.messages).toEqual([{ channel: "review:run-event", value: event }]);
+  });
+
+  it("writes the eight-file export into a newly created package directory", async () => {
+    const project = db.createProject("Export review");
+    const review = db.createReview({
+      projectId: project.id,
+      researchQuestion: "What was reviewed?"
+    });
+    const selectedDirectory = join(directory, "exports");
+    const runtime = new FakeReviewRuntime([
+      { canceled: false, filePaths: [selectedDirectory] },
+      { canceled: false, filePaths: [selectedDirectory] }
+    ]);
+    registerReviewIpc(fakeServices(), runtime);
+
+    const result = (await runtime.invoke("review:export", { reviewId: review.id })) as {
+      ok: boolean;
+      path: string;
+      fileCount: number;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.fileCount).toBe(8);
+    expect((await readdir(result.path)).sort()).toEqual(
+      [
+        "evidence-locators.csv",
+        "evidence-matrix.csv",
+        "included-references.bib",
+        "included-references.ris",
+        "review-audit.json",
+        "review-flow.svg",
+        "review-summary.md",
+        "screening-decisions.csv"
+      ].sort()
+    );
+    expect(JSON.parse(await readFile(join(result.path, "review-audit.json"), "utf8"))).toMatchObject({
+      schemaVersion: 2,
+      protocol: { id: review.id },
+      protocolHistory: [{ id: review.currentRevisionId }],
+      candidateOrigins: [],
+      runItems: []
+    });
+    expect((await readdir(selectedDirectory)).some((name) => name.startsWith(".paper-pilot-review-export-"))).toBe(
+      false
+    );
+
+    const repeated = (await runtime.invoke("review:export", { reviewId: review.id })) as typeof result;
+    expect(repeated.path).not.toBe(result.path);
+    for (const fileName of await readdir(result.path)) {
+      expect(await readFile(join(repeated.path, fileName))).toEqual(await readFile(join(result.path, fileName)));
+    }
+  });
+
+  it("exports only papers that currently pass both screening stages", async () => {
+    const project = db.createProject("Eligibility export");
+    const paper = db.savePaper(project.id, {
+      id: "paper-invalidated-upstream",
+      title: "Study invalidated by upstream screening",
+      authors: ["Ada Reviewer"],
+      source: "reference-import",
+      isOpenAccess: false,
+      fieldsOfStudy: []
+    });
+    const review = db.createReview({ projectId: project.id });
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "include"
+    });
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "full-text",
+      decision: "include"
+    });
+    const field = db.saveExtractionField({ reviewId: review.id, name: "Outcome", type: "short-text" });
+    db.saveExtractionValue({
+      reviewId: review.id,
+      paperId: paper.id,
+      fieldId: field.id,
+      value: "Improved",
+      status: "confirmed",
+      origin: "manual"
+    });
+
+    db.setScreeningDecision({
+      reviewId: review.id,
+      paperId: paper.id,
+      stage: "title-abstract",
+      decision: "exclude"
+    });
+    expect(db.getReviewFlowSummary(review.id).includedPapers).toBe(0);
+
+    const selectedDirectory = join(directory, "eligibility-export");
+    const runtime = new FakeReviewRuntime([{ canceled: false, filePaths: [selectedDirectory] }]);
+    registerReviewIpc(fakeServices(), runtime);
+    const result = (await runtime.invoke("review:export", { reviewId: review.id })) as { path: string };
+    const audit = JSON.parse(await readFile(join(result.path, "review-audit.json"), "utf8")) as {
+      flowSummary: { includedPapers: number };
+      includedPapers: Array<{ id: string }>;
+    };
+
+    expect(audit.flowSummary.includedPapers).toBe(0);
+    expect(audit.includedPapers).toEqual([]);
+    expect(await readFile(join(result.path, "included-references.ris"), "utf8")).not.toContain(paper.title);
+    expect(await readFile(join(result.path, "included-references.bib"), "utf8")).not.toContain(paper.title);
+    expect(await readFile(join(result.path, "evidence-matrix.csv"), "utf8")).not.toContain(paper.id);
+  });
+
+  it("does not overwrite an existing package directory", async () => {
+    const project = db.createProject("Atomic export");
+    const review = db.createReview({ projectId: project.id, researchQuestion: "Is export atomic?" });
+    const selectedDirectory = join(directory, "atomic-exports");
+    const suffix = review.updatedAt.replace(/[:.]/g, "-");
+    const targetDirectory = join(selectedDirectory, `Atomic export-evidence-review-${suffix}`);
+    await mkdir(targetDirectory, { recursive: true });
+    await writeFile(join(targetDirectory, "sentinel.txt"), "keep", "utf8");
+    const runtime = new FakeReviewRuntime([{ canceled: false, filePaths: [selectedDirectory] }]);
+    registerReviewIpc(fakeServices(), runtime);
+
+    const result = (await runtime.invoke("review:export", { reviewId: review.id })) as { path: string };
+
+    expect(result.path).toBe(`${targetDirectory}-2`);
+    expect(await readFile(join(targetDirectory, "sentinel.txt"), "utf8")).toBe("keep");
+    expect((await readdir(selectedDirectory)).filter((name) => name.startsWith(".paper-pilot-review-export-"))).toEqual(
+      []
+    );
+  });
+});
+
+class FakeSender {
+  readonly messages: Array<{ channel: string; value: unknown }> = [];
+
+  isDestroyed(): boolean {
+    return false;
+  }
+
+  send(channel: string, value: unknown): void {
+    this.messages.push({ channel, value });
+  }
+}
+
+class FakeReviewRuntime implements ReviewIpcRuntime {
+  readonly handlers = new Map<string, (event: IpcMainInvokeEvent, input: unknown) => unknown>();
+  private readonly selections: Electron.OpenDialogReturnValue[];
+
+  constructor(selections: Electron.OpenDialogReturnValue[] = []) {
+    this.selections = [...selections];
+  }
+
+  handle(channel: string, listener: (event: IpcMainInvokeEvent, input: unknown) => unknown): void {
+    this.handlers.set(channel, listener);
+  }
+
+  async showOpenDialog(): Promise<Electron.OpenDialogReturnValue> {
+    return this.selections.shift() ?? { canceled: true, filePaths: [] };
+  }
+
+  async showMessageBox(): Promise<Electron.MessageBoxReturnValue> {
+    return { response: 1, checkboxChecked: false };
+  }
+
+  async invoke(channel: string, input: unknown, sender = new FakeSender()): Promise<unknown> {
+    const handler = this.handlers.get(channel);
+    if (!handler) throw new Error(`Missing handler: ${channel}`);
+    return handler({ sender } as unknown as IpcMainInvokeEvent, input);
+  }
+}
+
+function fakeServices(
+  overrides: {
+    imports?: Partial<ReviewIpcServices["imports"]>;
+    agent?: Partial<ReviewIpcServices["agent"]>;
+    artifacts?: Partial<ReviewIpcServices["artifacts"]>;
+    fullText?: Partial<ReviewIpcServices["fullText"]>;
+  } = {}
+): ReviewIpcServices {
+  return {
+    db,
+    imports: {
+      preview: async () => {
+        throw new Error("Unexpected import preview");
+      },
+      commit: async () => {
+        throw new Error("Unexpected import commit");
+      },
+      ...overrides.imports
+    } as unknown as ReviewIpcServices["imports"],
+    agent: {
+      start: async () => {
+        throw new Error("Unexpected agent start");
+      },
+      cancel: () => false,
+      retry: async () => {
+        throw new Error("Unexpected agent retry");
+      },
+      ...overrides.agent
+    } as unknown as ReviewIpcServices["agent"],
+    artifacts: {
+      importFile: async () => {
+        throw new Error("Unexpected artifact import");
+      },
+      ...overrides.artifacts
+    } as unknown as ReviewIpcServices["artifacts"],
+    fullText: {
+      fetchOpenAccessPdf: async () => ({}),
+      ...overrides.fullText
+    } as unknown as ReviewIpcServices["fullText"],
+    settings: {
+      get: async () => ({
+        ui: { theme: "system" },
+        ai: {
+          provider: "ollama",
+          baseUrl: "http://127.0.0.1:11434",
+          model: "qwen3:8b",
+          hasApiKey: false,
+          reasoningEnabled: true
+        },
+        python: { runtimeMode: "managed", markitdownEnabled: true },
+        sources: { disabledSourceIds: [] }
+      })
+    } as unknown as ReviewIpcServices["settings"]
+  };
+}

--- a/tests/review-schemas.test.ts
+++ b/tests/review-schemas.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_REFERENCE_IMPORT_BYTES,
+  MAX_REFERENCE_IMPORT_RECORDS,
+  MAX_REVIEW_BATCH_PAPERS,
+  activateReviewRequestSchema,
+  crawlConfigSchema,
+  extractionFieldSchema,
+  extractionValueSchema,
+  paperSchema,
+  referenceImportPreviewSchema,
+  reviewEvidenceSchema,
+  reviewFlowSummarySchema,
+  reviewPaperQuerySchema,
+  reviewProtocolRevisionSchema,
+  reviewRunEventSchema,
+  saveExtractionValueRequestSchema,
+  saveScreeningDecisionRequestSchema,
+  sourceIdSchema,
+  startReviewRunRequestSchema
+} from "../src/shared/schemas";
+
+const timestamp = "2026-08-22T12:00:00.000Z";
+
+describe("review-domain schemas", () => {
+  it("keeps reference imports as paper provenance rather than crawler sources", () => {
+    expect(
+      paperSchema.parse({
+        id: "paper-1",
+        title: "Imported trial",
+        source: "reference-import"
+      }).source
+    ).toBe("reference-import");
+
+    expect(sourceIdSchema.safeParse("reference-import").success).toBe(false);
+    expect(crawlConfigSchema.safeParse({ topic: "trials", sourceIds: ["reference-import"] }).success).toBe(false);
+  });
+
+  it("validates a versioned protocol revision", () => {
+    const revision = reviewProtocolRevisionSchema.parse({
+      id: "revision-2",
+      reviewId: "review-1",
+      version: 2,
+      researchQuestion: "Does the intervention improve recovery?",
+      objectives: ["Measure recovery time"],
+      criteria: [
+        {
+          id: "criterion-1",
+          stage: "full-text",
+          type: "exclusion",
+          label: "Wrong population",
+          order: 0
+        }
+      ],
+      createdAt: timestamp
+    });
+
+    expect(revision.version).toBe(2);
+    expect(revision.criteria[0]?.stage).toBe("full-text");
+  });
+
+  it("requires a reason for full-text exclusions only", () => {
+    const common = {
+      reviewId: "review-1",
+      paperId: "paper-1",
+      protocolRevisionId: "revision-1",
+      decision: "exclude" as const
+    };
+
+    expect(saveScreeningDecisionRequestSchema.safeParse({ ...common, stage: "full-text" }).success).toBe(false);
+    expect(
+      saveScreeningDecisionRequestSchema.safeParse({
+        ...common,
+        stage: "full-text",
+        customReason: "The full text reports the wrong population"
+      }).success
+    ).toBe(true);
+    expect(saveScreeningDecisionRequestSchema.safeParse({ ...common, stage: "title-abstract" }).success).toBe(true);
+  });
+
+  it("enforces extraction-field option rules", () => {
+    const base = {
+      id: "field-1",
+      reviewId: "review-1",
+      name: "Study design",
+      order: 0,
+      revision: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    expect(extractionFieldSchema.safeParse({ ...base, type: "single-select" }).success).toBe(false);
+    expect(
+      extractionFieldSchema.safeParse({
+        ...base,
+        type: "single-select",
+        options: ["RCT", "Cohort"]
+      }).success
+    ).toBe(true);
+    expect(extractionFieldSchema.safeParse({ ...base, type: "number", options: ["not applicable"] }).success).toBe(
+      false
+    );
+  });
+
+  it("requires evidence before confirming an AI-derived value", () => {
+    const base = {
+      id: "value-1",
+      reviewId: "review-1",
+      paperId: "paper-1",
+      fieldId: "field-1",
+      fieldRevision: 1,
+      value: "Randomized controlled trial",
+      status: "confirmed" as const,
+      origin: "ai" as const,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    expect(extractionValueSchema.safeParse(base).success).toBe(false);
+    expect(extractionValueSchema.safeParse({ ...base, evidenceIds: ["evidence-1"] }).success).toBe(true);
+    expect(extractionValueSchema.safeParse({ ...base, origin: "manual" }).success).toBe(true);
+  });
+
+  it("requires an explicit not-found state instead of confirming blank extraction values", () => {
+    const base = {
+      reviewId: "review-1",
+      paperId: "paper-1",
+      fieldId: "field-1",
+      expectedFieldRevision: 1,
+      status: "confirmed" as const,
+      evidenceIds: []
+    };
+
+    for (const value of [null, "", "   ", []]) {
+      expect(saveExtractionValueRequestSchema.safeParse({ ...base, value }).success).toBe(false);
+    }
+    expect(saveExtractionValueRequestSchema.safeParse({ ...base, value: null, status: "not-found" }).success).toBe(
+      true
+    );
+    expect(saveExtractionValueRequestSchema.safeParse({ ...base, value: false }).success).toBe(true);
+    expect(saveExtractionValueRequestSchema.safeParse({ ...base, value: 0 }).success).toBe(true);
+  });
+
+  it("preserves evidence snapshots after linked records disappear", () => {
+    const evidence = reviewEvidenceSchema.parse({
+      id: "evidence-row-1",
+      reviewId: "review-1",
+      evidenceId: "S1",
+      sourceType: "artifact-chunk",
+      title: "Archived paper title",
+      excerpt: "The study randomized 120 participants.",
+      locator: "Methods, paragraph 2",
+      createdAt: timestamp
+    });
+
+    expect(evidence.paperId).toBeUndefined();
+    expect(evidence.artifactId).toBeUndefined();
+    expect(evidence.excerpt).toContain("120 participants");
+  });
+
+  it("bounds review batches and extraction fields at the API boundary", () => {
+    expect(
+      startReviewRunRequestSchema.safeParse({
+        reviewId: "review-1",
+        stage: "title-abstract",
+        paperIds: Array.from({ length: MAX_REVIEW_BATCH_PAPERS }, (_, index) => `paper-${index}`)
+      }).success
+    ).toBe(true);
+    expect(
+      startReviewRunRequestSchema.safeParse({
+        reviewId: "review-1",
+        stage: "title-abstract",
+        paperIds: Array.from({ length: MAX_REVIEW_BATCH_PAPERS + 1 }, (_, index) => `paper-${index}`)
+      }).success
+    ).toBe(false);
+  });
+
+  it("defaults persisted review runs to no selected extraction fields", () => {
+    const event = reviewRunEventSchema.parse({
+      type: "complete",
+      runId: "run-1",
+      reviewId: "review-1",
+      run: {
+        id: "run-1",
+        reviewId: "review-1",
+        stage: "title-abstract",
+        provider: "ollama",
+        model: "test-model",
+        protocolRevisionId: "revision-1",
+        status: "completed",
+        paperIds: ["paper-1"],
+        createdAt: timestamp,
+        updatedAt: timestamp
+      }
+    });
+
+    expect(event.type === "complete" ? event.run.fieldIds : undefined).toEqual([]);
+  });
+
+  it("applies stable queue defaults and rejects inverted year ranges", () => {
+    const query = reviewPaperQuerySchema.parse({ reviewId: "review-1" });
+    expect(query).toMatchObject({
+      stage: "title-abstract",
+      page: 1,
+      pageSize: 25,
+      fullText: "any",
+      sort: "created",
+      direction: "asc"
+    });
+    expect(reviewPaperQuerySchema.safeParse({ reviewId: "review-1", yearFrom: 2025, yearTo: 2020 }).success).toBe(
+      false
+    );
+  });
+
+  it("validates redacted, discriminated review run events", () => {
+    const event = reviewRunEventSchema.parse({
+      type: "progress",
+      runId: "run-1",
+      reviewId: "review-1",
+      completed: 2,
+      failed: 1,
+      cancelled: 0,
+      total: 10,
+      currentPaperId: "paper-4"
+    });
+
+    expect(event.type).toBe("progress");
+    expect("rawProviderPayload" in event).toBe(false);
+  });
+
+  it("validates deterministic flow-summary counts", () => {
+    const summary = reviewFlowSummarySchema.parse({
+      reviewId: "review-1",
+      identifiedRecords: 100,
+      filteredRecords: 5,
+      invalidRecords: 2,
+      duplicateRecords: 13,
+      mergedRecords: 3,
+      newRecords: 77,
+      uniqueRecordsScreened: 80,
+      titleAbstractExclusions: 40,
+      fullTextsSought: 40,
+      fullTextsUnavailable: 5,
+      fullTextExclusionsByReason: { "Wrong population": 10 },
+      includedPapers: 25,
+      extraction: {
+        totalCells: 100,
+        confirmedCells: 75,
+        notFoundCells: 5,
+        needsReviewCells: 20,
+        completionPercent: 80
+      },
+      historicalCountsAvailable: true,
+      generatedAt: timestamp
+    });
+
+    expect(summary.includedPapers).toBe(25);
+    expect(summary.extraction.completionPercent).toBe(80);
+  });
+
+  it("enforces import limits without accepting renderer file paths", () => {
+    const preview = {
+      previewId: "preview-1",
+      projectId: "project-1",
+      reviewId: "review-1",
+      fileName: "references.ris",
+      format: "ris" as const,
+      sizeBytes: MAX_REFERENCE_IMPORT_BYTES,
+      totalRecords: MAX_REFERENCE_IMPORT_RECORDS,
+      validRecords: 1,
+      invalidRecords: 0,
+      items: []
+    };
+    expect(referenceImportPreviewSchema.safeParse(preview).success).toBe(true);
+    expect(
+      referenceImportPreviewSchema.safeParse({
+        ...preview,
+        sizeBytes: MAX_REFERENCE_IMPORT_BYTES + 1
+      }).success
+    ).toBe(false);
+  });
+
+  it("defaults new reviews to the blank template", () => {
+    const request = activateReviewRequestSchema.parse({ projectId: "project-1" });
+    expect(request.template).toBe("blank");
+    expect(request.criteria).toEqual([]);
+  });
+});

--- a/tests/review-workspace.test.tsx
+++ b/tests/review-workspace.test.tsx
@@ -1,0 +1,1109 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { JSX } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PaperPilotApi } from "../src/preload/index";
+import { App } from "../src/renderer/App";
+import { ReviewWorkspace, type ReviewState } from "../src/renderer/components/review-workspace";
+import { TooltipProvider } from "../src/renderer/components/ui/tooltip";
+import type {
+  AppSettings,
+  DiscoveryBatch,
+  ExtractionField,
+  ExtractionValue,
+  ReferenceImportPreview,
+  ReviewFlowSummary,
+  ReviewPaperPage,
+  ReviewRun,
+  ReviewRunItem,
+  ScreeningDecision
+} from "../src/shared/schemas";
+
+vi.mock("pdfjs-dist", () => ({
+  GlobalWorkerOptions: { workerSrc: "" },
+  getDocument: vi.fn()
+}));
+vi.mock("pdfjs-dist/build/pdf.worker.mjs?url", () => ({ default: "pdf.worker.mjs" }));
+
+const timestamp = "2026-08-22T12:00:00.000Z";
+const projectId = "project-1";
+const reviewId = "review-1";
+const revisionId = "revision-1";
+
+const review: ReviewState = {
+  protocol: {
+    id: reviewId,
+    projectId,
+    template: "general-empirical",
+    currentRevisionId: revisionId,
+    currentRevisionNumber: 1,
+    historicalCountsAvailable: false,
+    activatedAt: timestamp,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  },
+  revision: {
+    id: revisionId,
+    reviewId,
+    version: 1,
+    researchQuestion: "Which interventions improve recovery?",
+    objectives: ["Compare outcomes"],
+    criteria: [],
+    createdAt: timestamp
+  }
+};
+
+const paper = {
+  reviewId,
+  paperId: "paper-1",
+  title: "Controlled recovery trial",
+  authors: ["Ada Researcher"],
+  abstract: "A randomized trial reports recovery outcomes.",
+  year: 2025,
+  venue: "Evidence Journal",
+  source: "pubmed" as const,
+  discoveryBatchIds: ["batch-1"],
+  hasFullText: true,
+  extractionProgress: { total: 1, confirmed: 0, needsReview: 1 },
+  needsReReview: false,
+  aiSuggestionStale: false
+};
+
+const paperPage: ReviewPaperPage = {
+  items: [paper],
+  page: 1,
+  pageSize: 25,
+  total: 1,
+  totalPages: 1,
+  counts: { pending: 1, include: 0, exclude: 0, uncertain: 0 }
+};
+
+function renderReview(
+  api: Record<string, unknown>,
+  state: ReviewState | null = review,
+  onOpenArtifact?: (artifactId: string, page?: number) => void
+): JSX.Element {
+  Object.defineProperty(window, "paperPilot", {
+    configurable: true,
+    value: {
+      getReview: vi.fn().mockResolvedValue(state),
+      listReviewProtocolRevisions: vi.fn().mockResolvedValue(state ? [state.revision] : []),
+      onReviewRunEvent: vi.fn().mockReturnValue(() => undefined),
+      listDiscoveryBatches: vi.fn().mockResolvedValue([]),
+      listReviewRuns: vi.fn().mockResolvedValue([]),
+      listReviewRunItems: vi.fn().mockResolvedValue([]),
+      listReviewEvidence: vi.fn().mockResolvedValue([]),
+      ...api
+    }
+  });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  });
+  const view = (
+    <QueryClientProvider client={queryClient}>
+      <ReviewWorkspace projectId={projectId} projectTitle="Recovery review" onOpenArtifact={onOpenArtifact} />
+    </QueryClientProvider>
+  );
+  render(view);
+  return view;
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  });
+  window.requestAnimationFrame = (callback) => window.setTimeout(callback, 0);
+  window.cancelAnimationFrame = (handle) => window.clearTimeout(handle);
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("evidence review workspace", () => {
+  it("activates a review from a PICO-style template", async () => {
+    const activateReview = vi.fn().mockResolvedValue({
+      ...review,
+      protocol: { ...review.protocol, template: "pico" as const }
+    });
+    renderReview({ activateReview }, null);
+
+    fireEvent.click(await screen.findByRole("button", { name: /PICO-style review/i }));
+    expect((screen.getByLabelText(/Research question/i) as HTMLTextAreaElement).value).toBe(
+      "In [population], how does [intervention] compared with [comparator] affect [outcome]?"
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Activate review/i }));
+
+    await waitFor(() =>
+      expect(activateReview).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId, template: "pico", criteria: expect.arrayContaining([expect.any(Object)]) })
+      )
+    );
+    expect(await screen.findByText("Evidence review")).toBeTruthy();
+  });
+
+  it("supports keyboard screening, required full-text reasons, and bounded AI batches", async () => {
+    const decision: ScreeningDecision = {
+      id: "decision-1",
+      reviewId,
+      paperId: paper.paperId,
+      stage: "title-abstract",
+      decision: "include",
+      protocolRevisionId: revisionId,
+      createdAt: timestamp
+    };
+    const saveScreeningDecision = vi.fn().mockResolvedValue(decision);
+    const run: ReviewRun = {
+      id: "run-1",
+      reviewId,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "qwen3.8",
+      protocolRevisionId: revisionId,
+      status: "running",
+      paperIds: [paper.paperId],
+      fieldIds: [],
+      completedCount: 0,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+    const startReviewRun = vi.fn().mockResolvedValue(run);
+    renderReview({
+      listReviewPapers: vi.fn().mockResolvedValue(paperPage),
+      saveScreeningDecision,
+      markReviewPapersForReview: vi.fn(),
+      fetchReviewPaperFullText: vi.fn(),
+      attachReviewPaperPdf: vi.fn(),
+      startReviewRun
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Abstract" }));
+    const row = await screen.findByLabelText(`Screen ${paper.title}`);
+    fireEvent.keyDown(row, { key: "i" });
+    await waitFor(() =>
+      expect(saveScreeningDecision).toHaveBeenCalledWith(
+        expect.objectContaining({ paperId: paper.paperId, stage: "title-abstract", decision: "include" })
+      )
+    );
+
+    fireEvent.click(screen.getByLabelText(`Select ${paper.title}`));
+    fireEvent.click(screen.getByRole("button", { name: /Suggest with AI \(1\)/i }));
+    await waitFor(() =>
+      expect(startReviewRun).toHaveBeenCalledWith(
+        expect.objectContaining({ stage: "title-abstract", paperIds: [paper.paperId] })
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Full text" }));
+    const fullTextRow = await screen.findByLabelText(`Screen ${paper.title}`);
+    fireEvent.keyDown(fullTextRow, { key: "e" });
+    expect((await screen.findByRole("alert")).textContent).toMatch(/Enter a full-text exclusion reason/i);
+    fireEvent.change(screen.getByLabelText(/Full-text exclusion reason/i), {
+      target: { value: "Wrong population" }
+    });
+    fireEvent.keyDown(fullTextRow, { key: "e" });
+    await waitFor(() =>
+      expect(saveScreeningDecision).toHaveBeenLastCalledWith(
+        expect.objectContaining({ stage: "full-text", decision: "exclude", customReason: "Wrong population" })
+      )
+    );
+  });
+
+  it("filters the screening queue by source and year and exposes complete paper metadata", async () => {
+    const listReviewPapers = vi.fn().mockResolvedValue({
+      ...paperPage,
+      items: [{ ...paper, doi: "10.1000/recovery" }]
+    });
+    const provenanceBatch: DiscoveryBatch = {
+      id: "batch-1",
+      reviewId,
+      kind: "reference-import",
+      label: "Imported registry search",
+      status: "completed",
+      counts: { identified: 1, filtered: 0, invalid: 0, duplicates: 0, merged: 0, newRecords: 1 },
+      historicalCountsAvailable: true,
+      createdAt: timestamp,
+      completedAt: timestamp
+    };
+    renderReview({
+      listReviewPapers,
+      listDiscoveryBatches: vi.fn().mockResolvedValue([provenanceBatch]),
+      getProjectBundle: vi.fn().mockResolvedValue({
+        papers: [
+          {
+            id: paper.paperId,
+            projectId,
+            title: paper.title,
+            authors: paper.authors,
+            abstract: `${paper.abstract} Full methods and outcome details.`,
+            year: paper.year,
+            doi: "10.1000/recovery",
+            url: "https://example.test/recovery-trial",
+            source: "pubmed"
+          }
+        ]
+      }),
+      saveScreeningDecision: vi.fn(),
+      markReviewPapersForReview: vi.fn(),
+      fetchReviewPaperFullText: vi.fn(),
+      attachReviewPaperPdf: vi.fn(),
+      startReviewRun: vi.fn()
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Abstract" }));
+    fireEvent.change(await screen.findByLabelText("Source"), { target: { value: "pubmed" } });
+    fireEvent.change(screen.getByLabelText("Year from"), { target: { value: "2020" } });
+    fireEvent.change(screen.getByLabelText("Year to"), { target: { value: "2025" } });
+
+    await waitFor(() =>
+      expect(listReviewPapers).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sources: ["pubmed"], yearFrom: 2020, yearTo: 2025 })
+      )
+    );
+
+    fireEvent.click(await screen.findByText("View paper details"));
+    expect(screen.getByRole("link", { name: "10.1000/recovery" }).getAttribute("href")).toContain("doi.org");
+    expect(screen.getByRole("link", { name: "https://example.test/recovery-trial" })).toBeTruthy();
+    expect(screen.getByText(/Full methods and outcome details/)).toBeTruthy();
+    expect(await screen.findByText(/Imported registry search/)).toBeTruthy();
+    expect(screen.getByText(/Source: PubMed/)).toBeTruthy();
+  });
+
+  it("applies protocol exclusion criteria and all bulk screening decisions", async () => {
+    const secondPaper = { ...paper, paperId: "paper-2", title: "Second recovery trial" };
+    const twoPaperPage: ReviewPaperPage = {
+      ...paperPage,
+      items: [paper, secondPaper],
+      total: 2,
+      counts: { ...paperPage.counts, pending: 2 }
+    };
+    const saveScreeningDecision = vi.fn().mockResolvedValue({
+      id: "bulk-decision",
+      reviewId,
+      paperId: paper.paperId,
+      stage: "full-text",
+      decision: "exclude",
+      protocolRevisionId: revisionId,
+      createdAt: timestamp
+    });
+    renderReview(
+      {
+        listReviewPapers: vi.fn().mockResolvedValue(twoPaperPage),
+        saveScreeningDecision,
+        markReviewPapersForReview: vi.fn(),
+        fetchReviewPaperFullText: vi.fn(),
+        attachReviewPaperPdf: vi.fn(),
+        startReviewRun: vi.fn()
+      },
+      {
+        ...review,
+        revision: {
+          ...review.revision,
+          criteria: [
+            {
+              id: "wrong-population",
+              stage: "full-text",
+              type: "exclusion",
+              label: "Wrong population",
+              order: 0
+            }
+          ]
+        }
+      }
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Full text" }));
+    fireEvent.change(await screen.findByLabelText("Full-text exclusion criterion"), {
+      target: { value: "wrong-population" }
+    });
+    fireEvent.click(screen.getByLabelText(`Select ${paper.title}`));
+    fireEvent.click(screen.getByLabelText(`Select ${secondPaper.title}`));
+    fireEvent.click(screen.getByRole("button", { name: "Exclude selected (2)" }));
+
+    await waitFor(() => expect(saveScreeningDecision).toHaveBeenCalledTimes(2));
+    expect(saveScreeningDecision).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ decision: "exclude", reasonCriterionId: "wrong-population" })
+    );
+    expect(saveScreeningDecision).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ decision: "exclude", reasonCriterionId: "wrong-population" })
+    );
+
+    fireEvent.click(screen.getByLabelText(`Select ${paper.title}`));
+    fireEvent.click(screen.getByRole("button", { name: "Include selected (1)" }));
+    await waitFor(() => expect(saveScreeningDecision).toHaveBeenCalledTimes(3));
+    expect(saveScreeningDecision).toHaveBeenLastCalledWith(expect.objectContaining({ decision: "include" }));
+
+    fireEvent.click(screen.getByLabelText(`Select ${paper.title}`));
+    fireEvent.click(screen.getByRole("button", { name: "Uncertain selected (1)" }));
+    await waitFor(() => expect(saveScreeningDecision).toHaveBeenCalledTimes(4));
+    expect(saveScreeningDecision).toHaveBeenLastCalledWith(expect.objectContaining({ decision: "uncertain" }));
+  });
+
+  it("reports success and failure for full-text actions", async () => {
+    const metadataOnlyPage: ReviewPaperPage = {
+      ...paperPage,
+      items: [{ ...paper, hasFullText: false }]
+    };
+    const fetchReviewPaperFullText = vi.fn().mockResolvedValue({ ok: true, artifactId: "artifact-1" });
+    const attachReviewPaperPdf = vi.fn().mockRejectedValue(new Error("The PDF could not be indexed"));
+    renderReview({
+      listReviewPapers: vi.fn().mockResolvedValue(metadataOnlyPage),
+      saveScreeningDecision: vi.fn(),
+      markReviewPapersForReview: vi.fn(),
+      fetchReviewPaperFullText,
+      attachReviewPaperPdf,
+      startReviewRun: vi.fn()
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Abstract" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Fetch full text" }));
+    expect((await screen.findByRole("status")).textContent).toContain("fetched and indexed");
+    fireEvent.click(screen.getByRole("button", { name: "Attach PDF" }));
+    expect((await screen.findByRole("alert")).textContent).toContain("The PDF could not be indexed");
+  });
+
+  it("previews CSV mapping and commits conservative import resolutions", async () => {
+    const batch: DiscoveryBatch = {
+      id: "batch-1",
+      reviewId,
+      kind: "pre-existing",
+      label: "Pre-existing project papers",
+      status: "completed",
+      counts: { identified: 1, filtered: 0, invalid: 0, duplicates: 0, merged: 0, newRecords: 1 },
+      historicalCountsAvailable: false,
+      createdAt: timestamp,
+      completedAt: timestamp
+    };
+    const preview: ReferenceImportPreview = {
+      previewId: "preview-1",
+      projectId,
+      reviewId,
+      fileName: "trials.csv",
+      format: "csv",
+      sizeBytes: 100,
+      totalRecords: 1,
+      validRecords: 1,
+      invalidRecords: 0,
+      columns: ["Study title", "DOI"],
+      suggestedMapping: { title: "Study title", doi: "DOI" },
+      items: [
+        {
+          recordIndex: 0,
+          record: { title: "Imported trial", authors: [] },
+          valid: true,
+          errors: [],
+          match: { kind: "none", candidatePaperIds: [] }
+        }
+      ],
+      warnings: []
+    };
+    const commitReferenceImport = vi.fn().mockResolvedValue({ batch, counts: batch.counts });
+    const remapReferenceImport = vi.fn().mockResolvedValue(preview);
+    renderReview({
+      listDiscoveryBatches: vi.fn().mockResolvedValue([batch]),
+      previewReferenceImport: vi.fn().mockResolvedValue(preview),
+      remapReferenceImport,
+      commitReferenceImport
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Discover" }));
+    fireEvent.click(screen.getByRole("button", { name: /Import references/i }));
+    expect(await screen.findByTestId("reference-import-preview")).toBeTruthy();
+    expect((screen.getByLabelText("Title (required)") as HTMLSelectElement).value).toBe("Study title");
+    fireEvent.change(screen.getByLabelText(/^abstract$/i), { target: { value: "DOI" } });
+    expect((screen.getByRole("button", { name: /Commit import/i }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: /Apply mapping and refresh preview/i }));
+    await waitFor(() =>
+      expect(remapReferenceImport).toHaveBeenCalledWith(
+        expect.objectContaining({ previewId: preview.previewId, mapping: expect.objectContaining({ abstract: "DOI" }) })
+      )
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Commit import/i }));
+
+    await waitFor(() =>
+      expect(commitReferenceImport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          previewId: preview.previewId,
+          mapping: expect.objectContaining({ title: "Study title" })
+        })
+      )
+    );
+    expect((await screen.findByRole("status")).textContent).toContain("Import complete");
+  });
+
+  it("paginates every ambiguous import match and requires explicit resolutions before commit", async () => {
+    const items = Array.from({ length: 101 }, (_, index) => ({
+      recordIndex: index,
+      record: { title: `Ambiguous ${index + 1}`, authors: [] },
+      valid: true,
+      errors: [],
+      match: { kind: "ambiguous" as const, candidatePaperIds: [`paper-match-${index}`] }
+    }));
+    const preview: ReferenceImportPreview = {
+      previewId: "preview-many",
+      projectId,
+      reviewId,
+      fileName: "ambiguous.ris",
+      format: "ris",
+      sizeBytes: 10_000,
+      totalRecords: items.length,
+      validRecords: items.length,
+      invalidRecords: 0,
+      columns: [],
+      items,
+      warnings: []
+    };
+    const batch: DiscoveryBatch = {
+      id: "batch-many",
+      reviewId,
+      kind: "reference-import",
+      label: "Ambiguous import",
+      status: "completed",
+      counts: { identified: 101, filtered: 101, invalid: 0, duplicates: 0, merged: 0, newRecords: 0 },
+      historicalCountsAvailable: true,
+      createdAt: timestamp,
+      completedAt: timestamp
+    };
+    const commitReferenceImport = vi.fn().mockResolvedValue({ batch, counts: batch.counts });
+    renderReview({
+      previewReferenceImport: vi.fn().mockResolvedValue(preview),
+      commitReferenceImport
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Discover" }));
+    fireEvent.click(screen.getByRole("button", { name: /Import references/i }));
+    expect(await screen.findByLabelText("Resolution for Ambiguous 1")).toBeTruthy();
+    expect(screen.queryByLabelText("Resolution for Ambiguous 101")).toBeNull();
+    expect((screen.getByRole("button", { name: /Commit import/i }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Ambiguous matches: next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Ambiguous matches: next" }));
+    expect(await screen.findByLabelText("Resolution for Ambiguous 101")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Skip all unresolved" }));
+    expect(screen.getByText(/101 of 101 explicitly resolved/i)).toBeTruthy();
+    const commit = screen.getByRole("button", { name: /Commit import/i }) as HTMLButtonElement;
+    expect(commit.disabled).toBe(false);
+    fireEvent.click(commit);
+
+    await waitFor(() => expect(commitReferenceImport).toHaveBeenCalledTimes(1));
+    const request = commitReferenceImport.mock.calls[0][0];
+    expect(request.resolutions).toHaveLength(101);
+    expect(request.resolutions).toEqual(
+      expect.arrayContaining([
+        { recordIndex: 0, action: "skip", paperId: undefined },
+        { recordIndex: 100, action: "skip", paperId: undefined }
+      ])
+    );
+  });
+
+  it("keeps invalid import details after the first preview page accessible", async () => {
+    const items = Array.from({ length: 151 }, (_, index) =>
+      index === 150
+        ? {
+            recordIndex: index,
+            rawTitle: "Malformed late record",
+            valid: false,
+            errors: ["Year must contain four digits."],
+            match: { kind: "none" as const, candidatePaperIds: [] }
+          }
+        : {
+            recordIndex: index,
+            record: { title: `Valid record ${index + 1}`, authors: [] },
+            valid: true,
+            errors: [],
+            match: { kind: "none" as const, candidatePaperIds: [] }
+          }
+    );
+    const preview: ReferenceImportPreview = {
+      previewId: "preview-invalid-late",
+      projectId,
+      reviewId,
+      fileName: "late-invalid.ris",
+      format: "ris",
+      sizeBytes: 15_000,
+      totalRecords: 151,
+      validRecords: 150,
+      invalidRecords: 1,
+      columns: [],
+      items,
+      warnings: []
+    };
+    renderReview({ previewReferenceImport: vi.fn().mockResolvedValue(preview) });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Discover" }));
+    fireEvent.click(screen.getByRole("button", { name: /Import references/i }));
+    expect(await screen.findByText("Valid record 1")).toBeTruthy();
+    expect(screen.queryByText("Year must contain four digits.")).toBeNull();
+    fireEvent.change(screen.getByLabelText("Preview records"), { target: { value: "invalid" } });
+    expect(await screen.findByText("Malformed late record")).toBeTruthy();
+    expect(screen.getByText("Year must contain four digits.")).toBeTruthy();
+  });
+
+  it("confirms manual extraction values and exports the deterministic flow summary", async () => {
+    const field: ExtractionField = {
+      id: "field-1",
+      reviewId,
+      name: "Primary outcome",
+      type: "short-text",
+      options: [],
+      order: 0,
+      revision: 1,
+      active: true,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+    let values: ExtractionValue[] = [];
+    const saveExtractionValue = vi.fn(async (input) => {
+      const value: ExtractionValue = {
+        id: "value-1",
+        reviewId,
+        paperId: paper.paperId,
+        fieldId: field.id,
+        fieldRevision: field.revision,
+        value: input.value,
+        status: input.status,
+        origin: "manual",
+        evidenceIds: [],
+        createdAt: timestamp,
+        updatedAt: timestamp
+      };
+      values = [value];
+      return value;
+    });
+    const summary: ReviewFlowSummary = {
+      reviewId,
+      identifiedRecords: 20,
+      filteredRecords: 1,
+      invalidRecords: 0,
+      duplicateRecords: 4,
+      mergedRecords: 0,
+      newRecords: 15,
+      uniqueRecordsScreened: 16,
+      titleAbstractExclusions: 8,
+      fullTextsSought: 8,
+      fullTextsUnavailable: 1,
+      fullTextExclusionsByReason: { "Wrong population": 2 },
+      includedPapers: 5,
+      extraction: {
+        totalCells: 5,
+        confirmedCells: 4,
+        notFoundCells: 0,
+        needsReviewCells: 1,
+        completionPercent: 80
+      },
+      historicalCountsAvailable: true,
+      warnings: [],
+      generatedAt: timestamp
+    };
+    const exportReview = vi.fn().mockResolvedValue({ ok: true, path: "C:/exports/review" });
+    renderReview({
+      listExtractionFields: vi.fn().mockResolvedValue([field]),
+      listReviewPapers: vi.fn().mockResolvedValue(paperPage),
+      listExtractionValues: vi.fn(async () => values),
+      saveExtractionValue,
+      upsertExtractionField: vi.fn(),
+      startReviewRun: vi.fn(),
+      getReviewSummary: vi.fn().mockResolvedValue(summary),
+      exportReview
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Extract" }));
+    const cell = await screen.findByLabelText("Primary outcome");
+    fireEvent.change(cell, { target: { value: "Faster recovery" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(saveExtractionValue).toHaveBeenCalledWith(
+        expect.objectContaining({ fieldId: field.id, value: "Faster recovery", status: "confirmed" })
+      )
+    );
+    expect(await screen.findByText("Manual—no linked evidence")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Summary" }));
+    expect((await screen.findAllByText("Review flow")).length).toBeGreaterThan(0);
+    expect(screen.getByText("80% complete · 4 confirmed · 0 not found · 1 need review")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Export review package/i }));
+    await waitFor(() => expect(exportReview).toHaveBeenCalledWith({ reviewId }));
+    expect((await screen.findByRole("status")).textContent).toContain("C:/exports/review");
+  });
+
+  it("restores an active persisted run and its completed suggestions after returning to Review", async () => {
+    const onOpenArtifact = vi.fn();
+    const persistedRun: ReviewRun = {
+      id: "persisted-run",
+      reviewId,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "qwen3.8",
+      protocolRevisionId: revisionId,
+      status: "running",
+      paperIds: [paper.paperId],
+      fieldIds: [],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+    const item: ReviewRunItem = {
+      id: "persisted-item",
+      runId: persistedRun.id,
+      paperId: paper.paperId,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      rationale: "The abstract matches the protocol.",
+      criterionAssessments: [],
+      extractionSuggestions: [],
+      evidence: [
+        {
+          id: "persisted-evidence",
+          reviewId,
+          evidenceId: "S1",
+          runId: persistedRun.id,
+          runItemId: "persisted-item",
+          paperId: paper.paperId,
+          artifactId: "artifact-1",
+          chunkId: "chunk-1",
+          sourceType: "artifact-chunk",
+          title: paper.title,
+          excerpt: paper.abstract,
+          locator: "Page 7",
+          page: 7,
+          createdAt: timestamp
+        }
+      ],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    };
+    renderReview(
+      {
+        listReviewRuns: vi.fn().mockResolvedValue([persistedRun]),
+        listReviewRunItems: vi.fn().mockResolvedValue([item]),
+        listReviewPapers: vi.fn().mockResolvedValue(paperPage)
+      },
+      review,
+      onOpenArtifact
+    );
+
+    expect(await screen.findByRole("button", { name: "Stop" })).toBeTruthy();
+    expect(screen.getByText("ollama · qwen3.8")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Abstract" }));
+    expect(await screen.findByText(/AI suggestion:/i)).toBeTruthy();
+    expect(screen.getByText("The abstract matches the protocol.")).toBeTruthy();
+    fireEvent.click(screen.getByText("Evidence (1)"));
+    fireEvent.click(screen.getByRole("button", { name: /Open source · p\. 7/i }));
+    expect(onOpenArtifact).toHaveBeenCalledWith("artifact-1", 7);
+  });
+
+  it("shows AI not-found as advisory, disables blank confirmation, and requires explicit acceptance", async () => {
+    const field: ExtractionField = {
+      id: "field-not-found",
+      reviewId,
+      name: "Primary outcome",
+      type: "short-text",
+      options: [],
+      order: 0,
+      revision: 1,
+      active: true,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+    const value: ExtractionValue = {
+      id: "value-not-found-suggestion",
+      reviewId,
+      paperId: paper.paperId,
+      fieldId: field.id,
+      fieldRevision: 1,
+      value: null,
+      status: "suggested",
+      origin: "ai",
+      evidenceIds: [],
+      runItemId: "item-not-found",
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+    const saveExtractionValue = vi.fn().mockResolvedValue({
+      ...value,
+      status: "not-found",
+      origin: "manual"
+    });
+    renderReview({
+      listExtractionFields: vi.fn().mockResolvedValue([field]),
+      listReviewPapers: vi.fn().mockResolvedValue(paperPage),
+      listExtractionValues: vi.fn().mockResolvedValue([value]),
+      saveExtractionValue,
+      upsertExtractionField: vi.fn(),
+      reorderExtractionFields: vi.fn(),
+      startReviewRun: vi.fn()
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Extract" }));
+    expect(await screen.findByText("Suggested: not found")).toBeTruthy();
+    const confirm = screen.getByRole("button", { name: "Confirm" }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Primary outcome"), { target: { value: "   " } });
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept not found" }));
+    await waitFor(() =>
+      expect(saveExtractionValue).toHaveBeenCalledWith(
+        expect.objectContaining({ fieldId: field.id, value: null, status: "not-found" })
+      )
+    );
+  });
+
+  it("hydrates suggestions across batches without letting an older run replace a newer paper result", async () => {
+    const secondPaper = { ...paper, paperId: "paper-2", title: "Second recovery trial" };
+    const page: ReviewPaperPage = {
+      ...paperPage,
+      items: [paper, secondPaper],
+      total: 2,
+      counts: { ...paperPage.counts, pending: 2 }
+    };
+    const run = (id: string, updatedAt: string, paperIds: string[]): ReviewRun => ({
+      id,
+      reviewId,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "qwen3.8",
+      protocolRevisionId: revisionId,
+      status: "completed",
+      paperIds,
+      fieldIds: [],
+      completedCount: paperIds.length,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: updatedAt,
+      updatedAt,
+      completedAt: updatedAt
+    });
+    const older = run("run-older", "2026-08-22T12:00:00.000Z", [paper.paperId]);
+    const otherBatch = run("run-other", "2026-08-22T13:00:00.000Z", [secondPaper.paperId]);
+    const newest = run("run-newest", "2026-08-22T14:00:00.000Z", [paper.paperId]);
+    const item = (runId: string, paperId: string, rationale: string): ReviewRunItem => ({
+      id: `item-${runId}`,
+      runId,
+      paperId,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      rationale,
+      criterionAssessments: [],
+      extractionSuggestions: [],
+      evidence: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const listReviewRunItems = vi.fn(async (runId: string) => {
+      if (runId === older.id) return [item(runId, paper.paperId, "Superseded older suggestion")];
+      if (runId === otherBatch.id) return [item(runId, secondPaper.paperId, "Suggestion from earlier batch")];
+      return [item(runId, paper.paperId, "Newest suggestion for paper one")];
+    });
+    renderReview({
+      listReviewRuns: vi.fn().mockResolvedValue([newest, older, otherBatch]),
+      listReviewRunItems,
+      listReviewPapers: vi.fn().mockResolvedValue(page)
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Abstract" }));
+    expect(await screen.findByText("Newest suggestion for paper one")).toBeTruthy();
+    expect(await screen.findByText("Suggestion from earlier batch")).toBeTruthy();
+    expect(screen.queryByText("Superseded older suggestion")).toBeNull();
+    expect(listReviewRunItems).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses authoritative run order for timestamp ties while preferring current non-stale suggestions", async () => {
+    const secondPaper = { ...paper, paperId: "paper-2", title: "Second recovery trial" };
+    const page: ReviewPaperPage = {
+      ...paperPage,
+      items: [paper, secondPaper],
+      total: 2,
+      counts: { ...paperPage.counts, pending: 2 }
+    };
+    const tiedRun = (id: string, paperId: string, protocolRevisionId = revisionId): ReviewRun => ({
+      id,
+      reviewId,
+      stage: "title-abstract",
+      provider: "ollama",
+      model: "qwen3.8",
+      protocolRevisionId,
+      status: "completed",
+      paperIds: [paperId],
+      fieldIds: [],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const currentNewer = tiedRun("run-a-current-newer", paper.paperId);
+    const currentOlder = tiedRun("run-z-current-older", paper.paperId);
+    const staleNewer = tiedRun("run-a-stale-newer", secondPaper.paperId, "superseded-revision");
+    const freshOlder = tiedRun("run-z-fresh-older", secondPaper.paperId);
+    const item = (run: ReviewRun, rationale: string, stale = false): ReviewRunItem => ({
+      id: `item-${run.id}`,
+      runId: run.id,
+      paperId: run.paperIds[0],
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      rationale,
+      criterionAssessments: [],
+      extractionSuggestions: [],
+      evidence: [],
+      stale,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const items = new Map([
+      [currentNewer.id, [item(currentNewer, "Authoritative newer tied suggestion")]],
+      [currentOlder.id, [item(currentOlder, "Lexically later but older suggestion")]],
+      [staleNewer.id, [item(staleNewer, "Later stale suggestion", true)]],
+      [freshOlder.id, [item(freshOlder, "Current non-stale suggestion")]]
+    ]);
+    renderReview({
+      // The API is newest-first. IDs deliberately sort in the opposite direction.
+      listReviewRuns: vi.fn().mockResolvedValue([staleNewer, currentNewer, freshOlder, currentOlder]),
+      listReviewRunItems: vi.fn(async (runId: string) => items.get(runId) ?? []),
+      listReviewPapers: vi.fn().mockResolvedValue(page)
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Abstract" }));
+    expect(await screen.findByText("Authoritative newer tied suggestion")).toBeTruthy();
+    expect(await screen.findByText("Current non-stale suggestion")).toBeTruthy();
+    expect(screen.queryByText("Lexically later but older suggestion")).toBeNull();
+    expect(screen.queryByText("Later stale suggestion")).toBeNull();
+  });
+
+  it("isolates suggestions for the same paper by review stage", async () => {
+    const run = (id: string, stage: "title-abstract" | "full-text"): ReviewRun => ({
+      id,
+      reviewId,
+      stage,
+      provider: "ollama",
+      model: "qwen3.8",
+      protocolRevisionId: revisionId,
+      status: "completed",
+      paperIds: [paper.paperId],
+      fieldIds: [],
+      completedCount: 1,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const abstractRun = run("run-abstract", "title-abstract");
+    const fullTextRun = run("run-full-text", "full-text");
+    const item = (run: ReviewRun, rationale: string): ReviewRunItem => ({
+      id: `item-${run.id}`,
+      runId: run.id,
+      paperId: paper.paperId,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "include",
+      rationale,
+      criterionAssessments: [],
+      extractionSuggestions: [],
+      evidence: [],
+      stale: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    renderReview({
+      listReviewRuns: vi.fn().mockResolvedValue([fullTextRun, abstractRun]),
+      listReviewRunItems: vi.fn(async (runId: string) =>
+        runId === abstractRun.id
+          ? [item(abstractRun, "Abstract-stage suggestion")]
+          : [item(fullTextRun, "Full-text-stage suggestion")]
+      ),
+      listReviewPapers: vi.fn().mockResolvedValue(paperPage)
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Abstract" }));
+    expect(await screen.findByText("Abstract-stage suggestion")).toBeTruthy();
+    expect(screen.queryByText("Full-text-stage suggestion")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Full text" }));
+    expect(await screen.findByText("Full-text-stage suggestion")).toBeTruthy();
+    expect(screen.queryByText("Abstract-stage suggestion")).toBeNull();
+  });
+
+  it("links confirmed AI screening suggestions to their run item and blocks stale confirmations", async () => {
+    const freshPaper = {
+      ...paper,
+      // Historical stale items may exist, but the selected current item below is fresh.
+      aiSuggestionStale: true
+    };
+    const stalePaper = {
+      ...paper,
+      paperId: "paper-stale",
+      title: "Stale protocol result",
+      aiSuggestionStale: true
+    };
+    const page: ReviewPaperPage = {
+      ...paperPage,
+      items: [freshPaper, stalePaper],
+      total: 2,
+      counts: { ...paperPage.counts, pending: 2 }
+    };
+    const run: ReviewRun = {
+      id: "run-full-text",
+      reviewId,
+      stage: "full-text",
+      provider: "ollama",
+      model: "qwen3.8",
+      protocolRevisionId: revisionId,
+      status: "completed",
+      paperIds: [paper.paperId, stalePaper.paperId],
+      fieldIds: [],
+      completedCount: 2,
+      failedCount: 0,
+      cancelledCount: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    };
+    const suggestion = (paperId: string, stale: boolean): ReviewRunItem => ({
+      id: `suggestion-${paperId}`,
+      runId: run.id,
+      paperId,
+      status: "completed",
+      attemptCount: 1,
+      suggestedDecision: "exclude",
+      suggestedReasonCriterionId: "wrong-population",
+      rationale: "The population does not meet the protocol.",
+      criterionAssessments: [
+        {
+          criterionId: "wrong-population",
+          assessment: "met",
+          explanation: "The sampled population is outside scope.",
+          evidenceIds: []
+        }
+      ],
+      extractionSuggestions: [],
+      evidence: [],
+      stale,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: timestamp
+    });
+    const saveScreeningDecision = vi.fn().mockResolvedValue({
+      id: "decision-ai",
+      reviewId,
+      paperId: paper.paperId,
+      stage: "full-text",
+      decision: "exclude",
+      protocolRevisionId: revisionId,
+      reasonCriterionId: "wrong-population",
+      runItemId: `suggestion-${paper.paperId}`,
+      createdAt: timestamp
+    });
+    renderReview({
+      listReviewRuns: vi.fn().mockResolvedValue([run]),
+      listReviewRunItems: vi
+        .fn()
+        .mockResolvedValue([suggestion(freshPaper.paperId, false), suggestion(stalePaper.paperId, true)]),
+      listReviewPapers: vi.fn().mockResolvedValue(page),
+      saveScreeningDecision
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Full text" }));
+    expect(await screen.findAllByText(/Criterion assessments \(1\)/i)).toHaveLength(2);
+    const confirmButtons = screen.getAllByRole("button", { name: "Confirm suggestion" });
+    expect(confirmButtons).toHaveLength(1);
+    fireEvent.click(confirmButtons[0]);
+    await waitFor(() =>
+      expect(saveScreeningDecision).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paperId: freshPaper.paperId,
+          decision: "exclude",
+          reasonCriterionId: "wrong-population",
+          runItemId: `suggestion-${freshPaper.paperId}`
+        })
+      )
+    );
+    expect(
+      (screen.getByRole("button", { name: "Rerun required for current protocol" }) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it("preserves chat as the default and exposes the top-level Review switch", async () => {
+    const settings: AppSettings = {
+      ui: { theme: "system" },
+      ai: {
+        provider: "ollama",
+        baseUrl: "http://127.0.0.1:11434",
+        model: "test-model",
+        hasApiKey: false,
+        reasoningEnabled: true
+      },
+      python: { runtimeMode: "managed", markitdownEnabled: true },
+      sources: { disabledSourceIds: [] }
+    };
+    Object.defineProperty(window, "paperPilot", {
+      configurable: true,
+      value: {
+        listProjects: vi.fn().mockResolvedValue([]),
+        listSources: vi.fn().mockResolvedValue([]),
+        getSettings: vi.fn().mockResolvedValue(settings),
+        setTitleBarTheme: vi.fn().mockResolvedValue(undefined),
+        checkAiProvider: vi.fn().mockResolvedValue({
+          provider: "ollama",
+          baseUrl: settings.ai.baseUrl,
+          model: settings.ai.model,
+          hasApiKey: false,
+          reachable: true,
+          status: "ok",
+          checkedAt: timestamp,
+          models: []
+        }),
+        listCredentialFlags: vi.fn().mockResolvedValue([]),
+        getUpdateStatus: vi
+          .fn()
+          .mockResolvedValue({ state: "idle", currentVersion: "0.0.0-development", retryCount: 0 }),
+        platform: vi.fn().mockResolvedValue("win32"),
+        onJobChanged: vi.fn().mockReturnValue(() => undefined),
+        onChatRunEvent: vi.fn().mockReturnValue(() => undefined),
+        onUpdateStatusChanged: vi.fn().mockReturnValue(() => undefined)
+      } as unknown as PaperPilotApi
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <App />
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Ask the project, inspect the evidence")).toBeTruthy();
+    const reviewTab = screen.getByRole("tab", { name: "Review" });
+    expect(reviewTab.getAttribute("aria-selected")).toBe("false");
+    fireEvent.click(reviewTab);
+    expect(await screen.findByText("Select a project to begin an evidence review.")).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Review" }).getAttribute("aria-selected")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

- Add an ordered, transactional schema-v3 review model with versioned protocols, discovery provenance, two-stage screening, extraction revisions, evidence snapshots, advisory AI runs, and append-only audit history.
- Add previewed RIS, BibTeX, and mapped CSV imports with conservative DOI/source/fingerprint identity resolution, explicit ambiguous-match handling, batched writes, and active-review crawl provenance.
- Add the full Review workspace: setup templates, paginated queues and filters, keyboard/bulk screening, trusted full-text actions, evidence-linked extraction, human confirmation, run progress/cancellation/retry, and deterministic flow/package exports.
- Preserve v1/v2 imports and existing project/chat behavior while making v3 duplication and import/export lossless and transactional.
- Harden migration collisions, concurrent review runs, trusted evidence ownership, malformed DOI handling, and tampered bundle rollback.

## Validation

- [x] `npm run verify`
- [x] Tests added or updated where behavior changed
- [x] `npm run verify:platform` on Windows
- [x] `npm audit --audit-level=high` (0 vulnerabilities)
- [x] 228 tests passed; 2 intentionally skipped
- [x] Coverage: 71.93% statements, 62.89% branches, 76.40% functions, 75.29% lines
- [ ] Required Ubuntu and Windows GitHub Actions checks
- [ ] Manual packaged-app and live Ollama/hosted-provider acceptance scenarios in `docs/qa-checklist.md`

## Release

This remains a draft until CI and the manual acceptance checklist are complete. Per the phase delivery plan, `release:minor` is intentionally not applied yet; apply it only when the PR is ready to merge.